### PR TITLE
Avoid exception handling loops if no handler is defined

### DIFF
--- a/emulator/src/runtime/exception.rs
+++ b/emulator/src/runtime/exception.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 use super::memory::MemoryError;
 use crate::constants::Word;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum Exception {
     #[error("hardware interrupt")]
     HardwareInterrupt,

--- a/emulator/src/runtime/memory.rs
+++ b/emulator/src/runtime/memory.rs
@@ -144,7 +144,7 @@ impl TryFrom<&Cell> for Address {
 }
 
 /// Represents errors related to memory manipulations
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone, Copy)]
 pub enum MemoryError {
     /// The given address was invalid
     #[error("invalid address {0}")]

--- a/emulator/src/runtime/mod.rs
+++ b/emulator/src/runtime/mod.rs
@@ -155,14 +155,13 @@ impl Computer {
         &mut self,
         exception: &Exception,
     ) -> std::result::Result<(), Exception> {
-        // Special case: if we're already on the handler, and the exception is an
-        // 'invalid instruction', we just return, as this means there is no handler
-        // setup. The '+ 1' is because we always move the PC by one after decoding the
-        // instruction
-        if self.registers.pc == C::INTERRUPT_HANDLER + 1
-            && matches!(exception, &Exception::InvalidInstruction)
-        {
-            info!("'Invalid instruction' exception within the exception handler, ignoring");
+        // We don't want to recover from the exception if there is no handler setup
+        let handler = self.memory.get(C::INTERRUPT_HANDLER)?;
+        if handler.extract_instruction().is_err() {
+            tracing::warn!(
+                "No exception handler at address 200 for exception {:?}",
+                exception
+            );
             return Err(exception.clone());
         }
 


### PR DESCRIPTION
This tweaks the exception handling to make sure we don't get in a loop if there is no exception handler defined.

When an exception occurs, it checks the cell at address 200 to see if there is a valid instruction. It only recovers from the exception if there is.

@pdav: Is this a good idea, and the right behavior?
