### PR TITLE
Fix clippy warnings introduced in Rust 1.66.0

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -58,8 +58,8 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          rustup toolchain install stable
-          rustup default stable
+          rustup toolchain install 1.66.0
+          rustup default 1.66.0
           rustup component add clippy
 
       - name: Setup Rust build cache

--- a/cli/src/commands/dump.rs
+++ b/cli/src/commands/dump.rs
@@ -34,7 +34,7 @@ impl DumpOpt {
         // Transform the AST relative locations to absolute ones
         let ast = ast.map_location(&AbsoluteLocation::default());
 
-        println!("{}", ast);
+        println!("{ast}");
 
         Ok(())
     }

--- a/cli/src/commands/preprocess.rs
+++ b/cli/src/commands/preprocess.rs
@@ -18,7 +18,7 @@ impl PreprocessOpt {
         info!(path = ?self.input, "Reading program");
         let preprocessor = Preprocessor::new(fs).and_load(&self.input);
         let source = preprocessor.preprocess(&self.input)?;
-        println!("{}", source);
+        println!("{source}");
         Ok(())
     }
 }

--- a/cli/src/commands/print.rs
+++ b/cli/src/commands/print.rs
@@ -25,7 +25,7 @@ impl PrintOpt {
 
         debug!("Parsing program");
         let program = parse(source).unwrap(); // TODO: the error is tied to the input
-        println!("{}", program);
+        println!("{program}");
 
         Ok(())
     }

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -52,7 +52,7 @@ impl RunOpt {
                     error!("{}", error);
                 }
 
-                let msg = format!("{}", e);
+                let msg = format!("{e}");
                 let mut files = SimpleFiles::new();
                 let file_ids: HashMap<_, _> = preprocessor
                     .sources()
@@ -96,15 +96,15 @@ impl RunOpt {
         let program = match parse(source) {
             Ok(p) => p,
             Err(e) => {
-                let msg = format!("{}", e);
+                let msg = format!("{e}");
                 let labels: Vec<_> = e
                     .errors
                     .iter()
                     .map(|(location, kind)| {
                         let message = match kind {
                             nom::error::VerboseErrorKind::Context(s) => (*s).to_owned(),
-                            nom::error::VerboseErrorKind::Char(c) => format!("expected '{}'", c),
-                            nom::error::VerboseErrorKind::Nom(code) => format!("{:?}", code),
+                            nom::error::VerboseErrorKind::Char(c) => format!("expected '{c}'"),
+                            nom::error::VerboseErrorKind::Nom(code) => format!("{code:?}"),
                         };
                         let offset = char_offset(source, location);
 
@@ -141,7 +141,7 @@ impl RunOpt {
                     last_error = error;
                 }
 
-                let msg = format!("{}", last_error);
+                let msg = format!("{last_error}");
 
                 let location = match &e {
                     CompilationError::MemoryLayout(e) => e.location(),

--- a/cli/src/interactive/mod.rs
+++ b/cli/src/interactive/mod.rs
@@ -274,7 +274,7 @@ pub(crate) fn run_interactive(
             match Command::try_parse_from(words) {
                 Ok(c) => c,
                 Err(e) => {
-                    eprintln!("{}", e);
+                    eprintln!("{e}");
                     continue;
                 }
             }

--- a/emulator/src/ast.rs
+++ b/emulator/src/ast.rs
@@ -166,7 +166,7 @@ impl<L: std::fmt::Display> Node<L> {
                 content.clone()
             };
 
-            writeln!(f, "{:?}({:?}) @ {}", self.kind, content, self.location)?;
+            writeln!(f, "{:?}({content:?}) @ {}", self.kind, self.location)?;
         } else {
             writeln!(f, "{:?} @ {}", self.kind, self.location)?;
         }

--- a/emulator/src/compiler/layout.rs
+++ b/emulator/src/compiler/layout.rs
@@ -80,7 +80,7 @@ impl<L> Layout<L> {
         let mut v: Vec<_> = self
             .memory
             .iter()
-            .map(|(k, v)| (*k, format!("{}", v)))
+            .map(|(k, v)| (*k, format!("{v}")))
             .collect();
         v.sort_by_key(|&(k, _)| k);
         v

--- a/emulator/src/parser/condition.rs
+++ b/emulator/src/parser/condition.rs
@@ -162,7 +162,7 @@ impl<L> std::fmt::Display for Node<L> {
                 b.inner.with_parent(self)
             ),
             Node::Not(a) => write!(f, "!{}", a.inner.with_parent(self)),
-            Node::Literal(a) => write!(f, "{}", a),
+            Node::Literal(a) => write!(f, "{a}"),
             Node::Defined(a) => write!(f, "defined({})", a.inner),
         }
     }

--- a/emulator/src/parser/errors.rs
+++ b/emulator/src/parser/errors.rs
@@ -92,6 +92,6 @@ impl<I: std::fmt::Debug> Error<I> {
         _input: &'a str,
         f: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
-        write!(f, "{:#?}", self)
+        write!(f, "{self:#?}")
     }
 }

--- a/emulator/src/parser/expression.rs
+++ b/emulator/src/parser/expression.rs
@@ -148,7 +148,7 @@ impl<L: Clone> AstNode<L> for Node<L> {
 
     fn content(&self) -> Option<String> {
         match self {
-            Node::Literal(l) => Some(format!("{}", l)),
+            Node::Literal(l) => Some(format!("{l}")),
             Node::Variable(v) => Some(v.clone()),
             _ => None,
         }
@@ -161,7 +161,7 @@ impl<L> std::fmt::Display for Node<L> {
             // Special case for indexed arguments
             match self {
                 Node::Invert(a) => write!(f, "- {}", a.inner),
-                n => write!(f, "+ {}", n),
+                n => write!(f, "+ {n}"),
             }
         } else {
             match self {
@@ -215,8 +215,8 @@ impl<L> std::fmt::Display for Node<L> {
                 ),
                 Node::Invert(a) => write!(f, "-{}", a.inner.with_parent(self)),
                 Node::BinaryNot(a) => write!(f, "~{}", a.inner.with_parent(self)),
-                Node::Literal(a) => write!(f, "{}", a),
-                Node::Variable(a) => write!(f, "{}", a),
+                Node::Literal(a) => write!(f, "{a}"),
+                Node::Variable(a) => write!(f, "{a}"),
             }
         }
     }

--- a/emulator/src/parser/preprocessor.rs
+++ b/emulator/src/parser/preprocessor.rs
@@ -524,7 +524,7 @@ mod tests {
                 }
                 .with_location((77, 12)),
                 Raw {
-                    content: "".to_string(),
+                    content: String::new(),
                 }
                 .with_location((90, 0))
             ]
@@ -582,7 +582,7 @@ mod tests {
                 }
                 .with_location((125, 27)),
                 Raw {
-                    content: "".to_string()
+                    content: String::new()
                 }
                 .with_location((153, 0)),
                 Raw {
@@ -590,7 +590,7 @@ mod tests {
                 }
                 .with_location((154, 10)),
                 Raw {
-                    content: "".to_string()
+                    content: String::new()
                 }
                 .with_location((165, 0)),
             ]

--- a/emulator/src/parser/value.rs
+++ b/emulator/src/parser/value.rs
@@ -69,7 +69,7 @@ impl<L> AstNode<L> for InstructionKind {
     }
 
     fn content(&self) -> Option<String> {
-        Some(format!("{}", self))
+        Some(format!("{self}"))
     }
 }
 
@@ -213,7 +213,7 @@ impl<L> AstNode<L> for DirectiveKind {
     }
 
     fn content(&self) -> Option<String> {
-        Some(format!("{}", self))
+        Some(format!("{self}"))
     }
 }
 
@@ -357,7 +357,7 @@ impl<L: Clone> AstNode<L> for InstructionArgument<L> {
 
     fn content(&self) -> Option<String> {
         match self {
-            InstructionArgument::Register(r) => Some(format!("{}", r)),
+            InstructionArgument::Register(r) => Some(format!("{r}")),
             _ => None,
         }
     }

--- a/emulator/src/runtime/arguments.rs
+++ b/emulator/src/runtime/arguments.rs
@@ -365,7 +365,7 @@ mod conversions {
                 if index != 0 {
                     write!(f, "/")?;
                 }
-                write!(f, "{}", entry)?;
+                write!(f, "{entry}")?;
             }
             Ok(())
         }

--- a/emulator/src/runtime/instructions.rs
+++ b/emulator/src/runtime/instructions.rs
@@ -305,7 +305,7 @@ impl Instruction {
 
             Self::Neg(reg) => {
                 let val = reg.extract_word(computer)?;
-                let res = -(val as i64);
+                let res = -val;
                 let res = res as Word;
                 debug!("-{} = {}", val, res);
                 computer.set_register(reg, res.into())?;

--- a/emulator/src/runtime/registers.rs
+++ b/emulator/src/runtime/registers.rs
@@ -120,7 +120,7 @@ impl<L> AstNode<L> for Reg {
     }
 
     fn content(&self) -> Option<String> {
-        Some(format!("{}", self))
+        Some(format!("{self}"))
     }
 }
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -37,7 +37,7 @@ pub fn dump(source: &str) -> Result<JsValue, JsValue> {
     let source = match preprocessor.preprocess(&path) {
         Ok(s) => s,
         Err(e) => {
-            output.error = Some(format!("{}", e));
+            output.error = Some(format!("{e}"));
             return Ok(serde_wasm_bindgen::to_value(&output)?);
         }
     };
@@ -49,7 +49,7 @@ pub fn dump(source: &str) -> Result<JsValue, JsValue> {
     let program = match program {
         Ok(p) => p,
         Err(e) => {
-            output.error = Some(format!("{:#?}", e));
+            output.error = Some(format!("{e:#?}"));
             return Ok(serde_wasm_bindgen::to_value(&output)?);
         }
     };
@@ -59,12 +59,12 @@ pub fn dump(source: &str) -> Result<JsValue, JsValue> {
     // Transform the AST relative locations to absolute ones
     let ast = ast.map_location(&AbsoluteLocation::default());
 
-    output.ast = Some(format!("{}", ast));
+    output.ast = Some(format!("{ast}"));
 
     let layout = layout(program.inner);
 
     if let Err(e) = layout {
-        output.error = Some(format!("{}", e));
+        output.error = Some(format!("{e}"));
         return Ok(serde_wasm_bindgen::to_value(&output)?);
     }
 


### PR DESCRIPTION
- Fix clippy warnings
- Pin the clippy version in CI
