### PR TITLE
Valeur immédiate sans crochets

### DIFF
--- a/emulator/src/runtime/arguments.rs
+++ b/emulator/src/runtime/arguments.rs
@@ -20,7 +20,7 @@ pub use traits::{ExtractError, ExtractValue, ResolveAddress};
 
 /// An immediate value
 #[derive(PartialEq, Clone, Debug, Display)]
-#[display("[{0}]")]
+#[display("{0}")]
 pub struct Imm(pub C::Word);
 
 impl Imm {


### PR DESCRIPTION
Lorsqu'une instruction s'affiche, la valeur immédiate est entre crochets :
	ld [1],%a

Selon les specifications (cf. z33refcard dans https://gitlab.com/pdagog/ens/), l'affichage correct est :
	ld 1,%a