### PR TITLE
DAP: transport-agnostic debug adapter + z33-cli dap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,7 @@ dependencies = [
  "codespan-reporting",
  "rustyline",
  "rustyline-derive",
+ "serde_json",
  "shell-words",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,6 +1994,7 @@ dependencies = [
  "parse-display",
  "percent-encoding",
  "pretty_assertions",
+ "serde",
  "serde_json",
  "smallvec",
  "thiserror",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,6 +23,7 @@ codespan-reporting.workspace = true
 clap_complete.workspace = true
 rustyline.workspace = true
 rustyline-derive.workspace = true
+serde_json.workspace = true
 shell-words.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/cli/src/commands/dap.rs
+++ b/cli/src/commands/dap.rs
@@ -1,0 +1,112 @@
+//! `z33-cli dap` — a stdio Debug Adapter Protocol server.
+//!
+//! Uses the same `Content-Length` framing as LSP. The emulator crate provides
+//! the transport-agnostic [`DebugSession`]; this command owns the I/O: a
+//! background thread reads and de-frames stdin into JSON messages, and the main
+//! loop interleaves message handling with the chunked run loop so `continue`
+//! never blocks incoming `pause` requests.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::sync::mpsc::{self, Receiver, TryRecvError};
+use std::thread;
+
+use clap::Parser;
+use serde_json::Value;
+use z33_emulator::dap::DebugSession;
+
+/// Start the Z33 Debug Adapter Protocol server (DAP)
+#[derive(Parser, Debug)]
+pub struct DapOpt {}
+
+impl DapOpt {
+    #[allow(clippy::unused_self)]
+    pub fn exec(self) -> anyhow::Result<()> {
+        let rx = spawn_reader();
+        let mut session = DebugSession::new();
+        let stdout = std::io::stdout();
+
+        loop {
+            let messages = if session.is_running() {
+                // While running, poll without blocking so we can advance the
+                // program between incoming messages (e.g. `pause`).
+                match rx.try_recv() {
+                    Ok(msg) => session.handle_message(&msg),
+                    Err(TryRecvError::Empty) => session.run_chunk(),
+                    Err(TryRecvError::Disconnected) => break,
+                }
+            } else {
+                // Idle: block until the next message arrives.
+                match rx.recv() {
+                    Ok(msg) => session.handle_message(&msg),
+                    Err(_) => break,
+                }
+            };
+
+            for message in messages {
+                write_message(&stdout, &message)?;
+            }
+
+            if session.exit_requested() {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Spawn a thread that reads `Content-Length`-framed JSON messages from stdin
+/// and forwards each decoded [`Value`] over a channel.
+fn spawn_reader() -> Receiver<Value> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut reader = BufReader::new(std::io::stdin());
+        loop {
+            let Some(length) = read_content_length(&mut reader) else {
+                break;
+            };
+            let mut body = vec![0u8; length];
+            if reader.read_exact(&mut body).is_err() {
+                break;
+            }
+            let Ok(value) = serde_json::from_slice::<Value>(&body) else {
+                continue;
+            };
+            if tx.send(value).is_err() {
+                break;
+            }
+        }
+    });
+    rx
+}
+
+/// Read the message headers, returning the `Content-Length` in bytes. Returns
+/// `None` on EOF.
+fn read_content_length<R: BufRead>(reader: &mut R) -> Option<usize> {
+    let mut content_length = None;
+    loop {
+        let mut line = String::new();
+        let read = reader.read_line(&mut line).ok()?;
+        if read == 0 {
+            return None; // EOF
+        }
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            // End of headers.
+            return content_length;
+        }
+        if let Some(value) = trimmed.strip_prefix("Content-Length:") {
+            content_length = value.trim().parse::<usize>().ok();
+        }
+    }
+}
+
+/// Serialize and frame a single DAP message to stdout.
+fn write_message(stdout: &std::io::Stdout, message: &Value) -> anyhow::Result<()> {
+    let body = serde_json::to_vec(message)?;
+    let mut handle = stdout.lock();
+    write!(handle, "Content-Length: {}\r\n\r\n", body.len())?;
+    handle.write_all(&body)?;
+    handle.flush()?;
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 
 mod completion;
+mod dap;
 mod dump;
 mod lsp;
 mod preprocess;
@@ -26,6 +27,9 @@ pub enum Subcommand {
 
     /// Start the Language Server (LSP)
     Lsp(self::lsp::LspOpt),
+
+    /// Start the Debug Adapter Protocol server (DAP)
+    Dap(self::dap::DapOpt),
 }
 
 impl Subcommand {
@@ -38,6 +42,7 @@ impl Subcommand {
             Self::Dump(opt) => opt.exec()?,
             Self::Completion(opt) => opt.exec(),
             Self::Lsp(opt) => opt.exec()?,
+            Self::Dap(opt) => opt.exec()?,
         }
 
         Ok(())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -71,8 +71,9 @@ fn main() {
     // Then, setup the tracing formatter for logging and instrumentation
     let registry = tracing_subscriber::Registry::default().with(opt.filter_layer());
 
-    // LSP uses stdout for JSON-RPC, so all logging must go to stderr.
-    let use_stderr = matches!(opt.command, Subcommand::Lsp(_));
+    // LSP and DAP use stdout for their protocols, so all logging must go to
+    // stderr.
+    let use_stderr = matches!(opt.command, Subcommand::Lsp(_) | Subcommand::Dap(_));
 
     if opt.json {
         let json_layer = tracing_subscriber::fmt::layer()

--- a/emulator/Cargo.toml
+++ b/emulator/Cargo.toml
@@ -20,6 +20,7 @@ chumsky.workspace = true
 codespan-reporting.workspace = true
 dashmap.workspace = true
 percent-encoding.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 smallvec.workspace = true
 thiserror.workspace = true

--- a/emulator/src/dap/index.rs
+++ b/emulator/src/dap/index.rs
@@ -1,0 +1,181 @@
+//! Bidirectional line ↔ address index for the debug adapter.
+//!
+//! Built at launch time by composing the compiler's source map (address → byte
+//! range in the *preprocessed* flat source) with the preprocessor's source map
+//! (preprocessed byte offset → original file + byte range). The result lets the
+//! adapter answer two questions:
+//!
+//! * given a program-counter address, where is it in the original source (file,
+//!   1-based line, 1-based column)?
+//! * given a source breakpoint (file + line), what address should it map to,
+//!   adjusting forward to the next line that actually has code?
+
+use std::collections::BTreeMap;
+use std::ops::Range;
+
+use crate::compiler::DebugInfo;
+use crate::constants::Address;
+use crate::diagnostic::FileDatabase;
+use crate::preprocessor::ReferencingSourceMap;
+
+/// A resolved source location.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Location {
+    pub file_index: usize,
+    /// 1-based line number.
+    pub line: u32,
+    /// 1-based column number.
+    pub column: u32,
+}
+
+struct FileInfo {
+    path: String,
+    source: String,
+    /// Byte offset of the start of each line (line 1 starts at
+    /// `line_starts[0]`).
+    line_starts: Vec<usize>,
+    /// Maps a 1-based line that has code to the first address placed on it.
+    lines_with_code: BTreeMap<u32, Address>,
+}
+
+impl FileInfo {
+    fn new(path: String, source: String) -> Self {
+        let mut line_starts = vec![0usize];
+        for (offset, byte) in source.bytes().enumerate() {
+            if byte == b'\n' {
+                line_starts.push(offset + 1);
+            }
+        }
+        Self {
+            path,
+            source,
+            line_starts,
+            lines_with_code: BTreeMap::new(),
+        }
+    }
+
+    /// Convert a byte offset within this file to a (line, column) pair, both
+    /// 1-based.
+    fn line_col(&self, offset: usize) -> (u32, u32) {
+        // Number of line starts that are <= offset is the 1-based line number.
+        let line = self.line_starts.partition_point(|&start| start <= offset);
+        let line = line.max(1);
+        let line_start = self.line_starts[line - 1];
+        let column = offset.saturating_sub(line_start) + 1;
+        (to_u32(line), to_u32(column))
+    }
+}
+
+/// The line ↔ address index.
+pub(super) struct LineIndex {
+    files: Vec<FileInfo>,
+    addr_to_loc: BTreeMap<Address, Location>,
+}
+
+impl LineIndex {
+    /// Build the index from the compiler debug info, the preprocessor source
+    /// map and the file database.
+    pub(super) fn build(
+        debug_info: &DebugInfo,
+        pre_source_map: &ReferencingSourceMap,
+        file_db: &FileDatabase,
+    ) -> Self {
+        // First pass: discover which original files are referenced and create a
+        // `FileInfo` for each, keyed by its diagnostic `FileId`.
+        let mut file_index_by_id: BTreeMap<usize, usize> = BTreeMap::new();
+        let mut files: Vec<FileInfo> = Vec::new();
+
+        let mut addr_to_loc = BTreeMap::new();
+
+        for (&address, range) in &debug_info.source_map {
+            let Some((original_file_id, original_range)) = resolve(pre_source_map, range) else {
+                continue;
+            };
+            let file_index = *file_index_by_id.entry(original_file_id).or_insert_with(|| {
+                let idx = files.len();
+                files.push(FileInfo::new(
+                    file_db.name(original_file_id),
+                    file_db.source(original_file_id).to_owned(),
+                ));
+                idx
+            });
+            let (line, column) = files[file_index].line_col(original_range.start);
+
+            // Record the first (lowest) address seen on each line so breakpoints
+            // resolve deterministically.
+            files[file_index]
+                .lines_with_code
+                .entry(line)
+                .and_modify(|existing| {
+                    if address < *existing {
+                        *existing = address;
+                    }
+                })
+                .or_insert(address);
+
+            addr_to_loc.insert(
+                address,
+                Location {
+                    file_index,
+                    line,
+                    column,
+                },
+            );
+        }
+
+        Self { files, addr_to_loc }
+    }
+
+    /// Resolve the source location of an address, if it maps to code.
+    pub(super) fn location(&self, address: Address) -> Option<&Location> {
+        self.addr_to_loc.get(&address)
+    }
+
+    /// The stored path of a file by index.
+    pub(super) fn path(&self, file_index: usize) -> &str {
+        &self.files[file_index].path
+    }
+
+    /// Return the source content of a file matching `path`, if any.
+    pub(super) fn source_of(&self, path: &str) -> Option<&str> {
+        self.find_file(path)
+            .map(|idx| self.files[idx].source.as_str())
+    }
+
+    /// Resolve a breakpoint request (`path`, 1-based `line`) to the adjusted
+    /// line (the next line with code at or after `line`) and its address.
+    pub(super) fn resolve_breakpoint(&self, path: &str, line: u32) -> Option<(u32, Address)> {
+        let idx = self.find_file(path)?;
+        let (&adjusted, &address) = self.files[idx].lines_with_code.range(line..).next()?;
+        Some((adjusted, address))
+    }
+
+    /// Find a file by its path, matching exactly first, then by base name.
+    fn find_file(&self, path: &str) -> Option<usize> {
+        if let Some(idx) = self.files.iter().position(|f| f.path == path) {
+            return Some(idx);
+        }
+        let wanted = base_name(path);
+        self.files.iter().position(|f| base_name(&f.path) == wanted)
+    }
+}
+
+/// Compose an address's preprocessed byte range with the preprocessor source
+/// map to obtain `(original_file_id, original_range)`.
+fn resolve(
+    pre_source_map: &ReferencingSourceMap,
+    range: &Range<usize>,
+) -> Option<(usize, Range<usize>)> {
+    let (chunk_key, span) = pre_source_map.find_with_key(range.start)?;
+    let start = span.range.start + (range.start - chunk_key);
+    let end = span.range.start + (range.end - chunk_key);
+    Some((span.file_id, start..end))
+}
+
+fn base_name(path: &str) -> &str {
+    path.rsplit(['/', '\\']).next().unwrap_or(path)
+}
+
+fn to_u32(value: usize) -> u32 {
+    u32::try_from(value).unwrap_or(u32::MAX)
+}

--- a/emulator/src/dap/mod.rs
+++ b/emulator/src/dap/mod.rs
@@ -1,0 +1,1073 @@
+//! A transport-agnostic Debug Adapter Protocol (DAP) implementation for the
+//! Z33 emulator.
+//!
+//! # Design
+//!
+//! [`DebugSession`] contains **no I/O**. The caller owns the transport (stdio
+//! for the native CLI, a JS bridge for the future WASM host) and does the
+//! framing. The session is driven through three entry points:
+//!
+//! * [`DebugSession::handle_message`] — feed it one decoded client message (a
+//!   [`serde_json::Value`]); it returns the responses and events to emit, each
+//!   a complete, sequence-stamped DAP message ready to serialize.
+//! * [`DebugSession::run_chunk`] — advance a *running* program by a bounded
+//!   number of instructions. Requests that start execution (`continue`, `next`,
+//!   `stepIn`, `stepOut`) only set the run mode and return immediately; the
+//!   actual stepping happens here so the transport is never blocked.
+//! * [`DebugSession::is_running`] — whether the caller should keep calling
+//!   `run_chunk`.
+//!
+//! ## Chunked-run contract
+//!
+//! ```text
+//! loop {
+//!     if session.is_running() {
+//!         match poll_incoming_nonblocking() {
+//!             Some(msg) => emit(session.handle_message(&msg)),   // e.g. pause
+//!             None      => emit(session.run_chunk()),            // advance
+//!         }
+//!     } else {
+//!         emit(session.handle_message(&recv_blocking()));
+//!     }
+//! }
+//! ```
+//!
+//! `run_chunk` executes at most [`CHUNK_SIZE`] instructions. If the program
+//! stops (breakpoint, step completion, halt, exception, or a pending pause) it
+//! returns the corresponding events and clears the running state. If the budget
+//! is exhausted without stopping it returns an empty vector and stays running,
+//! giving the caller a chance to poll for an incoming `pause`.
+
+mod index;
+pub mod protocol;
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::str::FromStr;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use serde_json::{json, Map, Value};
+
+use self::index::LineIndex;
+use self::protocol::{
+    Breakpoint, Capabilities, EvaluateArguments, IncomingRequest, LaunchArguments, Scope,
+    SetBreakpointsArguments, SetVariableArguments, Source, SourceArguments, StackFrame, Variable,
+    VariablesArguments,
+};
+use crate::constants as C;
+use crate::constants::Address;
+use crate::diagnostic::{
+    preprocessor_error_to_diagnostics, render_to_string, resolve_diagnostic_spans,
+};
+use crate::preprocessor::{
+    Filesystem, InMemoryFilesystem, NativeFilesystem, ReferencingSourceMap, Workspace,
+};
+use crate::runtime::registers::StatusRegister;
+use crate::runtime::{Cell, Computer, Instruction, ProcessorError, Reg};
+
+/// Maximum number of instructions executed per [`DebugSession::run_chunk`].
+pub const CHUNK_SIZE: usize = 10_000;
+
+/// The single thread exposed to the client.
+const THREAD_ID: i64 = 1;
+/// `variablesReference` for the registers scope.
+const REGISTERS_REF: i64 = 1;
+/// `variablesReference` for the status-register flags.
+const FLAGS_REF: i64 = 2;
+/// `variablesReference` for the execution scope (cycle counter and other
+/// run-state that is not an architectural register).
+const EXECUTION_REF: i64 = 3;
+/// Upper bound on synthesized caller frames.
+const MAX_FRAMES: usize = 64;
+
+const EXIT_OK: i64 = 0;
+const EXIT_EXCEPTION: i64 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum State {
+    Uninitialized,
+    Initialized,
+    Running,
+    Stopped,
+    Terminated,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RunMode {
+    Continue,
+    StepIn,
+    /// Step over: run until the stack pointer returns to (>=) this value.
+    StepOver {
+        sp: Address,
+    },
+    /// Step out: run until the stack pointer rises above this value.
+    StepOut {
+        sp: Address,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+enum StopReason {
+    Entry,
+    Breakpoint,
+    Step,
+    Pause,
+}
+
+impl StopReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            StopReason::Entry => "entry",
+            StopReason::Breakpoint => "breakpoint",
+            StopReason::Step => "step",
+            StopReason::Pause => "pause",
+        }
+    }
+}
+
+/// Outcome of executing an instruction budget.
+enum Outcome {
+    /// Budget exhausted, still running.
+    Pending,
+    Stopped(StopReason),
+    Terminated(i64),
+    Exception(String),
+}
+
+/// A compiled, runnable program plus everything needed to debug it.
+struct LoadedProgram {
+    computer: Computer,
+    index: LineIndex,
+    labels: BTreeMap<String, Address>,
+    /// Breakpoint addresses per source path (last `setBreakpoints` wins).
+    bp_by_file: HashMap<String, Vec<Address>>,
+    /// Union of all breakpoint addresses.
+    breakpoints: HashSet<Address>,
+}
+
+impl LoadedProgram {
+    fn recompute_breakpoints(&mut self) {
+        self.breakpoints = self.bp_by_file.values().flatten().copied().collect();
+    }
+}
+
+/// A DAP debug session.
+#[allow(clippy::struct_excessive_bools)] // independent protocol/session flags
+pub struct DebugSession {
+    seq: i64,
+    state: State,
+    configured: bool,
+    entered: bool,
+    stop_on_entry: bool,
+    exit_requested: bool,
+    exception_pending: bool,
+    pause_requested: bool,
+    run_mode: RunMode,
+    program: Option<LoadedProgram>,
+    launch_args: Option<LaunchArguments>,
+}
+
+impl Default for DebugSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DebugSession {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            seq: 0,
+            state: State::Uninitialized,
+            configured: false,
+            entered: false,
+            stop_on_entry: false,
+            exit_requested: false,
+            exception_pending: false,
+            pause_requested: false,
+            run_mode: RunMode::Continue,
+            program: None,
+            launch_args: None,
+        }
+    }
+
+    /// Whether the program is currently running and the caller should keep
+    /// calling [`run_chunk`](Self::run_chunk).
+    #[must_use]
+    pub fn is_running(&self) -> bool {
+        self.state == State::Running
+    }
+
+    /// Whether the client has asked to disconnect and the transport should
+    /// shut down.
+    #[must_use]
+    pub fn exit_requested(&self) -> bool {
+        self.exit_requested
+    }
+
+    // ----------------------------------------------------------------------
+    // Message handling
+    // ----------------------------------------------------------------------
+
+    /// Handle one decoded client message, returning the messages to emit.
+    #[must_use]
+    pub fn handle_message(&mut self, message: &Value) -> Vec<Value> {
+        let Ok(req) = serde_json::from_value::<IncomingRequest>(message.clone()) else {
+            return Vec::new();
+        };
+        if req.kind != "request" {
+            return Vec::new();
+        }
+
+        match req.command.as_str() {
+            "initialize" => self.on_initialize(&req),
+            "launch" => self.on_launch(&req),
+            "setBreakpoints" => self.on_set_breakpoints(&req),
+            "setExceptionBreakpoints" => {
+                vec![self.response(&req, json!({ "breakpoints": [] }))]
+            }
+            "configurationDone" => self.on_configuration_done(&req),
+            "threads" => {
+                vec![self.response(
+                    &req,
+                    json!({ "threads": [{ "id": THREAD_ID, "name": "CPU" }] }),
+                )]
+            }
+            "stackTrace" => self.on_stack_trace(&req),
+            "scopes" => self.on_scopes(&req),
+            "variables" => self.on_variables(&req),
+            "setVariable" => self.on_set_variable(&req),
+            "continue" => self.on_continue(&req),
+            "next" => self.on_next(&req),
+            "stepIn" => self.on_step_in(&req),
+            "stepOut" => self.on_step_out(&req),
+            "pause" => self.on_pause(&req),
+            "evaluate" => self.on_evaluate(&req),
+            "source" => self.on_source(&req),
+            "restart" => self.on_restart(&req),
+            "disconnect" => {
+                self.exit_requested = true;
+                self.state = State::Terminated;
+                vec![self.response(&req, Value::Null)]
+            }
+            "terminate" => {
+                self.state = State::Terminated;
+                let resp = self.response(&req, Value::Null);
+                vec![resp, self.make_event("terminated", Value::Null)]
+            }
+            other => {
+                vec![self.response_err(&req, format!("unsupported request: {other}"))]
+            }
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // Individual request handlers
+    // ----------------------------------------------------------------------
+
+    fn on_initialize(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        self.state = State::Initialized;
+        let caps = serde_json::to_value(Capabilities::default()).unwrap_or(Value::Null);
+        let resp = self.response(req, caps);
+        let ev = self.make_event("initialized", Value::Null);
+        vec![resp, ev]
+    }
+
+    fn on_launch(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        let args: LaunchArguments = match serde_json::from_value(req.arguments.clone()) {
+            Ok(a) => a,
+            Err(e) => {
+                return vec![self.response_err(req, format!("invalid launch arguments: {e}"))];
+            }
+        };
+
+        match load_program(&args) {
+            Ok(program) => {
+                self.stop_on_entry = args.stop_on_entry;
+                self.program = Some(program);
+                self.launch_args = Some(args);
+                let resp = self.response(req, Value::Null);
+                let mut out = vec![resp];
+                out.extend(self.maybe_enter());
+                out
+            }
+            Err(msg) => vec![self.response_err(req, msg)],
+        }
+    }
+
+    fn on_set_breakpoints(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        let args: SetBreakpointsArguments = match serde_json::from_value(req.arguments.clone()) {
+            Ok(a) => a,
+            Err(e) => return vec![self.response_err(req, format!("invalid arguments: {e}"))],
+        };
+
+        let body = {
+            let Some(program) = self.program.as_mut() else {
+                return vec![self.response_err(req, "no program launched")];
+            };
+            let source = args.source;
+            let path = source
+                .path
+                .clone()
+                .or_else(|| source.name.clone())
+                .unwrap_or_default();
+
+            let mut result: Vec<Breakpoint> = Vec::new();
+            let mut addrs: Vec<Address> = Vec::new();
+            for bp in args.breakpoints {
+                match program.index.resolve_breakpoint(&path, bp.line) {
+                    Some((line, address)) => {
+                        addrs.push(address);
+                        result.push(Breakpoint {
+                            verified: true,
+                            line: Some(line),
+                            source: Some(source.clone()),
+                            message: None,
+                        });
+                    }
+                    None => result.push(Breakpoint {
+                        verified: false,
+                        line: Some(bp.line),
+                        source: Some(source.clone()),
+                        message: Some("no code at or after this line".to_owned()),
+                    }),
+                }
+            }
+            program.bp_by_file.insert(path, addrs);
+            program.recompute_breakpoints();
+            json!({ "breakpoints": result })
+        };
+
+        vec![self.response(req, body)]
+    }
+
+    fn on_configuration_done(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        self.configured = true;
+        let resp = self.response(req, Value::Null);
+        let mut out = vec![resp];
+        out.extend(self.maybe_enter());
+        out
+    }
+
+    fn on_stack_trace(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        if self.program.is_none() {
+            return vec![self.response_err(req, "no program launched")];
+        }
+        let frames = self.stack_frames();
+        let total = frames.len();
+        let body = json!({ "stackFrames": frames, "totalFrames": total });
+        vec![self.response(req, body)]
+    }
+
+    fn on_scopes(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        let scopes = vec![
+            Scope {
+                name: "Registers".to_owned(),
+                variables_reference: REGISTERS_REF,
+                expensive: false,
+            },
+            Scope {
+                name: "Execution".to_owned(),
+                variables_reference: EXECUTION_REF,
+                expensive: false,
+            },
+        ];
+        vec![self.response(req, json!({ "scopes": scopes }))]
+    }
+
+    fn on_variables(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        let args: VariablesArguments = match serde_json::from_value(req.arguments.clone()) {
+            Ok(a) => a,
+            Err(e) => return vec![self.response_err(req, format!("invalid arguments: {e}"))],
+        };
+        let Some(program) = self.program.as_ref() else {
+            return vec![self.response_err(req, "no program launched")];
+        };
+
+        let variables = match args.variables_reference {
+            REGISTERS_REF => registers_variables(&program.computer),
+            FLAGS_REF => flags_variables(&program.computer),
+            EXECUTION_REF => execution_variables(&program.computer),
+            _ => Vec::new(),
+        };
+        vec![self.response(req, json!({ "variables": variables }))]
+    }
+
+    fn on_set_variable(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        let args: SetVariableArguments = match serde_json::from_value(req.arguments.clone()) {
+            Ok(a) => a,
+            Err(e) => return vec![self.response_err(req, format!("invalid arguments: {e}"))],
+        };
+
+        let outcome = {
+            let Some(program) = self.program.as_mut() else {
+                return vec![self.response_err(req, "no program launched")];
+            };
+            if args.variables_reference != REGISTERS_REF {
+                Err("only register variables can be set".to_owned())
+            } else if let Some(value) = parse_int(&args.value) {
+                let reg = match args.name.as_str() {
+                    "a" => Some(Reg::A),
+                    "b" => Some(Reg::B),
+                    "pc" => Some(Reg::PC),
+                    "sp" => Some(Reg::SP),
+                    _ => None,
+                };
+                match reg {
+                    Some(reg) => program
+                        .computer
+                        .registers
+                        .set(reg, Cell::Word(value))
+                        .map(|()| format!("{}", program.computer.registers.get(&reg)))
+                        .map_err(|e| e.to_string()),
+                    None => Err(format!("cannot set variable '{}'", args.name)),
+                }
+            } else {
+                Err(format!("invalid integer value '{}'", args.value))
+            }
+        };
+
+        match outcome {
+            Ok(value) => {
+                vec![self.response(req, json!({ "value": value, "variablesReference": 0 }))]
+            }
+            Err(msg) => vec![self.response_err(req, msg)],
+        }
+    }
+
+    /// Shared precondition check for the four resume requests (`continue`,
+    /// `next`, `stepIn`, `stepOut`). Returns `Some(messages)` when the request
+    /// must be answered immediately instead of starting execution:
+    ///
+    /// * no program is loaded, or the session has already terminated → error;
+    /// * an unhandled exception is pending → the same terminate sequence
+    ///   `continue` takes, since any resume after a stopped-on-exception ends
+    ///   the session.
+    ///
+    /// `resume_body` is the success-response body used on the exception path
+    /// (`continue` reports `allThreadsContinued`, the step requests use null).
+    fn resume_precheck(&mut self, req: &IncomingRequest, resume_body: Value) -> Option<Vec<Value>> {
+        if self.program.is_none() {
+            return Some(vec![self.response_err(req, "no program launched")]);
+        }
+        if self.state == State::Terminated {
+            return Some(vec![self.response_err(req, "program has terminated")]);
+        }
+        if self.exception_pending {
+            self.exception_pending = false;
+            let resp = self.response(req, resume_body);
+            let mut out = vec![resp];
+            out.extend(self.terminate_now(EXIT_EXCEPTION));
+            return Some(out);
+        }
+        None
+    }
+
+    fn on_continue(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        if let Some(out) = self.resume_precheck(req, json!({ "allThreadsContinued": true })) {
+            return out;
+        }
+        self.run_mode = RunMode::Continue;
+        self.state = State::Running;
+        vec![self.response(req, json!({ "allThreadsContinued": true }))]
+    }
+
+    fn on_next(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        if let Some(out) = self.resume_precheck(req, Value::Null) {
+            return out;
+        }
+        let program = self.program.as_ref().expect("program loaded");
+        let pc = program.computer.registers.pc;
+        let sp = program.computer.registers.sp;
+        let is_call = program
+            .computer
+            .memory
+            .get(pc)
+            .ok()
+            .and_then(|c| c.extract_instruction().ok())
+            .is_some_and(|i| matches!(i, Instruction::Call(_)));
+        self.run_mode = if is_call {
+            RunMode::StepOver { sp }
+        } else {
+            RunMode::StepIn
+        };
+        self.state = State::Running;
+        vec![self.response(req, Value::Null)]
+    }
+
+    fn on_step_in(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        if let Some(out) = self.resume_precheck(req, Value::Null) {
+            return out;
+        }
+        self.run_mode = RunMode::StepIn;
+        self.state = State::Running;
+        vec![self.response(req, Value::Null)]
+    }
+
+    fn on_step_out(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        if let Some(out) = self.resume_precheck(req, Value::Null) {
+            return out;
+        }
+        let program = self.program.as_ref().expect("program loaded");
+        let sp = program.computer.registers.sp;
+        self.run_mode = RunMode::StepOut { sp };
+        self.state = State::Running;
+        vec![self.response(req, Value::Null)]
+    }
+
+    fn on_pause(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        if self.is_running() {
+            self.pause_requested = true;
+        }
+        vec![self.response(req, Value::Null)]
+    }
+
+    fn on_evaluate(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        let args: EvaluateArguments = match serde_json::from_value(req.arguments.clone()) {
+            Ok(a) => a,
+            Err(e) => return vec![self.response_err(req, format!("invalid arguments: {e}"))],
+        };
+
+        let result = {
+            let Some(program) = self.program.as_ref() else {
+                return vec![self.response_err(req, "no program launched")];
+            };
+            evaluate_expression(program, args.expression.trim())
+        };
+
+        match result {
+            Some((value, kind)) => vec![self.response(
+                req,
+                json!({ "result": value, "type": kind, "variablesReference": 0 }),
+            )],
+            None => vec![self.response_err(req, "could not evaluate expression")],
+        }
+    }
+
+    fn on_source(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        let args: SourceArguments = match serde_json::from_value(req.arguments.clone()) {
+            Ok(a) => a,
+            Err(e) => return vec![self.response_err(req, format!("invalid arguments: {e}"))],
+        };
+        let content = {
+            let Some(program) = self.program.as_ref() else {
+                return vec![self.response_err(req, "no program launched")];
+            };
+            args.source
+                .and_then(|s| s.path.or(s.name))
+                .and_then(|p| program.index.source_of(&p).map(str::to_owned))
+        };
+        match content {
+            Some(content) => vec![self.response(req, json!({ "content": content }))],
+            None => vec![self.response_err(req, "source not found")],
+        }
+    }
+
+    fn on_restart(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        let Some(args) = self.launch_args.clone() else {
+            return vec![self.response_err(req, "nothing to restart")];
+        };
+        match load_program(&args) {
+            Ok(program) => {
+                self.program = Some(program);
+                self.entered = false;
+                self.exception_pending = false;
+                self.pause_requested = false;
+                self.stop_on_entry = args.stop_on_entry;
+                self.state = State::Initialized;
+                let resp = self.response(req, Value::Null);
+                let mut out = vec![resp];
+                out.extend(self.maybe_enter());
+                out
+            }
+            Err(msg) => vec![self.response_err(req, msg)],
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // Execution driving
+    // ----------------------------------------------------------------------
+
+    /// Advance a running program by up to [`CHUNK_SIZE`] instructions.
+    ///
+    /// Returns the events produced if the program stopped or terminated, or an
+    /// empty vector if the budget was exhausted while still running.
+    #[must_use]
+    pub fn run_chunk(&mut self) -> Vec<Value> {
+        if self.state != State::Running {
+            return Vec::new();
+        }
+        let outcome = self.execute_budget();
+        self.finish_run(outcome)
+    }
+
+    fn execute_budget(&mut self) -> Outcome {
+        if self.pause_requested {
+            self.pause_requested = false;
+            return Outcome::Stopped(StopReason::Pause);
+        }
+        let run_mode = self.run_mode;
+        let Some(program) = self.program.as_mut() else {
+            return Outcome::Terminated(EXIT_OK);
+        };
+
+        for _ in 0..CHUNK_SIZE {
+            match program.computer.step() {
+                Ok(()) => {
+                    let pc = program.computer.registers.pc;
+                    let sp = program.computer.registers.sp;
+                    if program.breakpoints.contains(&pc) {
+                        return Outcome::Stopped(StopReason::Breakpoint);
+                    }
+                    match run_mode {
+                        RunMode::Continue => {}
+                        RunMode::StepIn => return Outcome::Stopped(StopReason::Step),
+                        RunMode::StepOver { sp: target } => {
+                            if sp >= target {
+                                return Outcome::Stopped(StopReason::Step);
+                            }
+                        }
+                        RunMode::StepOut { sp: target } => {
+                            if sp > target {
+                                return Outcome::Stopped(StopReason::Step);
+                            }
+                        }
+                    }
+                }
+                Err(ProcessorError::Reset) => return Outcome::Terminated(EXIT_OK),
+                Err(e) => return Outcome::Exception(e.to_string()),
+            }
+        }
+        Outcome::Pending
+    }
+
+    fn finish_run(&mut self, outcome: Outcome) -> Vec<Value> {
+        match outcome {
+            Outcome::Pending => Vec::new(),
+            Outcome::Stopped(reason) => {
+                self.state = State::Stopped;
+                vec![self.stopped_event(reason, None, None)]
+            }
+            Outcome::Terminated(code) => self.terminate_now(code),
+            Outcome::Exception(msg) => {
+                self.state = State::Stopped;
+                self.exception_pending = true;
+                let output = self.make_event(
+                    "output",
+                    json!({ "category": "console", "output": format!("Exception: {msg}\n") }),
+                );
+                let stopped = self.stopped_event_named("exception", Some(msg.clone()), Some(msg));
+                vec![output, stopped]
+            }
+        }
+    }
+
+    fn terminate_now(&mut self, code: i64) -> Vec<Value> {
+        self.state = State::Terminated;
+        vec![
+            self.make_event("terminated", Value::Null),
+            self.make_event("exited", json!({ "exitCode": code })),
+        ]
+    }
+
+    /// If the program is loaded and configuration is done, deliver the initial
+    /// stop (or start running if `stopOnEntry` was not set).
+    fn maybe_enter(&mut self) -> Vec<Value> {
+        if self.program.is_none() || !self.configured || self.entered {
+            return Vec::new();
+        }
+        self.entered = true;
+        if self.stop_on_entry {
+            self.state = State::Stopped;
+            return vec![self.stopped_event(StopReason::Entry, None, None)];
+        }
+        // `execute_budget` steps before testing breakpoints, so a breakpoint on
+        // the entry instruction would be run past on a fresh launch. Test the
+        // initial pc here so it fires before the first step.
+        let program = self.program.as_ref().expect("program loaded");
+        let pc = program.computer.registers.pc;
+        if program.breakpoints.contains(&pc) {
+            self.state = State::Stopped;
+            return vec![self.stopped_event(StopReason::Breakpoint, None, None)];
+        }
+        self.run_mode = RunMode::Continue;
+        self.state = State::Running;
+        Vec::new()
+    }
+
+    // ----------------------------------------------------------------------
+    // Stack frames
+    // ----------------------------------------------------------------------
+
+    fn stack_frames(&self) -> Vec<StackFrame> {
+        let Some(program) = self.program.as_ref() else {
+            return Vec::new();
+        };
+        let mut frames = Vec::new();
+        let pc = program.computer.registers.pc;
+        frames.push(self.frame(0, pc));
+
+        // Best-effort synthesis of caller frames: scan the stack for words that
+        // look like return addresses (the cell just before them is a `call`).
+        let sp = program.computer.registers.sp;
+        let mut id = 1;
+        for addr in sp..C::STACK_START {
+            if frames.len() >= MAX_FRAMES {
+                break;
+            }
+            let Ok(cell) = program.computer.memory.get(addr) else {
+                continue;
+            };
+            let Cell::Word(word) = cell else { continue };
+            let Ok(target) = Address::try_from(*word) else {
+                continue;
+            };
+            if target == 0 {
+                continue;
+            }
+            let is_return = program
+                .computer
+                .memory
+                .get(target - 1)
+                .ok()
+                .and_then(|c| c.extract_instruction().ok())
+                .is_some_and(|i| matches!(i, Instruction::Call(_)));
+            if is_return && program.index.location(target).is_some() {
+                frames.push(self.frame(id, target));
+                id += 1;
+            }
+        }
+        frames
+    }
+
+    fn frame(&self, id: i64, address: Address) -> StackFrame {
+        let program = self.program.as_ref().expect("program loaded");
+        let name = enclosing_label(&program.labels, address);
+        match program.index.location(address) {
+            Some(loc) => {
+                let path = program.index.path(loc.file_index).to_owned();
+                StackFrame {
+                    id,
+                    name,
+                    source: Some(Source {
+                        name: Some(base_name(&path).to_owned()),
+                        path: Some(path),
+                    }),
+                    line: loc.line,
+                    column: loc.column,
+                }
+            }
+            None => StackFrame {
+                id,
+                name,
+                source: None,
+                line: 0,
+                column: 0,
+            },
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // Message envelope builders
+    // ----------------------------------------------------------------------
+
+    fn next_seq(&mut self) -> i64 {
+        self.seq += 1;
+        self.seq
+    }
+
+    fn response(&mut self, req: &IncomingRequest, body: Value) -> Value {
+        self.build_response(req, true, body, None)
+    }
+
+    fn response_err(&mut self, req: &IncomingRequest, message: impl Into<String>) -> Value {
+        self.build_response(req, false, Value::Null, Some(message.into()))
+    }
+
+    fn build_response(
+        &mut self,
+        req: &IncomingRequest,
+        success: bool,
+        body: Value,
+        message: Option<String>,
+    ) -> Value {
+        let seq = self.next_seq();
+        let mut m = Map::new();
+        m.insert("seq".to_owned(), seq.into());
+        m.insert("type".to_owned(), "response".into());
+        m.insert("request_seq".to_owned(), req.seq.into());
+        m.insert("success".to_owned(), success.into());
+        m.insert("command".to_owned(), req.command.clone().into());
+        if let Some(message) = message {
+            m.insert("message".to_owned(), message.into());
+        }
+        if !body.is_null() {
+            m.insert("body".to_owned(), body);
+        }
+        Value::Object(m)
+    }
+
+    fn make_event(&mut self, name: &str, body: Value) -> Value {
+        let seq = self.next_seq();
+        let mut m = Map::new();
+        m.insert("seq".to_owned(), seq.into());
+        m.insert("type".to_owned(), "event".into());
+        m.insert("event".to_owned(), name.into());
+        if !body.is_null() {
+            m.insert("body".to_owned(), body);
+        }
+        Value::Object(m)
+    }
+
+    fn stopped_event(
+        &mut self,
+        reason: StopReason,
+        description: Option<String>,
+        text: Option<String>,
+    ) -> Value {
+        self.stopped_event_named(reason.as_str(), description, text)
+    }
+
+    fn stopped_event_named(
+        &mut self,
+        reason: &str,
+        description: Option<String>,
+        text: Option<String>,
+    ) -> Value {
+        let mut body = json!({
+            "reason": reason,
+            "threadId": THREAD_ID,
+            "allThreadsStopped": true,
+        });
+        if let Some(description) = description {
+            body["description"] = description.into();
+        }
+        if let Some(text) = text {
+            body["text"] = text.into();
+        }
+        self.make_event("stopped", body)
+    }
+}
+
+// --------------------------------------------------------------------------
+// Free helpers
+// --------------------------------------------------------------------------
+
+fn registers_variables(computer: &Computer) -> Vec<Variable> {
+    let regs = &computer.registers;
+    vec![
+        Variable {
+            name: "a".to_owned(),
+            value: format!("{}", regs.a),
+            kind: Some("register".to_owned()),
+            variables_reference: 0,
+        },
+        Variable {
+            name: "b".to_owned(),
+            value: format!("{}", regs.b),
+            kind: Some("register".to_owned()),
+            variables_reference: 0,
+        },
+        Variable {
+            name: "pc".to_owned(),
+            value: regs.pc.to_string(),
+            kind: Some("register".to_owned()),
+            variables_reference: 0,
+        },
+        Variable {
+            name: "sp".to_owned(),
+            value: regs.sp.to_string(),
+            kind: Some("register".to_owned()),
+            variables_reference: 0,
+        },
+        Variable {
+            name: "sr".to_owned(),
+            value: format!("0x{:x}", regs.sr.bits()),
+            kind: Some("flags".to_owned()),
+            variables_reference: FLAGS_REF,
+        },
+    ]
+}
+
+fn execution_variables(computer: &Computer) -> Vec<Variable> {
+    vec![Variable {
+        name: "cycles".to_owned(),
+        value: computer.cycles.to_string(),
+        kind: Some("counter".to_owned()),
+        variables_reference: 0,
+    }]
+}
+
+fn flags_variables(computer: &Computer) -> Vec<Variable> {
+    let sr = computer.registers.sr;
+    // Derive the child variables straight from `StatusRegister` so the list can
+    // never drift from the bitflags definition. `iter_names` yields the flags in
+    // declaration order with their uppercase identifiers; lowercase them to keep
+    // the historical variable names (`carry`, `interrupt_enable`, ...).
+    StatusRegister::all()
+        .iter_names()
+        .map(|(name, flag)| Variable {
+            name: name.to_ascii_lowercase(),
+            value: sr.contains(flag).to_string(),
+            kind: Some("bool".to_owned()),
+            variables_reference: 0,
+        })
+        .collect()
+}
+
+fn evaluate_expression(program: &LoadedProgram, expr: &str) -> Option<(String, String)> {
+    if expr.is_empty() {
+        return None;
+    }
+    // Register?
+    if let Ok(reg) = Reg::from_str(expr) {
+        let value = format!("{}", program.computer.registers.get(&reg));
+        return Some((value, "register".to_owned()));
+    }
+    // Label?
+    if let Some(&address) = program.labels.get(expr) {
+        let cell = program
+            .computer
+            .memory
+            .get(address)
+            .map_or_else(|_| "?".to_owned(), |c| format!("{c}"));
+        return Some((format!("{address} ({cell})"), "address".to_owned()));
+    }
+    // Integer literal?
+    if let Some(value) = parse_int(expr) {
+        return Some((value.to_string(), "integer".to_owned()));
+    }
+    None
+}
+
+fn enclosing_label(labels: &BTreeMap<String, Address>, address: Address) -> String {
+    labels
+        .iter()
+        .filter(|(_, &a)| a <= address)
+        .max_by_key(|(_, &a)| a)
+        .map_or_else(|| format!("@{address}"), |(name, _)| name.clone())
+}
+
+fn parse_int(input: &str) -> Option<i64> {
+    let input = input.trim();
+    if let Some(hex) = input
+        .strip_prefix("0x")
+        .or_else(|| input.strip_prefix("0X"))
+    {
+        i64::from_str_radix(hex, 16).ok()
+    } else if let Some(hex) = input
+        .strip_prefix("-0x")
+        .or_else(|| input.strip_prefix("-0X"))
+    {
+        i64::from_str_radix(hex, 16).ok().map(|v| -v)
+    } else {
+        input.parse::<i64>().ok()
+    }
+}
+
+fn base_name(path: &str) -> &str {
+    path.rsplit(['/', '\\']).next().unwrap_or(path)
+}
+
+fn choose_entrypoint(
+    provided: Option<&str>,
+    labels: &BTreeMap<String, Address>,
+) -> Result<String, String> {
+    if let Some(entrypoint) = provided {
+        return Ok(entrypoint.to_owned());
+    }
+    for candidate in ["main", "start", "run", "entry"] {
+        if labels.contains_key(candidate) {
+            return Ok(candidate.to_owned());
+        }
+    }
+    let available: Vec<&str> = labels.keys().map(String::as_str).collect();
+    Err(format!(
+        "no entrypoint specified and none of main/start/run/entry found; available labels: {}",
+        available.join(", ")
+    ))
+}
+
+/// Build a [`LoadedProgram`] from launch arguments, selecting the filesystem
+/// based on whether an in-memory file map was provided.
+fn load_program(args: &LaunchArguments) -> Result<LoadedProgram, String> {
+    if let Some(files) = &args.files {
+        let map: HashMap<Utf8PathBuf, String> = files
+            .iter()
+            .map(|(k, v)| (Utf8PathBuf::from(k), v.clone()))
+            .collect();
+        let fs = InMemoryFilesystem::new(map);
+        compile_program(&fs, &args.program, args.entrypoint.as_deref())
+    } else {
+        let fs = NativeFilesystem::from_env().map_err(|e| e.to_string())?;
+        compile_program(&fs, &args.program, args.entrypoint.as_deref())
+    }
+}
+
+fn compile_program<FS: Filesystem>(
+    fs: &FS,
+    program: &str,
+    entrypoint: Option<&str>,
+) -> Result<LoadedProgram, String> {
+    let mut workspace = Workspace::new(fs, Utf8Path::new(program));
+    let preprocess = workspace.preprocess().map_err(|e| {
+        preprocessor_error_to_diagnostics(&e)
+            .iter()
+            .map(|d| render_to_string(d, workspace.file_db()))
+            .collect::<String>()
+    })?;
+
+    let ref_map: ReferencingSourceMap = preprocess.source_map.into();
+    let parse_result = crate::parse(&preprocess.source);
+
+    // First pass: gather labels and surface any diagnostics.
+    let check = crate::compile(
+        &parse_result.program.inner,
+        &parse_result.diagnostics,
+        None,
+        preprocess.preprocessed_file_id,
+    );
+    if !check.diagnostics.is_empty() {
+        return Err(render_diagnostics(&check.diagnostics, &ref_map, &workspace));
+    }
+
+    let entrypoint = choose_entrypoint(entrypoint, &check.debug_info.labels)?;
+
+    // Second pass: build the computer with the chosen entrypoint.
+    let built = crate::compile(
+        &parse_result.program.inner,
+        &parse_result.diagnostics,
+        Some(&entrypoint),
+        preprocess.preprocessed_file_id,
+    );
+    let Some(computer) = built.computer else {
+        return Err(render_diagnostics(&built.diagnostics, &ref_map, &workspace));
+    };
+
+    let file_db = workspace.into_file_db();
+    let index = LineIndex::build(&built.debug_info, &ref_map, &file_db);
+
+    Ok(LoadedProgram {
+        computer,
+        index,
+        labels: built.debug_info.labels,
+        bp_by_file: HashMap::new(),
+        breakpoints: HashSet::new(),
+    })
+}
+
+fn render_diagnostics(
+    diagnostics: &[codespan_reporting::diagnostic::Diagnostic<crate::diagnostic::FileId>],
+    source_map: &ReferencingSourceMap,
+    workspace: &Workspace,
+) -> String {
+    diagnostics
+        .iter()
+        .map(|d| {
+            let resolved = resolve_diagnostic_spans(d, source_map);
+            render_to_string(&resolved, workspace.file_db())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests;

--- a/emulator/src/dap/protocol.rs
+++ b/emulator/src/dap/protocol.rs
@@ -1,0 +1,175 @@
+//! Serde types for the subset of the Debug Adapter Protocol implemented here.
+//!
+//! Only the request arguments, response/event bodies and shared structures that
+//! the [`DebugSession`](super::DebugSession) actually uses are modelled. The
+//! wire envelopes (`seq`, `type`, `request_seq`, `success`, ...) are assembled
+//! in [`super`] so that sequence numbers stay centralised.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// An incoming DAP message. The adapter only ever receives requests from the
+/// client, so `arguments` is kept as a raw [`Value`] and deserialized per
+/// command.
+#[derive(Debug, Deserialize)]
+pub struct IncomingRequest {
+    pub seq: i64,
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub command: String,
+    #[serde(default)]
+    pub arguments: Value,
+}
+
+/// Capabilities advertised in the `initialize` response.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(clippy::struct_excessive_bools)] // mirrors the DAP capabilities schema
+pub struct Capabilities {
+    pub supports_configuration_done_request: bool,
+    pub supports_set_variable: bool,
+    pub supports_evaluate_for_hovers: bool,
+    pub supports_restart_request: bool,
+    pub supports_terminate_request: bool,
+    /// DAP "stepping granularity" means the client may attach a
+    /// `statement`/`line`/`instruction` granularity to step requests — it is
+    /// *not* step-over versus step-into (those are the separate `next` and
+    /// `stepIn` requests). We advertise `false` because a Z33 source line is
+    /// always exactly one instruction, so the granularities are
+    /// indistinguishable.
+    pub supports_stepping_granularity: bool,
+}
+
+impl Default for Capabilities {
+    fn default() -> Self {
+        Self {
+            supports_configuration_done_request: true,
+            supports_set_variable: true,
+            supports_evaluate_for_hovers: true,
+            supports_restart_request: true,
+            supports_terminate_request: true,
+            supports_stepping_granularity: false,
+        }
+    }
+}
+
+/// A source reference (subset).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Source {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub path: Option<String>,
+}
+
+/// Arguments to the `launch` request.
+///
+/// `program` is the entry file. When `files` is present the adapter reads from
+/// that in-memory map (used by the future WASM host); otherwise it falls back
+/// to the native filesystem. `entrypoint` selects the label whose address the
+/// program counter starts at; if omitted a common default is used.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LaunchArguments {
+    pub program: String,
+    #[serde(default)]
+    pub entrypoint: Option<String>,
+    #[serde(default)]
+    pub stop_on_entry: bool,
+    #[serde(default)]
+    pub files: Option<HashMap<String, String>>,
+}
+
+/// A breakpoint requested by the client.
+#[derive(Debug, Deserialize)]
+pub struct SourceBreakpoint {
+    pub line: u32,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub column: Option<u32>,
+}
+
+/// Arguments to `setBreakpoints`.
+#[derive(Debug, Deserialize)]
+pub struct SetBreakpointsArguments {
+    pub source: Source,
+    #[serde(default)]
+    pub breakpoints: Vec<SourceBreakpoint>,
+}
+
+/// A breakpoint as reported back to the client.
+#[derive(Debug, Serialize)]
+pub struct Breakpoint {
+    pub verified: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<Source>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// A stack frame in a `stackTrace` response.
+#[derive(Debug, Serialize)]
+pub struct StackFrame {
+    pub id: i64,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<Source>,
+    pub line: u32,
+    pub column: u32,
+}
+
+/// A variable scope.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Scope {
+    pub name: String,
+    pub variables_reference: i64,
+    pub expensive: bool,
+}
+
+/// A single variable.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Variable {
+    pub name: String,
+    pub value: String,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub variables_reference: i64,
+}
+
+/// Arguments carrying only a `variablesReference`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VariablesArguments {
+    pub variables_reference: i64,
+}
+
+/// Arguments to `setVariable`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetVariableArguments {
+    pub variables_reference: i64,
+    pub name: String,
+    pub value: String,
+}
+
+/// Arguments to `evaluate`.
+#[derive(Debug, Deserialize)]
+pub struct EvaluateArguments {
+    pub expression: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub context: Option<String>,
+}
+
+/// Arguments to `source`.
+#[derive(Debug, Deserialize)]
+pub struct SourceArguments {
+    #[serde(default)]
+    pub source: Option<Source>,
+}

--- a/emulator/src/dap/tests.rs
+++ b/emulator/src/dap/tests.rs
@@ -1,0 +1,508 @@
+//! Protocol-level tests driving a [`DebugSession`] against an in-memory copy of
+//! `samples/fact.s`.
+
+use pretty_assertions::assert_eq;
+use serde_json::{json, Value};
+
+use super::DebugSession;
+
+const FACT_SOURCE: &str = indoc::indoc! {r"
+    main:
+        push 5
+        call factorielle
+        reset
+
+    factorielle:
+        ld   [%sp+1],%a
+        cmp  1,%a
+        jge  casparticulier
+
+        sub  1,%a
+        push %a
+        call factorielle
+        add  1,%sp
+        push %b
+        ld   [%sp+2],%b
+        mul  %b,%a
+        pop  %b
+        rtn
+
+    casparticulier:
+        ld  1, %a
+        rtn
+"};
+
+/// A program that raises an unhandled exception on its first instruction: it
+/// reads out-of-bounds memory (`%sp` starts at `STACK_START`) with no exception
+/// handler installed at address 200.
+const FAULT_SOURCE: &str = indoc::indoc! {r"
+    main:
+        ld   [%sp+1],%a
+        reset
+"};
+
+/// A tiny harness wrapping a session and a monotonic request-sequence counter.
+struct Harness {
+    session: DebugSession,
+    seq: i64,
+}
+
+impl Harness {
+    fn new() -> Self {
+        Self {
+            session: DebugSession::new(),
+            seq: 0,
+        }
+    }
+
+    fn send(&mut self, command: &str, arguments: Value) -> Vec<Value> {
+        self.seq += 1;
+        let msg = json!({
+            "seq": self.seq,
+            "type": "request",
+            "command": command,
+            "arguments": arguments,
+        });
+        self.session.handle_message(&msg)
+    }
+
+    /// Drive execution until the program stops or terminates, returning the
+    /// collected events.
+    fn drive(&mut self) -> Vec<Value> {
+        let mut events = Vec::new();
+        let mut guard = 0;
+        while self.session.is_running() {
+            let out = self.session.run_chunk();
+            events.extend(out);
+            guard += 1;
+            assert!(guard < 1000, "run loop did not converge");
+        }
+        events
+    }
+
+    /// Launch the sample program, optionally stopping on entry, and run through
+    /// the standard initialize/launch/configurationDone handshake.
+    fn launch(&mut self, stop_on_entry: bool) -> Vec<Value> {
+        self.send("initialize", json!({}));
+        self.send(
+            "launch",
+            json!({
+                "program": "/fact.s",
+                "entrypoint": "main",
+                "stopOnEntry": stop_on_entry,
+                "files": { "/fact.s": FACT_SOURCE },
+            }),
+        );
+        let mut out = self.send("configurationDone", json!({}));
+        out.extend(self.drive());
+        out
+    }
+}
+
+/// Find the first event with the given name in a list of messages.
+fn find_event<'a>(messages: &'a [Value], name: &str) -> Option<&'a Value> {
+    messages
+        .iter()
+        .find(|m| m["type"] == "event" && m["event"] == name)
+}
+
+/// Find the response for a given command.
+fn find_response<'a>(messages: &'a [Value], command: &str) -> Option<&'a Value> {
+    messages
+        .iter()
+        .find(|m| m["type"] == "response" && m["command"] == command)
+}
+
+#[test]
+fn initialize_advertises_capabilities() {
+    let mut h = Harness::new();
+    let out = h.send("initialize", json!({}));
+    let resp = find_response(&out, "initialize").expect("initialize response");
+    assert_eq!(resp["success"], json!(true));
+    let caps = &resp["body"];
+    assert_eq!(caps["supportsConfigurationDoneRequest"], json!(true));
+    assert_eq!(caps["supportsSetVariable"], json!(true));
+    assert_eq!(caps["supportsEvaluateForHovers"], json!(true));
+    // The `initialized` event must follow.
+    assert!(find_event(&out, "initialized").is_some());
+}
+
+#[test]
+fn stop_on_entry_halts_at_entrypoint() {
+    let mut h = Harness::new();
+    let out = h.launch(true);
+    let stopped = find_event(&out, "stopped").expect("stopped event");
+    assert_eq!(stopped["body"]["reason"], json!("entry"));
+
+    // The top frame should be at `main`, line 2 (the `push 5`).
+    let st = h.send("stackTrace", json!({ "threadId": 1 }));
+    let resp = find_response(&st, "stackTrace").expect("stackTrace response");
+    let frame = &resp["body"]["stackFrames"][0];
+    assert_eq!(frame["name"], json!("main"));
+    assert_eq!(frame["line"], json!(2));
+    assert_eq!(frame["source"]["path"], json!("/fact.s"));
+}
+
+#[test]
+fn breakpoint_inside_factorielle_is_hit() {
+    let mut h = Harness::new();
+    h.launch(true);
+
+    // Line 8 is `cmp 1,%a` inside `factorielle`.
+    let bp = h.send(
+        "setBreakpoints",
+        json!({
+            "source": { "path": "/fact.s" },
+            "breakpoints": [{ "line": 8 }],
+        }),
+    );
+    let resp = find_response(&bp, "setBreakpoints").expect("setBreakpoints response");
+    let breakpoint = &resp["body"]["breakpoints"][0];
+    assert_eq!(breakpoint["verified"], json!(true));
+    assert_eq!(breakpoint["line"], json!(8));
+
+    // Continue: we should stop at the breakpoint.
+    h.send("continue", json!({ "threadId": 1 }));
+    let events = h.drive();
+    let stopped = find_event(&events, "stopped").expect("stopped at breakpoint");
+    assert_eq!(stopped["body"]["reason"], json!("breakpoint"));
+
+    let st = h.send("stackTrace", json!({ "threadId": 1 }));
+    let resp = find_response(&st, "stackTrace").expect("stackTrace response");
+    let frame = &resp["body"]["stackFrames"][0];
+    assert_eq!(frame["name"], json!("factorielle"));
+    assert_eq!(frame["line"], json!(8));
+}
+
+#[test]
+fn breakpoint_on_comment_line_adjusts_forward() {
+    let mut h = Harness::new();
+    h.launch(true);
+
+    // Line 5 is blank (between `reset` and `factorielle:`); the next code line
+    // with an instruction is line 7 (`ld [%sp+1],%a`).
+    let bp = h.send(
+        "setBreakpoints",
+        json!({
+            "source": { "path": "/fact.s" },
+            "breakpoints": [{ "line": 5 }],
+        }),
+    );
+    let resp = find_response(&bp, "setBreakpoints").expect("setBreakpoints response");
+    let breakpoint = &resp["body"]["breakpoints"][0];
+    assert_eq!(breakpoint["verified"], json!(true));
+    assert_eq!(breakpoint["line"], json!(7));
+}
+
+#[test]
+fn next_steps_over_the_recursive_call() {
+    let mut h = Harness::new();
+    h.launch(true);
+
+    // At entry (line 2, `push 5`): step to reach `call factorielle` (line 3).
+    h.send("next", json!({ "threadId": 1 }));
+    let events = h.drive();
+    assert!(find_event(&events, "stopped").is_some());
+
+    let st = h.send("stackTrace", json!({ "threadId": 1 }));
+    let resp = find_response(&st, "stackTrace").expect("stackTrace response");
+    assert_eq!(resp["body"]["stackFrames"][0]["line"], json!(3));
+
+    // Record %sp before stepping over the call.
+    let vars = h.send("variables", json!({ "variablesReference": 1 }));
+    let sp_before = register_value(&vars, "sp");
+
+    // `next` over `call factorielle` must run the whole recursion and land on
+    // the following instruction (`reset`, line 4) with %sp restored.
+    h.send("next", json!({ "threadId": 1 }));
+    let events = h.drive();
+    assert!(find_event(&events, "stopped").is_some());
+
+    let st = h.send("stackTrace", json!({ "threadId": 1 }));
+    let resp = find_response(&st, "stackTrace").expect("stackTrace response");
+    assert_eq!(resp["body"]["stackFrames"][0]["line"], json!(4));
+
+    let vars = h.send("variables", json!({ "variablesReference": 1 }));
+    let sp_after = register_value(&vars, "sp");
+    assert_eq!(
+        sp_before, sp_after,
+        "step-over must restore the stack pointer"
+    );
+}
+
+#[test]
+fn step_out_returns_to_caller() {
+    let mut h = Harness::new();
+    h.launch(true);
+
+    // Break at the start of `factorielle` (line 7) and continue into it.
+    h.send(
+        "setBreakpoints",
+        json!({
+            "source": { "path": "/fact.s" },
+            "breakpoints": [{ "line": 7 }],
+        }),
+    );
+    h.send("continue", json!({ "threadId": 1 }));
+    let events = h.drive();
+    assert_eq!(
+        find_event(&events, "stopped").expect("stopped")["body"]["reason"],
+        json!("breakpoint")
+    );
+
+    // We are inside factorielle called from main. Remove the breakpoint so
+    // stepOut is not re-triggered by the recursion, then step out.
+    h.send(
+        "setBreakpoints",
+        json!({ "source": { "path": "/fact.s" }, "breakpoints": [] }),
+    );
+    h.send("stepOut", json!({ "threadId": 1 }));
+    let events = h.drive();
+    assert!(find_event(&events, "stopped").is_some());
+
+    // After returning to main we should be at the `reset` (line 4).
+    let st = h.send("stackTrace", json!({ "threadId": 1 }));
+    let resp = find_response(&st, "stackTrace").expect("stackTrace response");
+    assert_eq!(resp["body"]["stackFrames"][0]["name"], json!("main"));
+    assert_eq!(resp["body"]["stackFrames"][0]["line"], json!(4));
+}
+
+#[test]
+fn variables_show_registers() {
+    let mut h = Harness::new();
+    h.launch(true);
+
+    let scopes = h.send("scopes", json!({ "frameId": 0 }));
+    let resp = find_response(&scopes, "scopes").expect("scopes response");
+    assert_eq!(resp["body"]["scopes"][0]["name"], json!("Registers"));
+    assert_eq!(resp["body"]["scopes"][1]["name"], json!("Execution"));
+
+    let vars = h.send("variables", json!({ "variablesReference": 1 }));
+    let resp = find_response(&vars, "variables").expect("variables response");
+    let names: Vec<&str> = resp["body"]["variables"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v["name"].as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"a"));
+    assert!(names.contains(&"b"));
+    assert!(names.contains(&"pc"));
+    assert!(names.contains(&"sp"));
+    assert!(names.contains(&"sr"));
+    // `cycles` is no longer a register: it lives in the "Execution" scope.
+    assert!(!names.contains(&"cycles"));
+
+    let exec = h.send("variables", json!({ "variablesReference": 3 }));
+    let resp = find_response(&exec, "variables").expect("variables response");
+    let names: Vec<&str> = resp["body"]["variables"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["cycles"]);
+}
+
+#[test]
+fn set_variable_updates_register() {
+    let mut h = Harness::new();
+    h.launch(true);
+
+    let resp = h.send(
+        "setVariable",
+        json!({ "variablesReference": 1, "name": "a", "value": "42" }),
+    );
+    let resp = find_response(&resp, "setVariable").expect("setVariable response");
+    assert_eq!(resp["success"], json!(true));
+    assert_eq!(resp["body"]["value"], json!("42"));
+
+    let vars = h.send("variables", json!({ "variablesReference": 1 }));
+    assert_eq!(register_value(&vars, "a"), "42");
+}
+
+#[test]
+fn evaluate_resolves_a_label() {
+    let mut h = Harness::new();
+    h.launch(true);
+
+    let resp = h.send(
+        "evaluate",
+        json!({ "expression": "factorielle", "context": "repl" }),
+    );
+    let resp = find_response(&resp, "evaluate").expect("evaluate response");
+    assert_eq!(resp["success"], json!(true));
+    assert_eq!(resp["body"]["type"], json!("address"));
+
+    // Also resolve a register and an integer literal.
+    let reg = h.send("evaluate", json!({ "expression": "%pc" }));
+    assert_eq!(
+        find_response(&reg, "evaluate").unwrap()["body"]["type"],
+        json!("register")
+    );
+    let lit = h.send("evaluate", json!({ "expression": "0x10" }));
+    assert_eq!(
+        find_response(&lit, "evaluate").unwrap()["body"]["result"],
+        json!("16")
+    );
+}
+
+#[test]
+fn running_to_completion_terminates() {
+    let mut h = Harness::new();
+    // Do not stop on entry: the program runs to the `reset` immediately.
+    let out = h.launch(false);
+    assert!(find_event(&out, "terminated").is_some());
+    let exited = find_event(&out, "exited").expect("exited event");
+    assert_eq!(exited["body"]["exitCode"], json!(0));
+}
+
+#[test]
+fn continue_from_stop_runs_to_completion() {
+    let mut h = Harness::new();
+    h.launch(true);
+    h.send("continue", json!({ "threadId": 1 }));
+    let events = h.drive();
+    assert!(find_event(&events, "terminated").is_some());
+    assert_eq!(
+        find_event(&events, "exited").unwrap()["body"]["exitCode"],
+        json!(0)
+    );
+}
+
+#[test]
+fn breakpoint_on_entry_stops_when_not_stopping_on_entry() {
+    let mut h = Harness::new();
+    h.send("initialize", json!({}));
+    h.send(
+        "launch",
+        json!({
+            "program": "/fact.s",
+            "entrypoint": "main",
+            "stopOnEntry": false,
+            "files": { "/fact.s": FACT_SOURCE },
+        }),
+    );
+    // Breakpoint on the entry instruction (line 2, `push 5`).
+    h.send(
+        "setBreakpoints",
+        json!({
+            "source": { "path": "/fact.s" },
+            "breakpoints": [{ "line": 2 }],
+        }),
+    );
+    let mut out = h.send("configurationDone", json!({}));
+    out.extend(h.drive());
+
+    // Even with stopOnEntry=false, a breakpoint on the entry line must fire
+    // instead of being run past.
+    let stopped = find_event(&out, "stopped").expect("stopped event");
+    assert_eq!(stopped["body"]["reason"], json!("breakpoint"));
+    assert!(find_event(&out, "terminated").is_none());
+
+    // We stopped before executing anything: the top frame is at `main`, line 2.
+    let st = h.send("stackTrace", json!({ "threadId": 1 }));
+    let resp = find_response(&st, "stackTrace").expect("stackTrace response");
+    assert_eq!(resp["body"]["stackFrames"][0]["name"], json!("main"));
+    assert_eq!(resp["body"]["stackFrames"][0]["line"], json!(2));
+}
+
+#[test]
+fn stop_on_entry_breakpoint_does_not_double_fire() {
+    let mut h = Harness::new();
+    h.send("initialize", json!({}));
+    h.send(
+        "launch",
+        json!({
+            "program": "/fact.s",
+            "entrypoint": "main",
+            "stopOnEntry": true,
+            "files": { "/fact.s": FACT_SOURCE },
+        }),
+    );
+    h.send(
+        "setBreakpoints",
+        json!({
+            "source": { "path": "/fact.s" },
+            "breakpoints": [{ "line": 2 }],
+        }),
+    );
+    let mut out = h.send("configurationDone", json!({}));
+    out.extend(h.drive());
+    // stopOnEntry wins: we stop once at entry.
+    let stopped = find_event(&out, "stopped").expect("stopped at entry");
+    assert_eq!(stopped["body"]["reason"], json!("entry"));
+
+    // Continue must move PAST the entry breakpoint, not re-fire on it. With the
+    // breakpoint only on the entry line, the program runs to completion.
+    h.send("continue", json!({ "threadId": 1 }));
+    let events = h.drive();
+    assert!(
+        find_event(&events, "stopped").is_none(),
+        "continue must not re-fire the breakpoint at the entry address"
+    );
+    assert!(find_event(&events, "terminated").is_some());
+}
+
+#[test]
+fn resume_after_unhandled_exception_terminates() {
+    let mut h = Harness::new();
+    h.send("initialize", json!({}));
+    h.send(
+        "launch",
+        json!({
+            "program": "/boom.s",
+            "entrypoint": "main",
+            "stopOnEntry": false,
+            "files": { "/boom.s": FAULT_SOURCE },
+        }),
+    );
+    let mut out = h.send("configurationDone", json!({}));
+    out.extend(h.drive());
+    // The unhandled exception surfaces as a stopped(exception) event.
+    let stopped = find_event(&out, "stopped").expect("stopped event");
+    assert_eq!(stopped["body"]["reason"], json!("exception"));
+
+    // stepIn after the exception must end the session, not re-fault forever.
+    let events = h.send("stepIn", json!({ "threadId": 1 }));
+    assert!(find_event(&events, "terminated").is_some());
+    let exited = find_event(&events, "exited").expect("exited event");
+    assert_eq!(exited["body"]["exitCode"], json!(1));
+    assert!(!h.session.is_running());
+
+    // A subsequent resume is rejected because the session has terminated.
+    let again = h.send("continue", json!({ "threadId": 1 }));
+    let resp = find_response(&again, "continue").expect("continue response");
+    assert_eq!(resp["success"], json!(false));
+}
+
+#[test]
+fn continue_after_termination_is_rejected() {
+    let mut h = Harness::new();
+    // Runs straight to `reset` and terminates.
+    let out = h.launch(false);
+    assert!(find_event(&out, "terminated").is_some());
+    assert!(!h.session.is_running());
+
+    // A continue after termination must be an error and must not re-run the
+    // program (no second terminated/exited pair).
+    let events = h.send("continue", json!({ "threadId": 1 }));
+    let resp = find_response(&events, "continue").expect("continue response");
+    assert_eq!(resp["success"], json!(false));
+    assert!(find_event(&events, "terminated").is_none());
+    assert!(find_event(&events, "exited").is_none());
+    assert!(!h.session.is_running());
+}
+
+/// Extract a register's string value from a `variables` response.
+fn register_value(messages: &[Value], name: &str) -> String {
+    let resp = find_response(messages, "variables").expect("variables response");
+    resp["body"]["variables"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|v| v["name"] == name)
+        .and_then(|v| v["value"].as_str())
+        .expect("register present")
+        .to_owned()
+}

--- a/emulator/src/lib.rs
+++ b/emulator/src/lib.rs
@@ -62,6 +62,7 @@
 mod ast;
 pub mod compiler;
 pub mod constants;
+pub mod dap;
 pub mod diagnostic;
 pub mod lsp;
 pub mod parser;

--- a/emulator/src/runtime/mod.rs
+++ b/emulator/src/runtime/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod arguments;
 mod exception;
 mod instructions;
 mod memory;
-mod registers;
+pub mod registers;
 
 pub use self::arguments::ExtractValue;
 use self::arguments::{ExtractError, Ind, ResolveAddress};


### PR DESCRIPTION
Part 2/9 — stacked on #928.

Adds a transport-agnostic Debug Adapter Protocol implementation to the emulator crate, plus a `z33-cli dap` stdio subcommand. `DebugSession` does no I/O: the caller drives `handle_message()` / `run_chunk()` (bounded chunks so pause stays responsive). Hand-rolled serde protocol types (the `dap` crate is pre-release and not wasm-clean). Line↔address mapping composes `DebugInfo.source_map` with the preprocessor source map; breakpoints snap to the next line with code.

Supports: launch (native disk or inline `files` map for wasm hosts), breakpoints, continue/next/stepIn/stepOut (`%sp` discipline for step-over/out), pause, stackTrace with best-effort caller-frame synthesis, scopes/variables/setVariable, evaluate, restart; clean terminal states for halt (`reset`) and unhandled exceptions.

Verified: 15 protocol-level tests + a scripted end-to-end session against `z33-cli dap` over real Content-Length framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)