### PR TITLE
Corrige l'affichage des caractères et ajoute un \0 à la fin des directives .string

### DIFF
--- a/emulator/src/compiler/layout.rs
+++ b/emulator/src/compiler/layout.rs
@@ -35,6 +35,10 @@ pub(crate) enum Placement<L> {
     #[display("{0:?}")]
     Char(char),
 
+    /// An empty memory cell, at the end of a .string
+    #[display("NUL")]
+    Nul,
+
     /// A instruction or a .word directive
     #[display("{0}")]
     Line(LineContent<L>),
@@ -203,6 +207,9 @@ pub(crate) fn layout_memory<L: Clone + Default>(
                         layout.insert_placement(position, Placement::Char(c))?;
                         position += 1;
                     }
+
+                    layout.insert_placement(position, Placement::Nul)?;
+                    position += 1;
                 }
 
                 LineContent::Directive { kind, .. } => {

--- a/emulator/src/compiler/layout.rs
+++ b/emulator/src/compiler/layout.rs
@@ -356,8 +356,8 @@ mod tests {
         let expected = {
             let mut h = HashMap::new();
             h.insert(String::from("first"), PROGRAM_START);
-            h.insert(String::from("second"), PROGRAM_START + 5);
-            h.insert(String::from("main"), PROGRAM_START + 5 + 12);
+            h.insert(String::from("second"), PROGRAM_START + 6);
+            h.insert(String::from("main"), PROGRAM_START + 6 + 13);
             h
         };
 

--- a/emulator/src/compiler/memory.rs
+++ b/emulator/src/compiler/memory.rs
@@ -302,13 +302,11 @@ fn compile_placement<L: Clone>(
 
     match placement {
         // Reserved placements are created by .space directives
-        P::Reserved => Ok(Cell::Empty),
+        // Empty placements at the end of .string directives
+        P::Reserved | P::Nul => Ok(Cell::Empty),
 
         // Char placements are created by .string directives
         P::Char(c) => Ok(Cell::Char(*c)),
-
-        // Empty placements at the end of .string directives
-        P::Nul => Ok(Cell::Empty),
 
         // A .word directive (don't mind the weird destructuring)
         P::Line(LineContent::Directive {

--- a/emulator/src/compiler/memory.rs
+++ b/emulator/src/compiler/memory.rs
@@ -304,8 +304,11 @@ fn compile_placement<L: Clone>(
         // Reserved placements are created by .space directives
         P::Reserved => Ok(Cell::Empty),
 
-        // Char placements are create by .string directives
+        // Char placements are created by .string directives
         P::Char(c) => Ok(Cell::Char(*c)),
+
+        // Empty placements at the end of .string directives
+        P::Nul => Ok(Cell::Empty),
 
         // A .word directive (don't mind the weird destructuring)
         P::Line(LineContent::Directive {

--- a/emulator/src/parser/expression.rs
+++ b/emulator/src/parser/expression.rs
@@ -390,7 +390,7 @@ fn parse_or_rec<'a, Error: ParseError<&'a str>>(
     let (rest, _) = space0(input)?;
     let (rest, _) = char('|')(rest)?;
     // Check if it's not a "||" to avoid conflict with boolean operations
-    let (rest, _) = not(char('|'))(rest)?;
+    let (rest, ()) = not(char('|'))(rest)?;
     let (rest, _) = space0(rest)?;
 
     cut(move |rest: &'a str| {
@@ -430,7 +430,7 @@ fn parse_and_rec<'a, Error: ParseError<&'a str>>(
     let (rest, _) = space0(input)?;
     let (rest, _) = char('&')(rest)?;
     // Check if it's not a "&&" to avoid conflict with boolean operations
-    let (rest, _) = not(char('&'))(rest)?;
+    let (rest, ()) = not(char('&'))(rest)?;
     let (rest, _) = space0(rest)?;
 
     cut(move |rest: &'a str| {

--- a/emulator/src/parser/location.rs
+++ b/emulator/src/parser/location.rs
@@ -38,7 +38,7 @@ pub struct RelativeLocation {
 }
 
 impl From<()> for RelativeLocation {
-    fn from(_: ()) -> Self {
+    fn from((): ()) -> Self {
         Self::default()
     }
 }

--- a/emulator/src/parser/preprocessor.rs
+++ b/emulator/src/parser/preprocessor.rs
@@ -176,7 +176,7 @@ fn parse_definition<'a, Error: ParseError<&'a str>>(
         Ok((rest, content))
     })(rest)?;
 
-    let (rest, _) = eat_end_of_line(rest)?;
+    let (rest, ()) = eat_end_of_line(rest)?;
 
     Ok((rest, Node::Definition { key, content }))
 }
@@ -193,7 +193,7 @@ fn parse_undefine<'a, Error: ParseError<&'a str>>(
     let (rest, key) = parse_identifier(rest)?;
     let key = key.to_owned().with_location((input, start, rest));
 
-    let (rest, _) = eat_end_of_line(rest)?;
+    let (rest, ()) = eat_end_of_line(rest)?;
 
     Ok((rest, Node::Undefine { key }))
 }
@@ -212,7 +212,7 @@ fn parse_inclusion<'a, Error: ParseError<&'a str>>(
     let (rest, path) = parse_string_literal(rest)?;
     let path = path.with_location((input, start, rest));
 
-    let (rest, _) = eat_end_of_line(rest)?;
+    let (rest, ()) = eat_end_of_line(rest)?;
 
     Ok((rest, Node::Inclusion { path }))
 }
@@ -231,7 +231,7 @@ fn parse_error<'a, Error: ParseError<&'a str>>(
     let (rest, message) = parse_string_literal(rest)?;
     let message = message.with_location((input, start, rest));
 
-    let (rest, _) = eat_end_of_line(rest)?;
+    let (rest, ()) = eat_end_of_line(rest)?;
 
     Ok((rest, Node::Error { message }))
 }
@@ -258,7 +258,7 @@ fn parse_condition<'a, Error: ParseError<&'a str>>(
     let (rest, condition) = parse_directive_argument(rest)?;
     let condition = condition.to_string().with_location((input, start, rest));
 
-    let (rest, _) = eat_end_of_line(rest)?;
+    let (rest, ()) = eat_end_of_line(rest)?;
     let (rest, _) = line_ending(rest)?;
 
     // Parse its body
@@ -291,7 +291,7 @@ fn parse_condition<'a, Error: ParseError<&'a str>>(
             map(tag("else"), |_| Else),
         ))(rest)?;
 
-        let (rest, _) = eat_end_of_line(rest)?;
+        let (rest, ()) = eat_end_of_line(rest)?;
 
         // We've got an "#end" directive, get out of the loop
         // We don't update the cursor here since we will be re-parsing the #end directive afterward
@@ -319,7 +319,7 @@ fn parse_condition<'a, Error: ParseError<&'a str>>(
     let (rest, _) = space0(rest)?;
     let (rest, _) = tag("endif")(rest)?;
 
-    let (rest, _) = eat_end_of_line(rest)?;
+    let (rest, ()) = eat_end_of_line(rest)?;
 
     Ok((rest, Node::Condition { branches, fallback }))
 }
@@ -327,7 +327,7 @@ fn parse_condition<'a, Error: ParseError<&'a str>>(
 fn parse_raw<'a, Error: ParseError<&'a str>>(
     input: &'a str,
 ) -> IResult<&'a str, Node<RelativeLocation>, Error> {
-    let (rest, _) = not(char('#'))(input)?;
+    let (rest, ()) = not(char('#'))(input)?;
     let (rest, content) = not_line_ending(rest)?;
     // Strip the comment from the content
     let content = if let Some(i) = content.find("//") {
@@ -600,7 +600,7 @@ mod tests {
     #[test]
     fn parse_condition_test() {
         use Node::{Condition, Raw};
-        let input = indoc::indoc! {r#"
+        let input = indoc::indoc! {r"
             #if true
             foo
             #if false
@@ -611,7 +611,7 @@ mod tests {
             #else
             baz
             #endif
-        "#}
+        "}
         .trim_end(); // Remove the trailing linebreak
 
         // Check a few locations used bellow

--- a/emulator/src/preprocessor/mod.rs
+++ b/emulator/src/preprocessor/mod.rs
@@ -342,7 +342,7 @@ impl<FS> Preprocessor<FS> {
                         .collect();
 
                     let (_, expression) =
-                        parse_condition(&condition).finish().map_err(|_: ()| {
+                        parse_condition(&condition).finish().map_err(|(): ()| {
                             PreprocessorError::ConditionParse {
                                 location: branch.condition.location.clone(),
                             }
@@ -403,28 +403,28 @@ mod tests {
             );
             t.insert(
                 "/define.S".into(),
-                indoc::indoc! {r#"
+                indoc::indoc! {r"
                     #define FOO world
                     hello FOO
                     helloFOO
                     #undefine FOO
                     hello FOO
-                "#}
+                "}
                 .into(),
             );
             t.insert(
                 "/double-define.S".into(),
-                indoc::indoc! {r#"
+                indoc::indoc! {r"
                     #define FOO world
                     #define WHAT hello FOO
                     #define FOO toto
                     WHAT
-                "#}
+                "}
                 .into(),
             );
             t.insert(
                 "/condition.S".into(),
-                indoc::indoc! {r#"
+                indoc::indoc! {r"
                     #if true
                     simple
                     #endif
@@ -449,7 +449,7 @@ mod tests {
                     nested
                     #endif
                     #endif
-                "#}
+                "}
                 .into(),
             );
             t
@@ -471,11 +471,11 @@ mod tests {
         let res = preprocess("/inclusion.S").unwrap();
         assert_eq!(
             res,
-            indoc::indoc! {r#"
+            indoc::indoc! {r"
                 this is before foo.S
                 this is foo.S
                 this is after foo.S
-            "#}
+            "}
         );
     }
 
@@ -484,7 +484,7 @@ mod tests {
         let res = preprocess("/condition.S").unwrap();
         assert_eq!(
             res,
-            indoc::indoc! {r#"
+            indoc::indoc! {r"
                 simple
 
 
@@ -493,7 +493,7 @@ mod tests {
                 definition
 
                 nested
-            "#}
+            "}
         );
     }
 
@@ -502,19 +502,19 @@ mod tests {
         let res = preprocess("/define.S").unwrap();
         assert_eq!(
             res,
-            indoc::indoc! {r#"
+            indoc::indoc! {r"
                 hello world
                 helloFOO
                 hello FOO
-            "#}
+            "}
         );
 
         let res = preprocess("/double-define.S").unwrap();
         assert_eq!(
             res,
-            indoc::indoc! {r#"
+            indoc::indoc! {r"
                 hello world
-            "#}
+            "}
         );
     }
 

--- a/emulator/src/runtime/memory.rs
+++ b/emulator/src/runtime/memory.rs
@@ -1,6 +1,5 @@
 use std::convert::TryInto;
 
-use parse_display::Display;
 use thiserror::Error;
 
 use crate::constants::{Address, Char, Word, MEMORY_SIZE};
@@ -28,28 +27,35 @@ pub enum CellError {
 }
 
 /// Represents a cell in memory and in general purpose registers
-#[derive(Debug, Clone, PartialEq, Eq, Display, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum Cell {
     /// An instruction
     ///
     /// The instruction can be a big type, so only a reference is saved here.
-    #[display("{0}")]
     Instruction(Box<Instruction>),
 
     /// An unsigned word
     ///
     /// In contrast, a word is small enough to be copied.
-    #[display("{0}")]
     Word(Word),
 
     /// A signle char
-    #[display("{:?}")]
     Char(Char),
 
     /// An empty cell, no value was ever set here,
-    #[display("0")]
     #[default]
     Empty,
+}
+
+impl std::fmt::Display for Cell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Instruction(i) => write!(f, "{}", i),
+            Self::Word(w) => write!(f, "{}", w),
+            Self::Char(c) => write!(f, "{} ({:#x})", c, u32::from(*c)),
+            Self::Empty => write!(f, "0"),
+        }
+    }
 }
 
 impl Cell {

--- a/emulator/src/runtime/memory.rs
+++ b/emulator/src/runtime/memory.rs
@@ -50,8 +50,8 @@ pub enum Cell {
 impl std::fmt::Display for Cell {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Instruction(i) => write!(f, "{}", i),
-            Self::Word(w) => write!(f, "{}", w),
+            Self::Instruction(i) => write!(f, "{i}"),
+            Self::Word(w) => write!(f, "{w}"),
             Self::Char(c) => write!(f, "{} ({:#x})", c, u32::from(*c)),
             Self::Empty => write!(f, "0"),
         }

--- a/emulator/src/runtime/mod.rs
+++ b/emulator/src/runtime/mod.rs
@@ -127,7 +127,7 @@ impl Computer {
             if let ProcessorError::Exception(e) = e {
                 self.recover_from_exception(&e)
                     .map_err(ProcessorError::Exception)
-                    .map(|_| 1) // TODO: fixed cost for exceptions?
+                    .map(|()| 1) // TODO: fixed cost for exceptions?
             } else {
                 Err(e)
             }
@@ -166,7 +166,7 @@ impl Computer {
     pub fn run(&mut self) -> Result<()> {
         loop {
             match self.step() {
-                Ok(_) => {}
+                Ok(()) => {}
                 Err(ProcessorError::Reset) => return Ok(()),
                 Err(v) => return Err(v),
             }


### PR DESCRIPTION
Deux problèmes réglés ici:

 - les directives .string n'ajoutaient pas de '\0' à la fin des chaînes de caractères
 - quand l'on affichait une case mémoire avec un caractère, la valeur affichée était systématiquement `Char`, au lieu du caractère ASCII

```
$ cargo run -- run -i samples/directives.S main
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/z33-cli run -i samples/directives.S main`
 INFO Reading program path="samples/directives.S"
 INFO Running program
 INFO Running in interactive mode. Type "help" to list available commands.
>> memory 1000 10
 INFO address=1000 value=h (0x68)
 INFO address=1001 value=e (0x65)
 INFO address=1002 value=l (0x6c)
 INFO address=1003 value=l (0x6c)
 INFO address=1004 value=o (0x6f)
 INFO address=1005 value=0
 INFO address=1006 value=8059
 INFO address=1007 value=100
 INFO address=1008 value=0
 INFO address=1009 value=0
```