### PR TITLE
Map errors back to the original source code

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -117,6 +117,7 @@ jobs:
         run: |
           rustup toolchain install stable
           rustup default stable
+          rustup target add wasm32-unknown-unknown
 
       - name: Setup Rust build cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -111,6 +111,7 @@ jobs:
         with:
           node-version: "20"
           cache: "pnpm"
+          cache-dependency-path: web/pnpm-lock.yaml
 
       - name: Install Rust toolchain
         run: |

--- a/.github/workflows/publish-web.yaml
+++ b/.github/workflows/publish-web.yaml
@@ -40,6 +40,7 @@ jobs:
         with:
           node-version: "20"
           cache: "pnpm"
+          cache-dependency-path: web/pnpm-lock.yaml
 
       - name: Install Rust toolchain
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,18 +119,21 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "camino"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cc"
-version = "1.1.8"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -146,9 +149,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "clap"
-version = "4.5.13"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -156,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.13"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -168,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.12"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8670053e87c316345e384ca1f3eba3006fc6355ed8b8a1140d104e109e3df34"
+checksum = "6d7db6eca8c205649e8d3ccd05aa5042b1800a784e56bc7c43524fde8abbfa9b"
 dependencies = [
  "clap",
 ]
@@ -334,9 +337,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -349,9 +352,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "linked-hash-map"
@@ -475,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.3"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
@@ -502,9 +505,9 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "parse-display"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+checksum = "287d8d3ebdce117b8539f59411e4ed9ec226e0a4153c7f55495c6070d68e6f72"
 dependencies = [
  "parse-display-derive",
  "regex",
@@ -513,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "parse-display-derive"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+checksum = "7fc048687be30d79502dea2f623d052f3a074012c6eac41726b7ab17213616b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -552,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -621,9 +624,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
  "bitflags",
  "errno",
@@ -673,9 +676,9 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
@@ -693,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -715,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
  "memchr",
@@ -739,6 +742,12 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "similar"
@@ -810,9 +819,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1017,19 +1026,20 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
@@ -1042,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1052,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1065,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,7 +62,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -57,7 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -65,6 +80,30 @@ name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
+name = "backtrace"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "bitflags"
@@ -86,6 +125,12 @@ checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "cc"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
 
 [[package]]
 name = "cfg-if"
@@ -173,6 +218,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,7 +264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -218,8 +281,14 @@ checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "heck"
@@ -233,7 +302,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -241,6 +310,24 @@ name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
+name = "insta"
+version = "1.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "similar",
+]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -276,6 +363,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,8 +401,16 @@ version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
 dependencies = [
+ "backtrace",
+ "backtrace-ext",
  "cfg-if",
  "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
  "thiserror",
  "unicode-width",
 ]
@@ -330,6 +431,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "nibble_vec"
@@ -373,6 +483,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +502,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "parse-display"
@@ -498,6 +623,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,7 +638,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -529,7 +660,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -619,10 +750,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "strsim"
@@ -654,6 +797,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "supports-color"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9829b314621dfc575df4e409e79f9d6a66a3bd707ab73f23cb4aa3a854ac854f"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0a1e5168041f5f3ff68ff7d95dcb9c8749df29f6e7e89ada40dd4c9de404ee"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +835,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -819,6 +1004,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,7 +1109,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -929,11 +1120,35 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -942,15 +1157,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -960,9 +1181,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -978,9 +1211,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -990,9 +1235,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1016,6 +1273,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "codespan-reporting",
+ "miette",
  "nom",
  "rustyline",
  "rustyline-derive",
@@ -1033,6 +1291,7 @@ dependencies = [
  "bitflags",
  "camino",
  "indoc",
+ "insta",
  "miette",
  "nom",
  "parse-display",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "camino"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +301,29 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miette"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -980,6 +1012,7 @@ version = "0.5.4"
 dependencies = [
  "anstyle",
  "anyhow",
+ "camino",
  "clap",
  "clap_complete",
  "codespan-reporting",
@@ -998,7 +1031,9 @@ name = "z33-emulator"
 version = "0.5.4"
 dependencies = [
  "bitflags",
+ "camino",
  "indoc",
+ "miette",
  "nom",
  "parse-display",
  "pretty_assertions",
@@ -1012,6 +1047,7 @@ dependencies = [
 name = "z33-web"
 version = "0.5.4"
 dependencies = [
+ "camino",
  "console_error_panic_hook",
  "js-sys",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,15 +203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "git+https://github.com/brendanzab/codespan.git#57c223b08932ba8a4644f2dcc1571c87844b7c68"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,15 +820,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,15 +1086,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,7 +1245,6 @@ dependencies = [
  "camino",
  "clap",
  "clap_complete",
- "codespan-reporting",
  "miette",
  "nom",
  "rustyline",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ console_error_panic_hook = "0.1.7"
 indoc = "2.0.5"
 insta = "1.39.0"
 js-sys = "0.3.70"
-miette = { version = "7.2.0", features = ["fancy"] }
+miette = "7.2.0"
 nom = "7.1.3"
 parse-display = "0.10.0"
 pretty_assertions = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,20 +26,20 @@ module_name_repetitions = "allow"
 anstyle = "1.0.8"
 anyhow = "1.0.86"
 bitflags = "2.6.0"
-camino = { version = "1.1.7", features = ["serde1"] }
-clap = { version = "4.5.13", features = ["derive"] }
-clap_complete = "4.5.12"
+camino = { version = "1.1.9", features = ["serde1"] }
+clap = { version = "4.5.16", features = ["derive"] }
+clap_complete = "4.5.24"
 console_error_panic_hook = "0.1.7"
 indoc = "2.0.5"
 insta = "1.39.0"
-js-sys = "0.3.69"
+js-sys = "0.3.70"
 miette = { version = "7.2.0", features = ["fancy"] }
 nom = "7.1.3"
-parse-display = "0.9.1"
+parse-display = "0.10.0"
 pretty_assertions = "1.4.0"
 rustyline = "14.0.0"
 rustyline-derive = "0.10.0"
-serde = { version = "1.0.204", features = ["derive"] }
+serde = { version = "1.0.209", features = ["derive"] }
 serde-wasm-bindgen = "0.5.0"
 shell-words = "1.1.0"
 thiserror = "1.0.63"
@@ -48,7 +48,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 tracing-wasm = "0.2.1"
 tsify = { version = "0.4.5", features = ["js"], default-features = false }
 unicode-segmentation = "1.11.0"
-wasm-bindgen = "0.2.92"
+wasm-bindgen = "0.2.93"
 z33-emulator = { path = "emulator" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,9 @@ clap_complete = "4.5.12"
 codespan-reporting = { git = "https://github.com/brendanzab/codespan.git" }
 console_error_panic_hook = "0.1.7"
 indoc = "2.0.5"
+insta = "1.39.0"
 js-sys = "0.3.69"
-miette = "7.2.0"
+miette = { version = "7.2.0", features = ["fancy"] }
 nom = "7.1.3"
 parse-display = "0.9.1"
 pretty_assertions = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,14 @@ module_name_repetitions = "allow"
 anstyle = "1.0.8"
 anyhow = "1.0.86"
 bitflags = "2.6.0"
+camino = { version = "1.1.7", features = ["serde1"] }
 clap = { version = "4.5.13", features = ["derive"] }
 clap_complete = "4.5.12"
 codespan-reporting = { git = "https://github.com/brendanzab/codespan.git" }
 console_error_panic_hook = "0.1.7"
 indoc = "2.0.5"
 js-sys = "0.3.69"
+miette = "7.2.0"
 nom = "7.1.3"
 parse-display = "0.9.1"
 pretty_assertions = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ bitflags = "2.6.0"
 camino = { version = "1.1.7", features = ["serde1"] }
 clap = { version = "4.5.13", features = ["derive"] }
 clap_complete = "4.5.12"
-codespan-reporting = { git = "https://github.com/brendanzab/codespan.git" }
 console_error_panic_hook = "0.1.7"
 indoc = "2.0.5"
 insta = "1.39.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,7 @@ anyhow.workspace = true
 camino.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
-miette.workspace = true
+miette = { workspace = true, features = ["fancy"] }
 nom.workspace = true
 rustyline.workspace = true
 rustyline-derive.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,6 @@ anyhow.workspace = true
 camino.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
-codespan-reporting.workspace = true
 miette.workspace = true
 nom.workspace = true
 rustyline.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 anstyle.workspace = true
 anyhow.workspace = true
+camino.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
 codespan-reporting.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,6 +20,7 @@ camino.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
 codespan-reporting.workspace = true
+miette.workspace = true
 nom.workspace = true
 rustyline.workspace = true
 rustyline-derive.workspace = true

--- a/cli/src/commands/completion.rs
+++ b/cli/src/commands/completion.rs
@@ -26,7 +26,7 @@ fn print_completions<G: Generator>(generator: G, command: &mut Command) {
 }
 
 impl CompletionOpt {
-    pub fn exec(&self) {
+    pub fn exec(self) {
         let mut command = Opt::command();
         match self.shell {
             ShellKind::Bash => print_completions(Bash, &mut command),

--- a/cli/src/commands/dump.rs
+++ b/cli/src/commands/dump.rs
@@ -2,7 +2,7 @@ use camino::Utf8PathBuf;
 use clap::{Parser, ValueHint};
 use tracing::{debug, info};
 use z33_emulator::parse;
-use z33_emulator::preprocessor::{NativeFilesystem, Preprocessor};
+use z33_emulator::preprocessor::{NativeFilesystem, Workspace};
 
 #[derive(Parser, Debug)]
 pub struct DumpOpt {
@@ -12,12 +12,12 @@ pub struct DumpOpt {
 }
 
 impl DumpOpt {
-    pub fn exec(&self) -> anyhow::Result<()> {
+    pub fn exec(self) -> anyhow::Result<()> {
         let fs = NativeFilesystem::from_env()?;
         info!(path = ?self.input, "Reading program");
-        let preprocessor = Preprocessor::new(fs).and_load(&self.input);
+        let preprocessor = Workspace::new(&fs, self.input);
 
-        let source = preprocessor.preprocess(&self.input)?;
+        let source = preprocessor.preprocess()?;
         let source = source.as_str();
 
         debug!("Parsing program");

--- a/cli/src/commands/dump.rs
+++ b/cli/src/commands/dump.rs
@@ -17,7 +17,7 @@ impl DumpOpt {
         info!(path = ?self.input, "Reading program");
         let preprocessor = Workspace::new(&fs, &self.input);
 
-        let source = preprocessor.preprocess()?;
+        let (_source_map, source) = preprocessor.preprocess()?;
         let source = source.as_str();
 
         debug!("Parsing program");

--- a/cli/src/commands/dump.rs
+++ b/cli/src/commands/dump.rs
@@ -1,16 +1,14 @@
-use std::path::PathBuf;
-
+use camino::Utf8PathBuf;
 use clap::{Parser, ValueHint};
 use tracing::{debug, info};
 use z33_emulator::parse;
-use z33_emulator::parser::location::{AbsoluteLocation, MapLocation};
 use z33_emulator::preprocessor::{NativeFilesystem, Preprocessor};
 
 #[derive(Parser, Debug)]
 pub struct DumpOpt {
     /// Input file
     #[clap(value_parser, value_hint = ValueHint::FilePath)]
-    input: PathBuf,
+    input: Utf8PathBuf,
 }
 
 impl DumpOpt {
@@ -27,9 +25,6 @@ impl DumpOpt {
 
         debug!("Transforming AST");
         let ast = program.to_node();
-
-        // Transform the AST relative locations to absolute ones
-        let ast = ast.map_location(&AbsoluteLocation::default());
 
         println!("{ast}");
 

--- a/cli/src/commands/dump.rs
+++ b/cli/src/commands/dump.rs
@@ -15,7 +15,7 @@ impl DumpOpt {
     pub fn exec(self) -> anyhow::Result<()> {
         let fs = NativeFilesystem::from_env()?;
         info!(path = ?self.input, "Reading program");
-        let preprocessor = Workspace::new(&fs, self.input);
+        let preprocessor = Workspace::new(&fs, &self.input);
 
         let source = preprocessor.preprocess()?;
         let source = source.as_str();

--- a/cli/src/commands/preprocess.rs
+++ b/cli/src/commands/preprocess.rs
@@ -14,7 +14,7 @@ impl PreprocessOpt {
     pub fn exec(self) -> anyhow::Result<()> {
         let fs = NativeFilesystem::from_env()?;
         info!(path = ?self.input, "Reading program");
-        let preprocessor = Workspace::new(&fs, self.input);
+        let preprocessor = Workspace::new(&fs, &self.input);
         let source = preprocessor.preprocess()?;
         println!("{source}");
         Ok(())

--- a/cli/src/commands/preprocess.rs
+++ b/cli/src/commands/preprocess.rs
@@ -1,5 +1,4 @@
-use std::path::PathBuf;
-
+use camino::Utf8PathBuf;
 use clap::{Parser, ValueHint};
 use tracing::info;
 use z33_emulator::preprocessor::{NativeFilesystem, Preprocessor};
@@ -8,7 +7,7 @@ use z33_emulator::preprocessor::{NativeFilesystem, Preprocessor};
 pub struct PreprocessOpt {
     /// Input file
     #[clap(value_parser, value_hint = ValueHint::FilePath)]
-    input: PathBuf,
+    input: Utf8PathBuf,
 }
 
 impl PreprocessOpt {

--- a/cli/src/commands/preprocess.rs
+++ b/cli/src/commands/preprocess.rs
@@ -15,7 +15,7 @@ impl PreprocessOpt {
         let fs = NativeFilesystem::from_env()?;
         info!(path = ?self.input, "Reading program");
         let preprocessor = Workspace::new(&fs, &self.input);
-        let source = preprocessor.preprocess()?;
+        let (_source_map, source) = preprocessor.preprocess()?;
         println!("{source}");
         Ok(())
     }

--- a/cli/src/commands/preprocess.rs
+++ b/cli/src/commands/preprocess.rs
@@ -1,7 +1,7 @@
 use camino::Utf8PathBuf;
 use clap::{Parser, ValueHint};
 use tracing::info;
-use z33_emulator::preprocessor::{NativeFilesystem, Preprocessor};
+use z33_emulator::preprocessor::{NativeFilesystem, Workspace};
 
 #[derive(Parser, Debug)]
 pub struct PreprocessOpt {
@@ -11,11 +11,11 @@ pub struct PreprocessOpt {
 }
 
 impl PreprocessOpt {
-    pub fn exec(&self) -> anyhow::Result<()> {
+    pub fn exec(self) -> anyhow::Result<()> {
         let fs = NativeFilesystem::from_env()?;
         info!(path = ?self.input, "Reading program");
-        let preprocessor = Preprocessor::new(fs).and_load(&self.input);
-        let source = preprocessor.preprocess(&self.input)?;
+        let preprocessor = Workspace::new(&fs, self.input);
+        let source = preprocessor.preprocess()?;
         println!("{source}");
         Ok(())
     }

--- a/cli/src/commands/print.rs
+++ b/cli/src/commands/print.rs
@@ -2,7 +2,7 @@ use camino::Utf8PathBuf;
 use clap::{Parser, ValueHint};
 use tracing::{debug, info};
 use z33_emulator::parse;
-use z33_emulator::preprocessor::{NativeFilesystem, Preprocessor};
+use z33_emulator::preprocessor::{NativeFilesystem, Workspace};
 
 #[derive(Parser, Debug)]
 pub struct PrintOpt {
@@ -12,12 +12,12 @@ pub struct PrintOpt {
 }
 
 impl PrintOpt {
-    pub fn exec(&self) -> anyhow::Result<()> {
+    pub fn exec(self) -> anyhow::Result<()> {
         let fs = NativeFilesystem::from_env()?;
         info!(path = ?self.input, "Reading program");
-        let preprocessor = Preprocessor::new(fs).and_load(&self.input);
+        let preprocessor = Workspace::new(&fs, self.input);
 
-        let source = preprocessor.preprocess(&self.input)?;
+        let source = preprocessor.preprocess()?;
         let source = source.as_str();
 
         debug!("Parsing program");

--- a/cli/src/commands/print.rs
+++ b/cli/src/commands/print.rs
@@ -17,7 +17,7 @@ impl PrintOpt {
         info!(path = ?self.input, "Reading program");
         let preprocessor = Workspace::new(&fs, &self.input);
 
-        let source = preprocessor.preprocess()?;
+        let (_source_map, source) = preprocessor.preprocess()?;
         let source = source.as_str();
 
         debug!("Parsing program");

--- a/cli/src/commands/print.rs
+++ b/cli/src/commands/print.rs
@@ -1,5 +1,4 @@
-use std::path::PathBuf;
-
+use camino::Utf8PathBuf;
 use clap::{Parser, ValueHint};
 use tracing::{debug, info};
 use z33_emulator::parse;
@@ -9,7 +8,7 @@ use z33_emulator::preprocessor::{NativeFilesystem, Preprocessor};
 pub struct PrintOpt {
     /// Input file
     #[clap(value_parser, value_hint = ValueHint::FilePath)]
-    input: PathBuf,
+    input: Utf8PathBuf,
 }
 
 impl PrintOpt {

--- a/cli/src/commands/print.rs
+++ b/cli/src/commands/print.rs
@@ -15,7 +15,7 @@ impl PrintOpt {
     pub fn exec(self) -> anyhow::Result<()> {
         let fs = NativeFilesystem::from_env()?;
         info!(path = ?self.input, "Reading program");
-        let preprocessor = Workspace::new(&fs, self.input);
+        let preprocessor = Workspace::new(&fs, &self.input);
 
         let source = preprocessor.preprocess()?;
         let source = source.as_str();

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -7,7 +7,7 @@ use codespan_reporting::files::SimpleFiles;
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
 use tracing::{debug, error, info};
 use z33_emulator::compiler::CompilationError;
-use z33_emulator::preprocessor::{NativeFilesystem, Preprocessor};
+use z33_emulator::preprocessor::{NativeFilesystem, Workspace};
 use z33_emulator::{compile, parse};
 
 use crate::interactive::run_interactive;
@@ -35,11 +35,11 @@ fn char_offset(a: &str, b: &str) -> usize {
 
 impl RunOpt {
     #[allow(clippy::too_many_lines)]
-    pub fn exec(&self) -> anyhow::Result<()> {
+    pub fn exec(self) -> anyhow::Result<()> {
         let fs = NativeFilesystem::from_env()?;
         info!(path = ?self.input, "Reading program");
-        let preprocessor = Preprocessor::new(fs).and_load(&self.input);
-        let source = match preprocessor.preprocess(&self.input) {
+        let preprocessor = Workspace::new(&fs, self.input);
+        let source = match preprocessor.preprocess() {
             Ok(p) => p,
             Err(e) => {
                 for error in anyhow::Chain::new(&e) {

--- a/cli/src/interactive/parse.rs
+++ b/cli/src/interactive/parse.rs
@@ -33,8 +33,8 @@ impl Address {
                 Box::new(ExpressionNode::Literal(i128::from(
                     reg.extract_word(computer)?,
                 )))
-                .with_location(()),
-                Box::new(node).with_location(()),
+                .with_location(0..0),
+                Box::new(node).with_location(0..0):w,
             ),
         };
 
@@ -74,7 +74,9 @@ fn parse_indexed(input: &str) -> IResult<&str, Address, VerboseError<&str>> {
     let (rest, mut expr) = parse_expression(rest)?;
 
     if let Minus = sign {
-        expr = ExpressionNode::Invert(Box::new(expr).with_location((input, start, rest)));
+        expr = ExpressionNode::Invert(
+            Box::new(expr).with_location(input.offset(start)..input.offset(rest)),
+        );
     };
 
     Ok((rest, Address::Indexed(reg, expr)))

--- a/cli/src/interactive/parse.rs
+++ b/cli/src/interactive/parse.rs
@@ -4,7 +4,7 @@ use nom::branch::alt;
 use nom::character::complete::char;
 use nom::combinator::{all_consuming, map, value};
 use nom::error::{convert_error, VerboseError};
-use nom::{Finish, IResult};
+use nom::{Finish, IResult, Offset};
 use thiserror::Error;
 use z33_emulator::constants as C;
 use z33_emulator::parser::location::Locatable;
@@ -34,7 +34,7 @@ impl Address {
                     reg.extract_word(computer)?,
                 )))
                 .with_location(0..0),
-                Box::new(node).with_location(0..0):w,
+                Box::new(node).with_location(0..0),
             ),
         };
 

--- a/deny.toml
+++ b/deny.toml
@@ -17,12 +17,7 @@ ignore = []
 
 [licenses]
 version = 2
-allow = [
-    "Apache-2.0",
-    "BSL-1.0",
-    "MIT",
-    "Unicode-DFS-2016",
-]
+allow = ["Apache-2.0", "BSL-1.0", "MIT", "Unicode-DFS-2016"]
 
 [bans]
 multiple-versions = "deny"
@@ -36,4 +31,3 @@ skip = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = ["https://github.com/brendanzab/codespan"]

--- a/deny.toml
+++ b/deny.toml
@@ -17,7 +17,7 @@ ignore = []
 
 [licenses]
 version = 2
-allow = ["Apache-2.0", "BSL-1.0", "MIT", "Unicode-DFS-2016"]
+allow = ["Apache-2.0", "BSL-1.0", "MIT", "ISC", "Unicode-DFS-2016"]
 
 [bans]
 multiple-versions = "deny"
@@ -25,6 +25,10 @@ skip = [
     # Both are because of the `matchers` dependency in `tracing-subscriber`
     { name = "regex-automata", version = "0.1.10" },
     { name = "regex-syntax", version = "0.6.29" },
+]
+skip-tree = [
+    # miette -> terminal_size depends on this old version
+    { name = "windows-sys", version = "0.48.0" },
 ]
 
 [sources]

--- a/emulator/Cargo.toml
+++ b/emulator/Cargo.toml
@@ -15,7 +15,9 @@ workspace = true
 
 [dependencies]
 bitflags.workspace = true
+camino.workspace = true
 thiserror.workspace = true
+miette.workspace = true
 nom.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/emulator/Cargo.toml
+++ b/emulator/Cargo.toml
@@ -26,4 +26,5 @@ parse-display.workspace = true
 
 [dev-dependencies]
 indoc.workspace = true
+insta.workspace = true
 pretty_assertions.workspace = true

--- a/emulator/src/compiler/layout.rs
+++ b/emulator/src/compiler/layout.rs
@@ -38,7 +38,7 @@ pub(crate) enum Placement {
 
     /// A instruction or a .word directive
     #[display("{0}")]
-    Line(LineContent),
+    Line(Located<LineContent>),
 }
 
 #[derive(Default)]
@@ -80,19 +80,19 @@ impl Layout {
 
 #[derive(Debug, Error, PartialEq)]
 pub enum MemoryLayoutError {
-    #[error("duplicate label {label}")]
+    #[error("duplicate label {label:?}")]
     DuplicateLabel {
         label: String,
         location: Range<usize>,
     },
 
-    #[error("invalid argument for directive .{kind}")]
+    #[error("invalid argument for directive \".{kind}\"")]
     InvalidDirectiveArgument {
         kind: DirectiveKind,
         location: Range<usize>,
     },
 
-    #[error("failed to evaluate argument for directive .{kind}")]
+    #[error("failed to evaluate argument for directive \".{kind}\"")]
     DirectiveArgumentEvaluation {
         kind: DirectiveKind,
         source: ExpressionEvaluationError,
@@ -118,7 +118,7 @@ impl MemoryLayoutError {
 ///
 /// It places the labels & prepare a hashmap of cells to be filled.
 #[tracing::instrument(skip(program))]
-pub(crate) fn layout_memory(program: &[Line]) -> Result<Layout, MemoryLayoutError> {
+pub(crate) fn layout_memory(program: &[Located<Line>]) -> Result<Layout, MemoryLayoutError> {
     use DirectiveKind::{Addr, Space, String, Word};
     use MemoryLayoutError::{DirectiveArgumentEvaluation, InvalidDirectiveArgument};
 
@@ -127,19 +127,26 @@ pub(crate) fn layout_memory(program: &[Line]) -> Result<Layout, MemoryLayoutErro
     let mut position = PROGRAM_START;
 
     for line in program {
+        let offset = line.location.start;
+        let line = &line.inner;
         for key in line.symbols.clone() {
+            let key = key.offset(offset);
             trace!(key = %key.inner, position, "Inserting label");
             layout.insert_label(key, position)?;
         }
 
         if let Some(ref content) = line.content {
+            let offset = offset + content.location.start;
             match &content.inner {
                 LineContent::Directive {
                     kind: Located { inner: Word, .. },
                     ..
                 }
                 | LineContent::Instruction { .. } => {
-                    layout.insert_placement(position, Placement::Line(content.inner.clone()))?;
+                    layout.insert_placement(
+                        position,
+                        Placement::Line(content.clone().offset(offset)),
+                    )?;
                     trace!(position, content = %content.inner, "Inserting line");
                     position += 1; // Instructions and word directives take one
                                    // memory cell
@@ -208,7 +215,10 @@ pub(crate) fn layout_memory(program: &[Line]) -> Result<Layout, MemoryLayoutErro
                 LineContent::Directive { kind, .. } => {
                     return Err(InvalidDirectiveArgument {
                         kind: kind.inner,
-                        location: kind.location.clone(),
+                        location: Range {
+                            start: kind.location.start + offset,
+                            end: kind.location.end + offset,
+                        },
                     });
                 }
             }
@@ -230,15 +240,15 @@ mod tests {
 
     #[test]
     fn place_labels_simple_test() {
-        let program: Vec<Line> = vec![
-            Line::default().symbol("main").instruction(
+        let program: Vec<Located<Line>> = vec![
+            Line::empty().symbol("main").instruction(
                 Add,
                 vec![
                     InstructionArgument::Register(Reg::A),
                     InstructionArgument::Register(Reg::B),
                 ],
             ),
-            Line::default().symbol("loop").instruction(
+            Line::empty().symbol("loop").instruction(
                 Jmp,
                 vec![InstructionArgument::Value(Node::Variable("main".into()))],
             ),
@@ -254,9 +264,9 @@ mod tests {
 
     #[test]
     fn place_labels_addr_test() {
-        let program: Vec<Line> = vec![
-            Line::default().directive(DirectiveKind::Addr, 10),
-            Line::default().symbol("main").instruction(
+        let program: Vec<Located<Line>> = vec![
+            Line::empty().directive(DirectiveKind::Addr, 10),
+            Line::empty().symbol("main").instruction(
                 Jmp,
                 vec![InstructionArgument::Value(Node::Variable("main".into()))],
             ),
@@ -269,14 +279,14 @@ mod tests {
 
     #[test]
     fn place_labels_space_test() {
-        let program: Vec<Line> = vec![
-            Line::default()
+        let program: Vec<Located<Line>> = vec![
+            Line::empty()
                 .symbol("first")
                 .directive(DirectiveKind::Space, 10),
-            Line::default()
+            Line::empty()
                 .symbol("second")
                 .directive(DirectiveKind::Space, 5),
-            Line::default().symbol("main").instruction(
+            Line::empty().symbol("main").instruction(
                 Jmp,
                 vec![InstructionArgument::Value(Node::Variable("main".into()))],
             ),
@@ -294,14 +304,14 @@ mod tests {
 
     #[test]
     fn place_labels_word_test() {
-        let program: Vec<Line> = vec![
-            Line::default()
+        let program: Vec<Located<Line>> = vec![
+            Line::empty()
                 .symbol("first")
                 .directive(DirectiveKind::Word, 123),
-            Line::default()
+            Line::empty()
                 .symbol("second")
                 .directive(DirectiveKind::Word, 456),
-            Line::default().symbol("main").instruction(
+            Line::empty().symbol("main").instruction(
                 Jmp,
                 vec![InstructionArgument::Value(Node::Variable("main".into()))],
             ),
@@ -319,14 +329,14 @@ mod tests {
 
     #[test]
     fn place_labels_string_test() {
-        let program: Vec<Line> = vec![
-            Line::default()
+        let program: Vec<Located<Line>> = vec![
+            Line::empty()
                 .symbol("first")
                 .directive(DirectiveKind::String, "hello"),
-            Line::default()
+            Line::empty()
                 .symbol("second")
                 .directive(DirectiveKind::String, "Émoticône: 🚙"), // length: 12 chars
-            Line::default().symbol("main").instruction(
+            Line::empty().symbol("main").instruction(
                 Jmp,
                 vec![InstructionArgument::Value(Node::Variable("main".into()))],
             ),
@@ -344,10 +354,8 @@ mod tests {
 
     #[test]
     fn duplicate_label_test() {
-        let program: Vec<Line> = vec![
-            Line::default().symbol("hello"),
-            Line::default().symbol("hello"),
-        ];
+        let program: Vec<Located<Line>> =
+            vec![Line::empty().symbol("hello"), Line::empty().symbol("hello")];
 
         assert_eq!(
             layout_memory(&program).err(),
@@ -360,7 +368,7 @@ mod tests {
 
     #[test]
     fn invalid_directive_argument_test() {
-        let program: Vec<Line> = vec![Line::default().directive(DirectiveKind::String, 3)];
+        let program: Vec<Located<Line>> = vec![Line::empty().directive(DirectiveKind::String, 3)];
 
         assert_eq!(
             layout_memory(&program).err(),
@@ -370,7 +378,8 @@ mod tests {
             })
         );
 
-        let program: Vec<Line> = vec![Line::default().directive(DirectiveKind::Space, "hello")];
+        let program: Vec<Located<Line>> =
+            vec![Line::empty().directive(DirectiveKind::Space, "hello")];
 
         assert_eq!(
             layout_memory(&program).err(),
@@ -381,7 +390,8 @@ mod tests {
             })
         );
 
-        let program: Vec<Line> = vec![Line::default().directive(DirectiveKind::Addr, "hello")];
+        let program: Vec<Located<Line>> =
+            vec![Line::empty().directive(DirectiveKind::Addr, "hello")];
 
         assert_eq!(
             layout_memory(&program).err(),
@@ -395,11 +405,12 @@ mod tests {
 
     #[test]
     fn memory_overlap_test() {
-        let program: Vec<Line> = vec![
-            Line::default().directive(DirectiveKind::Addr, 10),
-            Line::default().directive(DirectiveKind::String, "hello"), /* This takes 5 chars, so fills cells 10 to 15 */
-            Line::default().directive(DirectiveKind::Addr, 14),
-            Line::default().directive(DirectiveKind::Word, 0), // This overlaps with the second "l"
+        let program: Vec<Located<Line>> = vec![
+            Line::empty().directive(DirectiveKind::Addr, 10),
+            // This takes 5 chars, so fills cells 10 to 15
+            Line::empty().directive(DirectiveKind::String, "hello"),
+            Line::empty().directive(DirectiveKind::Addr, 14),
+            Line::empty().directive(DirectiveKind::Word, 0), // This overlaps with the second "l"
         ];
 
         assert_eq!(

--- a/emulator/src/compiler/mod.rs
+++ b/emulator/src/compiler/mod.rs
@@ -21,12 +21,12 @@ pub struct DebugInfo {
 }
 
 #[derive(Debug, Error)]
-pub enum CompilationError<L> {
+pub enum CompilationError {
     #[error("could not layout memory")]
-    MemoryLayout(#[from] MemoryLayoutError<L>),
+    MemoryLayout(#[from] MemoryLayoutError),
 
     #[error("could not fill memory")]
-    MemoryFill(#[from] MemoryFillError<L>),
+    MemoryFill(#[from] MemoryFillError),
 
     #[error("unknown entrypoint: {0}")]
     UnknownEntrypoint(String),
@@ -41,18 +41,16 @@ pub enum CompilationError<L> {
 /// # Errors
 ///
 /// This function will return an error if the program is invalid
-pub fn layout<L: Clone + Default>(
-    program: Program<L>,
-) -> Result<layout::Layout<L>, MemoryLayoutError<L>> {
+pub fn layout(program: Program) -> Result<layout::Layout, MemoryLayoutError> {
     let lines: Vec<_> = program.lines.into_iter().map(|l| l.inner).collect();
     self::layout::layout_memory(&lines)
 }
 
 #[tracing::instrument(skip(program))]
-pub fn compile<L: Clone + Default + std::fmt::Debug>(
-    program: Program<L>,
+pub fn compile(
+    program: Program,
     entrypoint: &str,
-) -> Result<(Computer, DebugInfo), CompilationError<L>> {
+) -> Result<(Computer, DebugInfo), CompilationError> {
     let lines: Vec<_> = program.lines.into_iter().map(|l| l.inner).collect();
     let layout = self::layout::layout_memory(&lines)?;
     let memory = self::memory::fill_memory(&layout)?;

--- a/emulator/src/compiler/mod.rs
+++ b/emulator/src/compiler/mod.rs
@@ -32,27 +32,12 @@ pub enum CompilationError {
     UnknownEntrypoint(String),
 }
 
-/// Construct the memory layout for a program
-///
-/// This will take the program AST and compute the memory layout for it,
-/// which includes the memory cells set as well as the labels defined in the
-/// program.
-///
-/// # Errors
-///
-/// This function will return an error if the program is invalid
-pub fn layout(program: Program) -> Result<layout::Layout, MemoryLayoutError> {
-    let lines: Vec<_> = program.lines.into_iter().map(|l| l.inner).collect();
-    self::layout::layout_memory(&lines)
-}
-
 #[tracing::instrument(skip(program))]
 pub fn compile(
     program: Program,
     entrypoint: &str,
 ) -> Result<(Computer, DebugInfo), CompilationError> {
-    let lines: Vec<_> = program.lines.into_iter().map(|l| l.inner).collect();
-    let layout = self::layout::layout_memory(&lines)?;
+    let layout = self::layout::layout_memory(&program.lines)?;
     let memory = self::memory::fill_memory(&layout)?;
 
     // Lookup the entrypoint

--- a/emulator/src/parser/errors.rs
+++ b/emulator/src/parser/errors.rs
@@ -1,5 +1,8 @@
 use std::num::ParseIntError;
 
+use miette::SourceOffset;
+use nom::Offset;
+
 pub trait ParseError<I>:
     nom::error::ParseError<I>
     + nom::error::FromExternalError<I, ParseIntError>
@@ -22,8 +25,7 @@ pub enum Error<I> {
         child: Box<Error<I>>,
     },
     Or {
-        original: Box<Error<I>>,
-        other: Box<Error<I>>,
+        inner: Vec<Error<I>>,
     },
     Char {
         input: I,
@@ -39,6 +41,66 @@ pub enum Error<I> {
         kind: nom::error::ErrorKind,
         inner: ParseIntError,
     },
+}
+
+impl<I> Error<I> {
+    // The potential panic is because of the `expect` on the `Or` variant, but we
+    // never construct empty `Or` lists, so this would never panic
+    #[allow(clippy::missing_panics_doc)]
+    pub fn input(&self) -> &I {
+        match self {
+            Self::Context { input, .. }
+            | Self::Char { input, .. }
+            | Self::Nom { input, .. }
+            | Self::ParseIntError { input, .. } => input,
+
+            Self::Or { inner } => inner.first().expect("not empty error list").input(),
+        }
+    }
+
+    pub fn to_miette_diagnostic(
+        &self,
+        source: &I,
+        additional_offset: usize,
+    ) -> Box<dyn miette::Diagnostic + Send + Sync>
+    where
+        I: Offset,
+    {
+        Box::new(self.to_diagnostic(source, additional_offset))
+    }
+
+    fn to_diagnostic(&self, source: &I, additional_offset: usize) -> Diagnostic
+    where
+        I: Offset,
+    {
+        match self {
+            Error::Context { input, ctx, child } => Diagnostic::Context {
+                span: (source.offset(input) + additional_offset).into(),
+                ctx,
+                child: child.to_miette_diagnostic(source, additional_offset),
+            },
+            Error::Or { inner } => Diagnostic::Or {
+                inner: inner
+                    .iter()
+                    .map(|e| e.to_diagnostic(source, additional_offset))
+                    .collect(),
+            },
+            Error::Char { input, needed } => Diagnostic::Char {
+                span: (source.offset(input) + additional_offset).into(),
+                needed: *needed,
+            },
+            Error::Nom { input, child, .. } => Diagnostic::Nom {
+                span: (source.offset(input) + additional_offset).into(),
+                child: child
+                    .as_ref()
+                    .map(|child| child.to_miette_diagnostic(source, additional_offset)),
+            },
+            Error::ParseIntError { input, inner, .. } => Diagnostic::ParseIntError {
+                span: (source.offset(input) + additional_offset).into(),
+                inner: inner.clone(),
+            },
+        }
+    }
 }
 
 impl<I> nom::error::ParseError<I> for Error<I> {
@@ -63,9 +125,21 @@ impl<I> nom::error::ParseError<I> for Error<I> {
     }
 
     fn or(self, other: Self) -> Self {
-        Self::Or {
-            original: Box::new(self),
-            other: Box::new(other),
+        // If any of `self` or `other` are `Or`, merge them
+        // Otherwise, create a new `Or` with both as children
+        match (self, other) {
+            (Self::Or { inner: first }, Self::Or { inner: second }) => Self::Or {
+                inner: first.into_iter().chain(second).collect(),
+            },
+            (Self::Or { inner: first }, second) => Self::Or {
+                inner: first.into_iter().chain(std::iter::once(second)).collect(),
+            },
+            (first, Self::Or { inner: second }) => Self::Or {
+                inner: std::iter::once(first).chain(second).collect(),
+            },
+            (first, second) => Self::Or {
+                inner: vec![first, second],
+            },
         }
     }
 }
@@ -84,4 +158,42 @@ impl<I> nom::error::FromExternalError<I, ParseIntError> for Error<I> {
     fn from_external_error(input: I, kind: nom::error::ErrorKind, inner: ParseIntError) -> Self {
         Self::ParseIntError { input, kind, inner }
     }
+}
+
+#[derive(Debug, miette::Diagnostic, thiserror::Error)]
+#[error("invalid syntax")]
+enum Diagnostic {
+    // TODO: embed source code?
+    Context {
+        #[label("{ctx}")]
+        span: SourceOffset,
+        ctx: &'static str,
+        child: Box<dyn miette::Diagnostic + Send + Sync>,
+    },
+
+    Or {
+        #[related]
+        inner: Vec<Diagnostic>,
+    },
+
+    Char {
+        #[label("Expect '{needed}' here")]
+        span: SourceOffset,
+
+        needed: char,
+    },
+
+    Nom {
+        #[label("here")]
+        span: SourceOffset,
+        child: Option<Box<dyn miette::Diagnostic + Send + Sync>>,
+    },
+
+    ParseIntError {
+        #[label("here")]
+        span: SourceOffset,
+
+        #[source]
+        inner: ParseIntError,
+    },
 }

--- a/emulator/src/parser/line.rs
+++ b/emulator/src/parser/line.rs
@@ -17,9 +17,9 @@ use nom::combinator::{all_consuming, cut, eof, map, opt, peek, value};
 use nom::error::context;
 use nom::multi::separated_list1;
 use nom::sequence::delimited;
-use nom::IResult;
+use nom::{IResult, Offset};
 
-use super::location::{Locatable, Located, MapLocation, RelativeLocation};
+use super::location::{Locatable, Located};
 use super::value::{
     parse_directive_argument, parse_directive_kind, parse_instruction_argument,
     parse_instruction_kind, DirectiveArgument, DirectiveKind, InstructionArgument, InstructionKind,
@@ -29,54 +29,27 @@ use crate::ast::{AstNode, Node, NodeKind};
 
 /// Holds the content of a line
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum LineContent<L> {
+pub(crate) enum LineContent {
     /// Represents an instruction, with its opcode and list of arguments
     Instruction {
-        kind: Located<InstructionKind, L>,
-        arguments: Vec<Located<InstructionArgument<L>, L>>,
+        kind: Located<InstructionKind>,
+        arguments: Vec<Located<InstructionArgument>>,
     },
     /// Represents a directive, with its type and argument
     Directive {
-        kind: Located<DirectiveKind, L>,
-        argument: Located<DirectiveArgument<L>, L>,
+        kind: Located<DirectiveKind>,
+        argument: Located<DirectiveArgument>,
     },
 }
 
-impl<L> LineContent<L> {
+impl LineContent {
     /// Check if the line is a directive
     pub(crate) fn is_directive(&self) -> bool {
         matches!(self, Self::Directive { .. })
     }
 }
 
-impl<L, P> MapLocation<P> for LineContent<L>
-where
-    L: MapLocation<P, Mapped = P>,
-{
-    type Mapped = LineContent<L::Mapped>;
-
-    fn map_location(self, parent: &P) -> Self::Mapped {
-        match self {
-            LineContent::Instruction { kind, arguments } => {
-                let kind = kind.map_location_only(parent);
-                let arguments = arguments
-                    .into_iter()
-                    .map(|a| a.map_location(parent))
-                    .collect();
-
-                LineContent::Instruction { kind, arguments }
-            }
-            LineContent::Directive { kind, argument } => {
-                let kind = kind.map_location_only(parent);
-                let argument = argument.map_location(parent);
-
-                LineContent::Directive { kind, argument }
-            }
-        }
-    }
-}
-
-impl<L: Clone> AstNode<L> for LineContent<L> {
+impl AstNode for LineContent {
     fn kind(&self) -> NodeKind {
         match self {
             LineContent::Instruction { .. } => NodeKind::Instruction,
@@ -84,7 +57,7 @@ impl<L: Clone> AstNode<L> for LineContent<L> {
         }
     }
 
-    fn children(&self) -> Vec<Node<L>> {
+    fn children(&self) -> Vec<Node> {
         match self {
             LineContent::Instruction { kind, arguments } => std::iter::once(kind.to_node())
                 .chain(arguments.iter().map(Located::to_node))
@@ -94,7 +67,7 @@ impl<L: Clone> AstNode<L> for LineContent<L> {
     }
 }
 
-impl<L> std::fmt::Display for LineContent<L> {
+impl std::fmt::Display for LineContent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             LineContent::Instruction { kind, arguments } => {
@@ -124,35 +97,17 @@ impl<L> std::fmt::Display for LineContent<L> {
 ///
 /// Note that the `Default::default()` implementation represents an empty line.
 #[derive(Debug, Clone, PartialEq, Default)]
-pub(crate) struct Line<L> {
-    pub symbols: Vec<Located<String, L>>,
-    pub content: Option<Located<LineContent<L>, L>>,
+pub(crate) struct Line {
+    pub symbols: Vec<Located<String>>,
+    pub content: Option<Located<LineContent>>,
 }
 
-impl<L, P> MapLocation<P> for Line<L>
-where
-    L: MapLocation<P, Mapped = P>,
-{
-    type Mapped = Line<L::Mapped>;
-
-    fn map_location(self, parent: &P) -> Self::Mapped {
-        let symbols = self
-            .symbols
-            .into_iter()
-            .map(|line| line.map_location_only(parent))
-            .collect();
-        let content = self.content.map(|c| c.map_location(parent));
-
-        Line { symbols, content }
-    }
-}
-
-impl<L: Clone> AstNode<L> for Line<L> {
+impl AstNode for Line {
     fn kind(&self) -> NodeKind {
         NodeKind::Line
     }
 
-    fn children(&self) -> Vec<Node<L>> {
+    fn children(&self) -> Vec<Node> {
         let mut children = Vec::new();
 
         children.extend(
@@ -167,7 +122,7 @@ impl<L: Clone> AstNode<L> for Line<L> {
     }
 }
 
-impl<L> std::fmt::Display for Line<L> {
+impl std::fmt::Display for Line {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut had_something = false;
         for symbol in &self.symbols {
@@ -186,28 +141,25 @@ impl<L> std::fmt::Display for Line<L> {
     }
 }
 
-impl<L> Line<L>
-where
-    L: From<()>,
-{
+impl Line {
     #[cfg(test)] // Only used in tests for now
     pub(crate) fn symbol(mut self, symbol: &str) -> Self {
-        self.symbols.push(symbol.to_string().with_location(()));
+        self.symbols.push(symbol.to_string().with_location(0..0));
         self
     }
 
     #[cfg(test)] // Only used in tests for now
-    pub(crate) fn directive<T: Into<DirectiveArgument<L>>>(
+    pub(crate) fn directive<T: Into<DirectiveArgument>>(
         mut self,
         kind: DirectiveKind,
         argument: T,
     ) -> Self {
         self.content = Some(
             LineContent::Directive {
-                kind: kind.with_location(()),
-                argument: argument.into().with_location(()),
+                kind: kind.with_location(0..0),
+                argument: argument.into().with_location(0..0),
             }
-            .with_location(()),
+            .with_location(0..0),
         );
         self
     }
@@ -216,25 +168,28 @@ where
     pub(crate) fn instruction(
         mut self,
         kind: InstructionKind,
-        arguments: Vec<InstructionArgument<L>>,
+        arguments: Vec<InstructionArgument>,
     ) -> Self {
         self.content = Some(
             LineContent::Instruction {
-                kind: kind.with_location(()),
-                arguments: arguments.into_iter().map(|a| a.with_location(())).collect(),
+                kind: kind.with_location(0..0),
+                arguments: arguments
+                    .into_iter()
+                    .map(|a| a.with_location(0..0))
+                    .collect(),
             }
-            .with_location(()),
+            .with_location(0..0),
         );
         self
     }
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Program<L> {
-    pub(crate) lines: Vec<Located<Line<L>, L>>,
+pub struct Program {
+    pub(crate) lines: Vec<Located<Line>>,
 }
 
-impl<L> Program<L> {
+impl Program {
     #[must_use]
     pub fn labels(&self) -> Vec<&str> {
         self.lines
@@ -244,33 +199,17 @@ impl<L> Program<L> {
     }
 }
 
-impl<L, P> MapLocation<P> for Program<L>
-where
-    L: MapLocation<P, Mapped = P>,
-{
-    type Mapped = Program<L::Mapped>;
-    fn map_location(self, parent: &P) -> Self::Mapped {
-        let lines = self
-            .lines
-            .into_iter()
-            .map(|line| line.map_location(parent))
-            .collect();
-
-        Program { lines }
-    }
-}
-
-impl<L: Clone> AstNode<L> for Program<L> {
+impl AstNode for Program {
     fn kind(&self) -> NodeKind {
         NodeKind::Program
     }
 
-    fn children(&self) -> Vec<Node<L>> {
+    fn children(&self) -> Vec<Node> {
         self.lines.iter().map(Located::to_node).collect()
     }
 }
 
-impl<L> std::fmt::Display for Program<L> {
+impl std::fmt::Display for Program {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for line in &self.lines {
             writeln!(f, "{}", line.inner)?;
@@ -283,19 +222,19 @@ impl<L> std::fmt::Display for Program<L> {
 /// Parses a directive
 fn parse_directive_line<'a, Error: ParseError<&'a str>>(
     input: &'a str,
-) -> IResult<&'a str, LineContent<RelativeLocation>, Error> {
+) -> IResult<&'a str, LineContent, Error> {
     let (rest, _) = char('.')(input)?;
 
     cut(|rest: &'a str| {
         let start = rest;
         let (rest, kind) = parse_directive_kind(rest)?;
-        let kind = kind.with_location((input, start, rest));
+        let kind = kind.with_location(input.offset(start)..input.offset(rest));
 
         let (rest, _) = space1(rest)?;
 
         let start = rest;
         let (rest, argument) = parse_directive_argument(rest)?;
-        let argument = argument.with_location((input, start, rest));
+        let argument = argument.with_location(input.offset(start)..input.offset(rest));
 
         Ok((rest, LineContent::Directive { kind, argument }))
     })(rest)
@@ -304,12 +243,12 @@ fn parse_directive_line<'a, Error: ParseError<&'a str>>(
 /// Parses an instruction
 fn parse_instruction_line<'a, Error: ParseError<&'a str>>(
     input: &'a str,
-) -> IResult<&'a str, LineContent<RelativeLocation>, Error> {
+) -> IResult<&'a str, LineContent, Error> {
     // First parse the opcode
     let (rest, kind) = parse_instruction_kind(input)?;
 
     cut(move |rest: &'a str| {
-        let kind = kind.with_location((input, input, rest));
+        let kind = kind.with_location(input.offset(input)..input.offset(rest));
         // Then loop to parse the list of arguments
         let mut cursor = rest;
         let mut arguments = Vec::with_capacity(2); // Instructions usually have <= 2 arguments
@@ -333,7 +272,7 @@ fn parse_instruction_line<'a, Error: ParseError<&'a str>>(
 
                 // Then continue parsing the argument
                 if let (rest, Some(argument)) = opt(parse_instruction_argument)(rest)? {
-                    let argument = argument.with_location((input, start, rest));
+                    let argument = argument.with_location(input.offset(start)..input.offset(rest));
                     arguments.push(argument);
                     // Only update the cursor here, in case it fails earlier
                     cursor = rest;
@@ -350,7 +289,7 @@ fn parse_instruction_line<'a, Error: ParseError<&'a str>>(
 /// Parses the content of a line: an instruction or a directive
 fn parse_line_content<'a, Error: ParseError<&'a str>>(
     input: &'a str,
-) -> IResult<&'a str, LineContent<RelativeLocation>, Error> {
+) -> IResult<&'a str, LineContent, Error> {
     alt((
         context("directive", parse_directive_line),
         context("instruction", parse_instruction_line),
@@ -368,9 +307,7 @@ fn parse_symbol_definition<'a, Error: ParseError<&'a str>>(
 }
 
 /// Parses a whole line
-fn parse_line<'a, Error: ParseError<&'a str>>(
-    input: &'a str,
-) -> IResult<&'a str, Line<RelativeLocation>, Error> {
+fn parse_line<'a, Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Line, Error> {
     let (rest, _) = space0(input)?;
 
     // Extract the list of symbol definitions
@@ -378,7 +315,7 @@ fn parse_line<'a, Error: ParseError<&'a str>>(
     let mut symbols = Vec::new();
     while let (rest, Some(symbol)) = opt(parse_symbol_definition)(cursor)? {
         // TODO: symbol location includes the colon, maybe we don't want that
-        let symbol = symbol.with_location((input, cursor, rest));
+        let symbol = symbol.with_location(input.offset(cursor)..input.offset(rest));
         let (rest, _) = space0(rest)?;
         symbols.push(symbol);
         cursor = rest;
@@ -388,7 +325,7 @@ fn parse_line<'a, Error: ParseError<&'a str>>(
     // Extract the line content
     let start = rest;
     let (rest, content) = opt(parse_line_content)(rest)?;
-    let content = content.map(|line| line.with_location((input, start, rest))); // Save location information
+    let content = content.map(|line| line.with_location(input.offset(start)..input.offset(rest))); // Save location information
     let (rest, _) = space0(rest)?;
 
     // Build the line
@@ -412,14 +349,14 @@ fn split_lines<'a, Error: ParseError<&'a str>>(
 
 pub(crate) fn parse_program<'a, Error: ParseError<&'a str>>(
     input: &'a str,
-) -> IResult<&'a str, Program<RelativeLocation>, Error> {
+) -> IResult<&'a str, Program, Error> {
     let (rest, lines) = split_lines(input)?;
     // TODO: bubble up more detailed errors here
     let lines: Result<_, _> = lines
         .into_iter()
         .map(|start| {
             context("line", all_consuming(parse_line))(start)
-                .map(|(end, line)| line.with_location((input, start, end)))
+                .map(|(end, line)| line.with_location(input.offset(start)..input.offset(end)))
         })
         .collect();
     let lines = lines?;
@@ -454,10 +391,10 @@ mod tests {
             line,
             Line {
                 symbols: vec![
-                    "hello".to_string().with_location((0, 6)),
-                    "world".to_string().with_location((6, 7)),
-                    "duplicate".to_string().with_location((14, 10)),
-                    "duplicate".to_string().with_location((25, 10))
+                    "hello".to_string().with_location(0..6),
+                    "world".to_string().with_location(6..13),
+                    "duplicate".to_string().with_location(14..24),
+                    "duplicate".to_string().with_location(25..35)
                 ],
                 ..Default::default()
             }
@@ -472,19 +409,19 @@ mod tests {
             line,
             Line {
                 symbols: vec![
-                    "foo".to_string().with_location((0, 4)),
-                    "bar".to_string().with_location((5, 4)),
+                    "foo".to_string().with_location(0..4),
+                    "bar".to_string().with_location(5..9),
                 ],
                 content: Some(
                     LineContent::Directive {
-                        kind: DirectiveKind::Space.with_location((1, 5)),
+                        kind: DirectiveKind::Space.with_location(1..6),
                         argument: DirectiveArgument::Expression(Node::Sum(
-                            Box::new(Node::Literal(30)).with_location((0, 2)),
-                            Box::new(Node::Literal(5)).with_location((5, 1))
+                            Box::new(Node::Literal(30)).with_location(0..2),
+                            Box::new(Node::Literal(5)).with_location(5..6)
                         ))
-                        .with_location((7, 6)),
+                        .with_location(7..13),
                     }
-                    .with_location((10, 13))
+                    .with_location(10..23)
                 ),
             }
         );
@@ -525,52 +462,52 @@ main:
             program,
             Program {
                 lines: vec![
-                    Line::default().with_location((0, 0)),
+                    Line::default().with_location(0..0),
                     Line {
-                        symbols: vec!["str".to_string().with_location((0, 4))],
+                        symbols: vec!["str".to_string().with_location(0..4)],
                         content: Some(
                             LineContent::Directive {
-                                kind: Space.with_location((1, 5)),
+                                kind: Space.with_location(1..6),
                                 argument: DirectiveArgument::StringLiteral(
                                     "some multiline string".to_string()
                                 )
-                                .with_location((7, 25))
+                                .with_location(7..32)
                             }
-                            .with_location((5, 32))
+                            .with_location(5..37)
                         ),
                     }
-                    .with_location((1, 37)),
+                    .with_location(1..38),
                     Line {
-                        symbols: vec!["main".to_string().with_location((0, 5))],
+                        symbols: vec!["main".to_string().with_location(0..5)],
                         ..Default::default()
                     }
-                    .with_location((39, 5)),
+                    .with_location(39..44),
                     Line {
                         content: Some(
                             LineContent::Instruction {
-                                kind: Add.with_location((0, 3)),
+                                kind: Add.with_location(0..3),
                                 arguments: vec![
-                                    InstructionArgument::Register(Reg::A).with_location((4, 2)),
-                                    InstructionArgument::Register(Reg::B).with_location((8, 2)),
+                                    InstructionArgument::Register(Reg::A).with_location(4..6),
+                                    InstructionArgument::Register(Reg::B).with_location(8..10),
                                 ],
                             }
-                            .with_location((4, 10))
+                            .with_location(4..14)
                         ),
                         ..Default::default()
                     }
-                    .with_location((45, 14)),
+                    .with_location(45..59),
                     Line {
                         content: Some(
                             LineContent::Instruction {
-                                kind: Reset.with_location((0, 5)),
+                                kind: Reset.with_location(0..5),
                                 arguments: vec![],
                             }
-                            .with_location((4, 5))
+                            .with_location(4..9)
                         ),
                         ..Default::default()
                     }
-                    .with_location((60, 9)),
-                    Line::default().with_location((70, 8)),
+                    .with_location(60..69),
+                    Line::default().with_location(70..78),
                 ]
             }
         );
@@ -582,7 +519,7 @@ main:
         assert_eq!(
             program,
             Program {
-                lines: vec![Line::default().with_location((0, 0))]
+                lines: vec![Line::default().with_location(0..0)]
             }
         );
     }

--- a/emulator/src/parser/line.rs
+++ b/emulator/src/parser/line.rs
@@ -143,24 +143,17 @@ impl std::fmt::Display for Line {
 
 impl Line {
     #[cfg(test)] // Only used in tests for now
-    pub(crate) fn symbol(mut self, symbol: &str) -> Self {
-        self.symbols.push(symbol.to_string().with_location(0..0));
-        self
+    pub(crate) fn empty() -> Located<Self> {
+        Self::default().with_location(0..0)
     }
+}
 
+impl Located<Line> {
     #[cfg(test)] // Only used in tests for now
-    pub(crate) fn directive<T: Into<DirectiveArgument>>(
-        mut self,
-        kind: DirectiveKind,
-        argument: T,
-    ) -> Self {
-        self.content = Some(
-            LineContent::Directive {
-                kind: kind.with_location(0..0),
-                argument: argument.into().with_location(0..0),
-            }
-            .with_location(0..0),
-        );
+    pub(crate) fn symbol(mut self, symbol: &str) -> Self {
+        self.inner
+            .symbols
+            .push(symbol.to_string().with_location(0..0));
         self
     }
 
@@ -170,13 +163,29 @@ impl Line {
         kind: InstructionKind,
         arguments: Vec<InstructionArgument>,
     ) -> Self {
-        self.content = Some(
+        self.inner.content = Some(
             LineContent::Instruction {
                 kind: kind.with_location(0..0),
                 arguments: arguments
                     .into_iter()
                     .map(|a| a.with_location(0..0))
                     .collect(),
+            }
+            .with_location(0..0),
+        );
+        self
+    }
+
+    #[cfg(test)] // Only used in tests for now
+    pub(crate) fn directive<T: Into<DirectiveArgument>>(
+        mut self,
+        kind: DirectiveKind,
+        argument: T,
+    ) -> Self {
+        self.inner.content = Some(
+            LineContent::Directive {
+                kind: kind.with_location(0..0),
+                argument: argument.into().with_location(0..0),
             }
             .with_location(0..0),
         );

--- a/emulator/src/parser/location.rs
+++ b/emulator/src/parser/location.rs
@@ -1,30 +1,32 @@
+use std::ops::Range;
+
 use nom::Offset;
 use parse_display::Display;
 
 #[derive(Clone, Debug, PartialEq, Eq, Display)]
 #[display("{inner}", bound(T))]
-pub struct Located<T, L> {
+pub struct Located<T> {
     pub inner: T,
-    pub(crate) location: L,
+    pub(crate) location: Range<usize>,
 }
 
-impl<T> Located<T, RelativeLocation> {
+impl<T> Located<T> {
     pub(crate) fn offset(self, offset: usize) -> Self {
         Located {
             inner: self.inner,
-            location: RelativeLocation {
-                offset: offset + self.location.offset,
-                length: self.location.length,
+            location: Range {
+                start: offset + self.location.start,
+                end: offset + self.location.end,
             },
         }
     }
 }
 
 pub trait Locatable: Sized {
-    fn with_location<L, L1: Into<L>>(self, location: L1) -> Located<Self, L> {
+    fn with_location(self, location: Range<usize>) -> Located<Self> {
         Located {
             inner: self,
-            location: location.into(),
+            location,
         }
     }
 }
@@ -60,155 +62,8 @@ where
     }
 }
 
-impl RelativeLocation {
-    #[must_use]
-    pub fn into_absolute(self, parent: &AbsoluteLocation) -> AbsoluteLocation {
-        self.to_absolute(parent)
-    }
-
-    pub(crate) fn to_absolute(&self, parent: &AbsoluteLocation) -> AbsoluteLocation {
-        AbsoluteLocation {
-            offset: parent.offset + self.offset,
-            length: self.length,
-            file: (),
-        }
-    }
-}
-
 impl std::fmt::Display for RelativeLocation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}..{}", self.offset, self.offset + self.length)
-    }
-}
-
-impl<T> Located<T, RelativeLocation> {
-    pub fn into_absolute<O, M>(
-        self,
-        parent: &AbsoluteLocation,
-        mapper: M,
-    ) -> Located<O, AbsoluteLocation>
-    where
-        M: Fn(T, &AbsoluteLocation) -> O,
-    {
-        let location = self.location.to_absolute(parent);
-        let inner = mapper(self.inner, &location);
-        Located { inner, location }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
-pub struct AbsoluteLocation<File = ()> {
-    pub offset: usize,
-    pub length: usize,
-    pub file: File,
-}
-
-impl<F: Default> From<(usize, usize)> for AbsoluteLocation<F> {
-    fn from((offset, length): (usize, usize)) -> Self {
-        AbsoluteLocation {
-            offset,
-            length,
-            file: F::default(),
-        }
-    }
-}
-
-impl std::fmt::Display for AbsoluteLocation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}..{}", self.offset, self.offset + self.length)
-    }
-}
-
-pub trait MapLocation<Parent> {
-    type Mapped;
-
-    fn map_location(self, parent: &Parent) -> Self::Mapped;
-}
-
-impl<P, L, T> MapLocation<P> for Located<T, L>
-where
-    T: MapLocation<L::Mapped>,
-    L: MapLocation<P>,
-{
-    type Mapped = Located<T::Mapped, L::Mapped>;
-
-    fn map_location(self, parent: &P) -> Self::Mapped {
-        let location = self.location.map_location(parent);
-        let inner = self.inner.map_location(&location);
-
-        Located { inner, location }
-    }
-}
-
-impl<P, T> MapLocation<P> for Box<T>
-where
-    T: MapLocation<P>,
-{
-    type Mapped = Box<T::Mapped>;
-
-    fn map_location(self, parent: &P) -> Self::Mapped {
-        Box::new((*self).map_location(parent))
-    }
-}
-
-impl<P, T> MapLocation<P> for Option<T>
-where
-    T: MapLocation<P>,
-{
-    type Mapped = Option<T::Mapped>;
-
-    fn map_location(self, parent: &P) -> Self::Mapped {
-        self.map(|inner| inner.map_location(parent))
-    }
-}
-
-impl<P, T> MapLocation<P> for Vec<T>
-where
-    T: MapLocation<P>,
-{
-    type Mapped = Vec<T::Mapped>;
-
-    fn map_location(self, parent: &P) -> Self::Mapped {
-        self.into_iter()
-            .map(|item| item.map_location(parent))
-            .collect()
-    }
-}
-
-impl<F> MapLocation<AbsoluteLocation<F>> for RelativeLocation
-where
-    F: Clone,
-{
-    type Mapped = AbsoluteLocation<F>;
-
-    fn map_location(self, parent: &AbsoluteLocation<F>) -> Self::Mapped {
-        AbsoluteLocation {
-            offset: parent.offset + self.offset,
-            length: self.length,
-            file: parent.file.clone(),
-        }
-    }
-}
-
-impl MapLocation<()> for AbsoluteLocation {
-    type Mapped = ();
-    fn map_location(self, _parent: &()) -> Self::Mapped {}
-}
-
-impl MapLocation<()> for RelativeLocation {
-    type Mapped = ();
-    fn map_location(self, _parent: &()) -> Self::Mapped {}
-}
-
-impl<T, L> Located<T, L> {
-    pub fn map_location_only<P>(self, parent: &P) -> Located<T, L::Mapped>
-    where
-        L: MapLocation<P>,
-    {
-        let location = self.location.map_location(parent);
-        Located {
-            location,
-            inner: self.inner,
-        }
     }
 }

--- a/emulator/src/parser/location.rs
+++ b/emulator/src/parser/location.rs
@@ -1,13 +1,18 @@
 use std::ops::Range;
 
-use nom::Offset;
-use parse_display::Display;
-
-#[derive(Clone, Debug, PartialEq, Eq, Display)]
-#[display("{inner}", bound(T))]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Located<T> {
     pub inner: T,
     pub(crate) location: Range<usize>,
+}
+
+impl<T> std::fmt::Display for Located<T>
+where
+    T: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
 }
 
 impl<T> Located<T> {
@@ -32,38 +37,3 @@ pub trait Locatable: Sized {
 }
 
 impl<T> Locatable for T {}
-
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
-pub struct RelativeLocation {
-    offset: usize,
-    length: usize,
-}
-
-impl From<()> for RelativeLocation {
-    fn from((): ()) -> Self {
-        Self::default()
-    }
-}
-
-impl From<(usize, usize)> for RelativeLocation {
-    fn from((offset, length): (usize, usize)) -> Self {
-        RelativeLocation { offset, length }
-    }
-}
-
-impl<T> From<(T, T, T)> for RelativeLocation
-where
-    T: Offset,
-{
-    fn from((full, start, end): (T, T, T)) -> Self {
-        let offset = full.offset(&start);
-        let length = start.offset(&end);
-        RelativeLocation { offset, length }
-    }
-}
-
-impl std::fmt::Display for RelativeLocation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}..{}", self.offset, self.offset + self.length)
-    }
-}

--- a/emulator/src/parser/mod.rs
+++ b/emulator/src/parser/mod.rs
@@ -7,7 +7,7 @@ use nom::bytes::complete::take_while1;
 use nom::combinator::{all_consuming, verify};
 use nom::{Finish, IResult};
 
-use self::location::{Locatable, Located, RelativeLocation};
+use self::location::{Locatable, Located};
 
 pub(crate) mod condition;
 mod errors;
@@ -49,19 +49,17 @@ pub(crate) fn parse_identifier<'a, Error: ParseError<&'a str>>(
 /// # Errors
 ///
 /// This function will return an error if the program is invalid
-pub fn parse(
-    input: &str,
-) -> Result<Located<Program<RelativeLocation>, RelativeLocation>, nom::error::VerboseError<&str>> {
+pub fn parse(input: &str) -> Result<Located<Program>, nom::error::VerboseError<&str>> {
     parse_new(input)
 }
 
 #[doc(hidden)]
 pub fn parse_new<'a, Error: ParseError<&'a str>>(
     input: &'a str,
-) -> Result<Located<Program<RelativeLocation>, RelativeLocation>, Error> {
+) -> Result<Located<Program>, Error> {
     // TODO: proper error handling & wrap those steps
     let (_, program) = all_consuming(self::line::parse_program)(input).finish()?;
-    let program = program.with_location((0, input.len()));
+    let program = program.with_location(0..input.len());
 
     Ok(program)
 }

--- a/emulator/src/parser/precedence.rs
+++ b/emulator/src/parser/precedence.rs
@@ -43,7 +43,7 @@ impl<'a, T: std::fmt::Display + Precedence> std::fmt::Display for ChildTree<'a, 
 
 // Precedence values are taken from here: https://en.cppreference.com/w/c/language/operator_precedence
 
-impl<L> Precedence for ExpressionNode<L> {
+impl Precedence for ExpressionNode {
     fn precedence(&self) -> usize {
         match self {
             Self::Literal(_) | Self::Variable(_) => 0,
@@ -57,7 +57,7 @@ impl<L> Precedence for ExpressionNode<L> {
     }
 }
 
-impl<L> Precedence for ConditionNode<L> {
+impl Precedence for ConditionNode {
     fn precedence(&self) -> usize {
         match self {
             Self::Literal(_) | Self::Defined(_) => 0,

--- a/emulator/src/parser/preprocessor.rs
+++ b/emulator/src/parser/preprocessor.rs
@@ -6,85 +6,42 @@ use nom::sequence::preceded;
 use nom::{IResult, Offset};
 
 use super::literal::parse_string_literal;
-use super::location::{Locatable, Located, MapLocation, RelativeLocation};
+use super::location::{Locatable, Located};
 use super::{parse_identifier, ParseError};
 
-type Children<L> = Vec<Located<Node<L>, L>>;
+type Children = Vec<Located<Node>>;
 
 #[derive(Debug, PartialEq)]
-pub(crate) struct ConditionBranch<L> {
-    pub condition: Located<String, L>,
-    pub body: Located<Children<L>, L>,
-}
-
-impl<P, L> MapLocation<P> for ConditionBranch<L>
-where
-    L: MapLocation<P, Mapped = P>,
-{
-    type Mapped = ConditionBranch<P>;
-
-    fn map_location(self, parent: &P) -> Self::Mapped {
-        let condition = self.condition.map_location_only(parent);
-        let body = self.body.map_location(parent);
-        ConditionBranch { condition, body }
-    }
+pub(crate) struct ConditionBranch {
+    pub condition: Located<String>,
+    pub body: Located<Children>,
 }
 
 #[derive(Debug, PartialEq)]
-pub(crate) enum Node<L> {
+pub(crate) enum Node {
     Raw {
         content: String,
     },
     Error {
-        message: Located<String, L>,
+        message: Located<String>,
     },
     Undefine {
-        key: Located<String, L>,
+        key: Located<String>,
     },
     Definition {
-        key: Located<String, L>,
-        content: Option<Located<String, L>>,
+        key: Located<String>,
+        content: Option<Located<String>>,
     },
     Inclusion {
-        path: Located<String, L>,
+        path: Located<String>,
     },
     Condition {
-        branches: Vec<ConditionBranch<L>>,
-        fallback: Option<Located<Children<L>, L>>,
+        branches: Vec<ConditionBranch>,
+        fallback: Option<Located<Children>>,
     },
 }
 
-impl<P, L> MapLocation<P> for Node<L>
-where
-    L: MapLocation<P, Mapped = P>,
-{
-    type Mapped = Node<P>;
-
-    fn map_location(self, parent: &P) -> Self::Mapped {
-        match self {
-            Self::Raw { content } => Node::Raw { content },
-            Self::Error { message } => Node::Error {
-                message: message.map_location_only(parent),
-            },
-            Self::Undefine { key } => Node::Undefine {
-                key: key.map_location_only(parent),
-            },
-            Self::Definition { key, content } => Node::Definition {
-                key: key.map_location_only(parent),
-                content: content.map(|c| c.map_location_only(parent)),
-            },
-            Self::Inclusion { path } => Node::Inclusion {
-                path: path.map_location_only(parent),
-            },
-            Self::Condition { branches, fallback } => Node::Condition {
-                branches: branches.map_location(parent),
-                fallback: fallback.map_location(parent),
-            },
-        }
-    }
-}
-
-impl<L> Node<L> {
+impl Node {
     pub(crate) fn walk<F>(&self, f: &mut F)
     where
         F: FnMut(&Self),
@@ -156,20 +113,24 @@ fn parse_directive_argument<'a, Error: ParseError<&'a str>>(
 
 fn parse_definition<'a, Error: ParseError<&'a str>>(
     input: &'a str,
-) -> IResult<&'a str, Node<RelativeLocation>, Error> {
+) -> IResult<&'a str, Node, Error> {
     let (rest, _) = char('#')(input)?;
     let (rest, _) = space0(rest)?;
     let (rest, _) = tag("define")(rest)?;
     let (rest, _) = space1(rest)?;
     let start = rest;
     let (rest, key) = parse_identifier(rest)?;
-    let key = key.to_owned().with_location((input, start, rest));
+    let key = key
+        .to_owned()
+        .with_location(input.offset(start)..input.offset(rest));
 
     let (rest, content) = opt(|rest| {
         let (rest, _) = space1(rest)?;
         let start = rest;
         let (rest, content) = parse_directive_argument(rest)?;
-        let content = content.to_owned().with_location((input, start, rest));
+        let content = content
+            .to_owned()
+            .with_location(input.offset(start)..input.offset(rest));
         Ok((rest, content))
     })(rest)?;
 
@@ -178,9 +139,7 @@ fn parse_definition<'a, Error: ParseError<&'a str>>(
     Ok((rest, Node::Definition { key, content }))
 }
 
-fn parse_undefine<'a, Error: ParseError<&'a str>>(
-    input: &'a str,
-) -> IResult<&'a str, Node<RelativeLocation>, Error> {
+fn parse_undefine<'a, Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, Error> {
     let (rest, _) = char('#')(input)?;
     let (rest, _) = space0(rest)?;
     let (rest, _) = tag("undefine")(rest)?;
@@ -188,7 +147,9 @@ fn parse_undefine<'a, Error: ParseError<&'a str>>(
 
     let start = rest;
     let (rest, key) = parse_identifier(rest)?;
-    let key = key.to_owned().with_location((input, start, rest));
+    let key = key
+        .to_owned()
+        .with_location(input.offset(start)..input.offset(rest));
 
     let (rest, ()) = eat_end_of_line(rest)?;
 
@@ -197,7 +158,7 @@ fn parse_undefine<'a, Error: ParseError<&'a str>>(
 
 fn parse_inclusion<'a, Error: ParseError<&'a str>>(
     input: &'a str,
-) -> IResult<&'a str, Node<RelativeLocation>, Error> {
+) -> IResult<&'a str, Node, Error> {
     // Parse "#include"
     let (rest, _) = char('#')(input)?;
     let (rest, _) = space0(rest)?;
@@ -207,16 +168,14 @@ fn parse_inclusion<'a, Error: ParseError<&'a str>>(
     // Parse the argument
     let start = rest;
     let (rest, path) = parse_string_literal(rest)?;
-    let path = path.with_location((input, start, rest));
+    let path = path.with_location(input.offset(start)..input.offset(rest));
 
     let (rest, ()) = eat_end_of_line(rest)?;
 
     Ok((rest, Node::Inclusion { path }))
 }
 
-fn parse_error<'a, Error: ParseError<&'a str>>(
-    input: &'a str,
-) -> IResult<&'a str, Node<RelativeLocation>, Error> {
+fn parse_error<'a, Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, Error> {
     // Parse "#error"
     let (rest, _) = char('#')(input)?;
     let (rest, _) = space0(rest)?;
@@ -226,7 +185,7 @@ fn parse_error<'a, Error: ParseError<&'a str>>(
     // Parse the argument
     let start = rest;
     let (rest, message) = parse_string_literal(rest)?;
-    let message = message.with_location((input, start, rest));
+    let message = message.with_location(input.offset(start)..input.offset(rest));
 
     let (rest, ()) = eat_end_of_line(rest)?;
 
@@ -235,11 +194,11 @@ fn parse_error<'a, Error: ParseError<&'a str>>(
 
 fn parse_condition<'a, Error: ParseError<&'a str>>(
     input: &'a str,
-) -> IResult<&'a str, Node<RelativeLocation>, Error> {
+) -> IResult<&'a str, Node, Error> {
     // This structure helps parsing the else/elif/end directives
     enum BranchDirective {
         Else,
-        ElseIf(Located<String, RelativeLocation>),
+        ElseIf(Located<String>),
         EndIf,
     }
     use BranchDirective::{Else, ElseIf, EndIf};
@@ -253,7 +212,9 @@ fn parse_condition<'a, Error: ParseError<&'a str>>(
     // Then parse the first condition
     let start = rest;
     let (rest, condition) = parse_directive_argument(rest)?;
-    let condition = condition.to_string().with_location((input, start, rest));
+    let condition = condition
+        .to_string()
+        .with_location(input.offset(start)..input.offset(rest));
 
     let (rest, ()) = eat_end_of_line(rest)?;
     let (rest, _) = line_ending(rest)?;
@@ -261,7 +222,7 @@ fn parse_condition<'a, Error: ParseError<&'a str>>(
     // Parse its body
     let start = rest;
     let (rest, body) = parse(rest)?;
-    let body = body.with_location((input, start, rest));
+    let body = body.with_location(input.offset(start)..input.offset(rest));
 
     // We have the first branch parsed, let's parse the others
     let branch = ConditionBranch { condition, body };
@@ -282,7 +243,9 @@ fn parse_condition<'a, Error: ParseError<&'a str>>(
                 let (rest, _) = space1(rest)?;
                 let start = rest;
                 let (rest, condition) = parse_directive_argument(rest)?;
-                let condition = condition.to_string().with_location((input, start, rest));
+                let condition = condition
+                    .to_string()
+                    .with_location(input.offset(start)..input.offset(rest));
                 Ok((rest, ElseIf(condition)))
             },
             map(tag("else"), |_| Else),
@@ -301,7 +264,7 @@ fn parse_condition<'a, Error: ParseError<&'a str>>(
 
         let start = rest;
         let (rest, body) = parse(rest)?;
-        let body = body.with_location((input, start, rest));
+        let body = body.with_location(input.offset(start)..input.offset(rest));
 
         cursor = rest;
 
@@ -322,9 +285,7 @@ fn parse_condition<'a, Error: ParseError<&'a str>>(
     Ok((rest, Node::Condition { branches, fallback }))
 }
 
-fn parse_raw<'a, Error: ParseError<&'a str>>(
-    input: &'a str,
-) -> IResult<&'a str, Node<RelativeLocation>, Error> {
+fn parse_raw<'a, Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, Error> {
     let (rest, ()) = not(char('#'))(input)?;
     let (rest, content) = not_line_ending(rest)?;
     // Strip the comment from the content
@@ -337,9 +298,7 @@ fn parse_raw<'a, Error: ParseError<&'a str>>(
     Ok((rest, Node::Raw { content }))
 }
 
-fn parse_chunk<'a, Error: ParseError<&'a str>>(
-    input: &'a str,
-) -> IResult<&'a str, Node<RelativeLocation>, Error> {
+fn parse_chunk<'a, Error: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Node, Error> {
     alt((
         parse_definition, // #define X [Y]
         parse_undefine,   // #undefine X
@@ -352,12 +311,12 @@ fn parse_chunk<'a, Error: ParseError<&'a str>>(
 
 pub(crate) fn parse<'a, Error: ParseError<&'a str>>(
     input: &'a str,
-) -> IResult<&'a str, Children<RelativeLocation>, Error> {
+) -> IResult<&'a str, Children, Error> {
     let mut chunks = Vec::new();
     let mut cursor = input;
 
     while let (rest, Some(chunk)) = opt(parse_chunk)(cursor)? {
-        let chunk = chunk.with_location((input, cursor, rest));
+        let chunk = chunk.with_location(input.offset(cursor)..input.offset(rest));
         chunks.push(chunk);
 
         if let Ok((rest, _)) = line_ending::<_, nom::error::Error<_>>(rest) {
@@ -392,8 +351,8 @@ mod tests {
             (
                 "",
                 Node::Definition {
-                    key: "foo".to_owned().with_location((8, 3)),
-                    content: Some("bar".to_owned().with_location((12, 3))),
+                    key: "foo".to_owned().with_location(8..11),
+                    content: Some("bar".to_owned().with_location(12..15)),
                 }
             )
         );
@@ -404,7 +363,7 @@ mod tests {
             (
                 "",
                 Node::Definition {
-                    key: "foo".to_owned().with_location((8, 3)),
+                    key: "foo".to_owned().with_location(8..11),
                     content: None,
                 }
             )
@@ -416,7 +375,7 @@ mod tests {
             (
                 "",
                 Node::Definition {
-                    key: "trailing".to_owned().with_location((8, 8)),
+                    key: "trailing".to_owned().with_location(8..16),
                     content: None,
                 }
             )
@@ -431,7 +390,7 @@ mod tests {
             (
                 "",
                 Node::Inclusion {
-                    path: "foo".to_string().with_location((9, 5))
+                    path: "foo".to_string().with_location(9..14)
                 }
             )
         );
@@ -494,37 +453,37 @@ mod tests {
                 Raw {
                     content: "hello".to_string()
                 }
-                .with_location((0, 5)),
+                .with_location(0..5),
                 Inclusion {
-                    path: "foo".to_string().with_location((9, 5))
+                    path: "foo".to_string().with_location(9..14)
                 }
-                .with_location((6, 14)),
+                .with_location(6..20),
                 Definition {
-                    key: "bar".to_string().with_location((8, 3)),
-                    content: Some("baz".to_string().with_location((12, 3)))
+                    key: "bar".to_string().with_location(8..11),
+                    content: Some("baz".to_string().with_location(12..15))
                 }
-                .with_location((21, 15)),
+                .with_location(21..36),
                 Raw {
                     content: "world".to_string()
                 }
-                .with_location((37, 5)),
+                .with_location(37..42),
                 Error {
-                    message: "deprecated".to_string().with_location((7, 12))
+                    message: "deprecated".to_string().with_location(7..19)
                 }
-                .with_location((43, 19)),
+                .with_location(43..62),
                 Undefine {
-                    key: "bar".to_string().with_location((10, 3)),
+                    key: "bar".to_string().with_location(10..13)
                 }
-                .with_location((63, 13)),
+                .with_location(63..76),
                 Definition {
-                    key: "test".to_string().with_location((8, 4)),
+                    key: "test".to_string().with_location(8..12),
                     content: None,
                 }
-                .with_location((77, 12)),
+                .with_location(77..89),
                 Raw {
                     content: String::new(),
                 }
-                .with_location((90, 0))
+                .with_location(90..90),
             ]
         );
     }
@@ -552,45 +511,45 @@ mod tests {
                 Raw {
                     content: "hello".to_string()
                 }
-                .with_location((0, 5)),
+                .with_location(0..5),
                 Inclusion {
-                    path: "foo".to_string().with_location((13, 5))
+                    path: "foo".to_string().with_location(13..18)
                 }
-                .with_location((6, 27)),
+                .with_location(6..33),
                 Definition {
-                    key: "bar".to_string().with_location((11, 3)),
-                    content: Some("baz".to_string().with_location((17, 3)))
+                    key: "bar".to_string().with_location(11..14),
+                    content: Some("baz".to_string().with_location(17..20))
                 }
-                .with_location((34, 32)),
+                .with_location(34..66),
                 Raw {
                     content: "world".to_string()
                 }
-                .with_location((67, 5)),
+                .with_location(67..72),
                 Error {
-                    message: "deprecated".to_string().with_location((13, 12))
+                    message: "deprecated".to_string().with_location(13..25)
                 }
-                .with_location((73, 25)),
+                .with_location(73..98),
                 Undefine {
-                    key: "bar".to_string().with_location((12, 3)),
+                    key: "bar".to_string().with_location(12..15),
                 }
-                .with_location((99, 25)),
+                .with_location(99..124),
                 Definition {
-                    key: "test".to_string().with_location((12, 4)),
+                    key: "test".to_string().with_location(12..16),
                     content: None,
                 }
-                .with_location((125, 27)),
+                .with_location(125..152),
                 Raw {
                     content: String::new()
                 }
-                .with_location((153, 0)),
+                .with_location(153..153),
                 Raw {
                     content: "empty line".to_string()
                 }
-                .with_location((154, 10)),
+                .with_location(154..164),
                 Raw {
                     content: String::new()
                 }
-                .with_location((165, 0)),
+                .with_location(165..165),
             ]
         );
     }
@@ -627,34 +586,34 @@ mod tests {
             Condition {
                 branches: vec![
                     ConditionBranch {
-                        condition: "true".to_string().with_location((4, 4)),
+                        condition: "true".to_string().with_location(4..8),
                         body: vec![
                             Raw {
                                 content: "foo".to_string()
                             }
-                            .with_location((0, 3)),
+                            .with_location(0..3),
                             Condition {
                                 branches: vec![ConditionBranch {
-                                    condition: "false".to_string().with_location((4, 5)),
+                                    condition: "false".to_string().with_location(4..9),
                                     body: vec![Raw {
                                         content: "bar".to_string()
                                     }
-                                    .with_location((0, 3))]
-                                    .with_location((10, 4))
+                                    .with_location(0..3)]
+                                    .with_location(10..14)
                                 },],
                                 fallback: None,
                             }
-                            .with_location((4, 20)),
+                            .with_location(4..24),
                         ]
-                        .with_location((9, 25))
+                        .with_location(9..34)
                     },
                     ConditionBranch {
-                        condition: "true".to_string().with_location((40, 4)),
+                        condition: "true".to_string().with_location(40..44),
                         body: vec![Raw {
                             content: "foobar".to_string()
                         }
-                        .with_location((0, 6))]
-                        .with_location((63, 7))
+                        .with_location(0..6)]
+                        .with_location(63..70)
                     }
                 ],
                 fallback: Some(
@@ -663,9 +622,9 @@ mod tests {
                         Raw {
                             content: "baz".to_string()
                         }
-                        .with_location((0, 3))
+                        .with_location(0..3)
                     ]
-                    .with_location((76, 4))
+                    .with_location(76..80)
                 )
             }
         );

--- a/emulator/src/preprocessor/fs.rs
+++ b/emulator/src/preprocessor/fs.rs
@@ -32,8 +32,10 @@ pub struct InMemoryFilesystem {
 
 impl InMemoryFilesystem {
     #[must_use]
-    pub const fn new(files: HashMap<Utf8PathBuf, String>) -> Self {
-        InMemoryFilesystem { files }
+    pub fn new<T: Into<HashMap<Utf8PathBuf, String>>>(files: T) -> Self {
+        InMemoryFilesystem {
+            files: files.into(),
+        }
     }
 }
 

--- a/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__condition_parse_error_test.snap
+++ b/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__condition_parse_error_test.snap
@@ -1,0 +1,13 @@
+---
+source: emulator/src/preprocessor/mod.rs
+expression: report
+---
+  x Invalid syntax in condition
+  `->   x invalid syntax
+      
+   ,-[/invalid.S:2:5]
+ 1 | hello
+ 2 | #if (1 + 5
+   :     ^^^^^^
+ 3 | #endif
+   `----

--- a/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__condition_test.snap
+++ b/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__condition_test.snap
@@ -1,0 +1,12 @@
+---
+source: emulator/src/preprocessor/mod.rs
+expression: res
+---
+simple
+
+
+fallback
+
+definition
+
+nested

--- a/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__definition_test-2.snap
+++ b/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__definition_test-2.snap
@@ -1,0 +1,5 @@
+---
+source: emulator/src/preprocessor/mod.rs
+expression: res
+---
+hello world

--- a/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__definition_test.snap
+++ b/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__definition_test.snap
@@ -1,0 +1,7 @@
+---
+source: emulator/src/preprocessor/mod.rs
+expression: res
+---
+hello world
+helloFOO
+hello FOO

--- a/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__if_defined_test.snap
+++ b/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__if_defined_test.snap
@@ -1,0 +1,5 @@
+---
+source: emulator/src/preprocessor/mod.rs
+expression: res
+---
+_FOO_ is defined

--- a/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__inclusion_test.snap
+++ b/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__inclusion_test.snap
@@ -1,0 +1,7 @@
+---
+source: emulator/src/preprocessor/mod.rs
+expression: res
+---
+this is before foo.S
+this is foo.S
+this is after foo.S

--- a/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__parse_error_in_include_test.snap
+++ b/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__parse_error_in_include_test.snap
@@ -1,0 +1,20 @@
+---
+source: emulator/src/preprocessor/mod.rs
+expression: report
+---
+  x Failed to process included file
+  `->   x Failed to parse file
+      
+      Error:   x invalid syntax
+         ,-[/invalid.S:2:1]
+       1 | hello
+       2 | #else
+         : ^
+         : `-- here
+         `----
+      
+   ,-[/include.S:1:10]
+ 1 | #include "invalid.S"
+   :          ^^^^^|^^^^^
+   :               `-- File included here
+   `----

--- a/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__unknown_include_error_test.snap
+++ b/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__unknown_include_error_test.snap
@@ -1,0 +1,13 @@
+---
+source: emulator/src/preprocessor/mod.rs
+expression: report
+---
+  x Failed to process included file
+  |->   x Failed to load file "/foo.S"
+  |   
+  `-> file not found
+   ,-[/include.S:1:10]
+ 1 | #include "foo.S"
+   :          ^^^|^^^
+   :             `-- File included here
+   `----

--- a/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__user_error_in_include_test.snap
+++ b/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__user_error_in_include_test.snap
@@ -1,0 +1,17 @@
+---
+source: emulator/src/preprocessor/mod.rs
+expression: report
+---
+  x Failed to process included file
+  `->   x User error: message
+         ,-[/error.S:1:8]
+       1 | #error "message"
+         :        ^^^^|^^^^
+         :            `-- '#error' preprocessor directive used here
+         `----
+      
+   ,-[/include.S:1:10]
+ 1 | #include "error.S"
+   :          ^^^^|^^^^
+   :              `-- File included here
+   `----

--- a/emulator/src/runtime/registers.rs
+++ b/emulator/src/runtime/registers.rs
@@ -117,7 +117,7 @@ impl Reg {
     }
 }
 
-impl<L> AstNode<L> for Reg {
+impl AstNode for Reg {
     fn kind(&self) -> NodeKind {
         NodeKind::Register
     }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -20,12 +20,13 @@ wasm-opt = ["-Oz", "--enable-mutable-globals"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-z33-emulator.workspace = true
-wasm-bindgen.workspace = true
+camino.workspace = true
+console_error_panic_hook.workspace = true
+js-sys.workspace = true
 serde.workspace = true
 serde-wasm-bindgen.workspace = true
 tsify.workspace = true
-console_error_panic_hook.workspace = true
 tracing.workspace = true
 tracing-wasm.workspace = true
-js-sys.workspace = true
+wasm-bindgen.workspace = true
+z33-emulator.workspace = true

--- a/web/app/multi-file-editor.tsx
+++ b/web/app/multi-file-editor.tsx
@@ -172,8 +172,8 @@ export const MultiFileEditor: React.FC<Props> = ({
       models.map((model) => [model.uri.path, model.getValue()]),
     );
 
-    const preprocessor = new InMemoryPreprocessor(files);
-    const preprocessed = preprocessor.preprocess(fileName.path);
+    const preprocessor = new InMemoryPreprocessor(files, fileName.path);
+    const preprocessed = preprocessor.preprocess();
     const newProgram = Program.parse(preprocessed);
     setProgram(newProgram);
   }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -37,7 +37,7 @@ impl InMemoryPreprocessor {
     pub fn new(files: InputFiles, entrypoint: String) -> Self {
         let fs = InMemoryFilesystem::new(files.0);
         let entrypoint = Utf8PathBuf::from(entrypoint);
-        let preprocessor = Workspace::new(&fs, entrypoint);
+        let preprocessor = Workspace::new(&fs, &entrypoint);
         Self { preprocessor }
     }
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -12,7 +12,7 @@ use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 use z33_emulator::compiler::compile;
 use z33_emulator::constants::Address;
-use z33_emulator::preprocessor::{InMemoryFilesystem, Preprocessor};
+use z33_emulator::preprocessor::{InMemoryFilesystem, Workspace};
 use z33_emulator::runtime::{Memory, ProcessorError};
 
 #[wasm_bindgen(start)]
@@ -23,7 +23,7 @@ fn start() {
 
 #[wasm_bindgen]
 pub struct InMemoryPreprocessor {
-    preprocessor: Preprocessor<InMemoryFilesystem>,
+    preprocessor: Workspace,
 }
 
 #[derive(Default, Deserialize, Tsify)]
@@ -34,9 +34,10 @@ pub struct InputFiles(HashMap<Utf8PathBuf, String>);
 impl InMemoryPreprocessor {
     #[wasm_bindgen(constructor)]
     #[must_use]
-    pub fn new(files: InputFiles) -> Self {
+    pub fn new(files: InputFiles, entrypoint: String) -> Self {
         let fs = InMemoryFilesystem::new(files.0);
-        let preprocessor = Preprocessor::new(fs);
+        let entrypoint = Utf8PathBuf::from(entrypoint);
+        let preprocessor = Workspace::new(&fs, entrypoint);
         Self { preprocessor }
     }
 
@@ -45,10 +46,8 @@ impl InMemoryPreprocessor {
     /// # Errors
     ///
     /// Returns an error if the file could not be preprocessed.
-    pub fn preprocess(&mut self, path: &str) -> Result<String, JsValue> {
-        let path = Utf8PathBuf::from(path);
-        self.preprocessor.load(&path);
-        let source = self.preprocessor.preprocess(&path);
+    pub fn preprocess(&mut self) -> Result<String, JsValue> {
+        let source = self.preprocessor.preprocess();
         match source {
             Ok(s) => Ok(s),
             Err(e) => Err(format!("{e}").into()),

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -49,7 +49,7 @@ impl InMemoryPreprocessor {
     pub fn preprocess(&mut self) -> Result<String, JsValue> {
         let source = self.preprocessor.preprocess();
         match source {
-            Ok(s) => Ok(s),
+            Ok((_source_map, source)) => Ok(source),
             Err(e) => Err(format!("{e}").into()),
         }
     }


### PR DESCRIPTION
This is a big refactoring on how we handle AST node locations.
This is so that we can build a source map after the preprocessor, so that we can emit error with the right file and location.

Fixes #726
