### PR TITLE
DAP: stack/globals scopes, watch dereferences, memory read/write

### DIFF
--- a/emulator/src/dap/mod.rs
+++ b/emulator/src/dap/mod.rs
@@ -49,15 +49,16 @@ use serde_json::{json, Map, Value};
 
 use self::index::LineIndex;
 use self::protocol::{
-    Breakpoint, Capabilities, EvaluateArguments, IncomingRequest, LaunchArguments, Scope,
-    SetBreakpointsArguments, SetVariableArguments, Source, SourceArguments, StackFrame, Variable,
-    VariablesArguments,
+    Breakpoint, Capabilities, EvaluateArguments, IncomingRequest, LaunchArguments,
+    ReadMemoryArguments, Scope, ScopesArguments, SetBreakpointsArguments, SetVariableArguments,
+    Source, SourceArguments, StackFrame, Variable, VariablesArguments, WriteMemoryArguments,
 };
 use crate::constants as C;
 use crate::constants::Address;
 use crate::diagnostic::{
     preprocessor_error_to_diagnostics, render_to_string, resolve_diagnostic_spans,
 };
+use crate::parser::ExpressionNode;
 use crate::preprocessor::{
     Filesystem, InMemoryFilesystem, NativeFilesystem, ReferencingSourceMap, Workspace,
 };
@@ -69,15 +70,43 @@ pub const CHUNK_SIZE: usize = 10_000;
 
 /// The single thread exposed to the client.
 const THREAD_ID: i64 = 1;
-/// `variablesReference` for the registers scope.
+/// `variablesReference` for the registers scope (all frames share the live
+/// registers).
 const REGISTERS_REF: i64 = 1;
 /// `variablesReference` for the status-register flags.
 const FLAGS_REF: i64 = 2;
 /// `variablesReference` for the execution scope (cycle counter and other
 /// run-state that is not an architectural register).
 const EXECUTION_REF: i64 = 3;
+/// `variablesReference` for the top frame's stack scope.
+const STACK_REF: i64 = 4;
+/// `variablesReference` for the globals (labels) scope.
+const GLOBALS_REF: i64 = 5;
+/// First value used for dynamically allocated, per-stop `variablesReference`
+/// handles (region expansions and per-frame stack scopes). Monotonic across the
+/// session so a stale handle from a previous stop never collides with a live
+/// one.
+const DYN_BASE: i64 = 1_000;
+/// Default page size when a `variables` request does not specify a `count`.
+const DEFAULT_PAGE: u32 = 256;
 /// Upper bound on synthesized caller frames.
 const MAX_FRAMES: usize = 64;
+/// Bytes on the wire for a single Z33 cell (one `i64` word, little-endian).
+const CELL_BYTES: i64 = 8;
+
+/// What a dynamically allocated `variablesReference` expands to. Rebuilt on
+/// every stop; see [`DynRef`] allocation in [`DebugSession::alloc_dyn`].
+#[derive(Debug, Clone)]
+enum DynRef {
+    /// Indexed children of a multi-cell global (label) region.
+    GlobalLabel {
+        label: String,
+        base: Address,
+        len: u32,
+    },
+    /// The words a synthesized caller frame pushed, `[start, end)`.
+    FrameStack { start: Address, end: Address },
+}
 
 const EXIT_OK: i64 = 0;
 const EXIT_EXCEPTION: i64 = 1;
@@ -164,6 +193,11 @@ pub struct DebugSession {
     run_mode: RunMode,
     program: Option<LoadedProgram>,
     launch_args: Option<LaunchArguments>,
+    /// Live dynamic `variablesReference` handles for the current stop.
+    dyn_handles: HashMap<i64, DynRef>,
+    /// Monotonic allocator for dynamic handles (never reset, so stale handles
+    /// stay invalid once cleared).
+    next_dyn: i64,
 }
 
 impl Default for DebugSession {
@@ -187,7 +221,24 @@ impl DebugSession {
             run_mode: RunMode::Continue,
             program: None,
             launch_args: None,
+            dyn_handles: HashMap::new(),
+            next_dyn: 0,
         }
+    }
+
+    /// Allocate a fresh dynamic `variablesReference` for the current stop.
+    fn alloc_dyn(&mut self, r: DynRef) -> i64 {
+        let id = DYN_BASE + self.next_dyn;
+        self.next_dyn += 1;
+        self.dyn_handles.insert(id, r);
+        id
+    }
+
+    /// Invalidate every dynamic handle. Called on both stop and resume so a
+    /// `variablesReference` handed out during one stop cannot be read across a
+    /// resume (standard DAP practice — references live only while stopped).
+    fn invalidate_handles(&mut self) {
+        self.dyn_handles.clear();
     }
 
     /// Whether the program is currently running and the caller should keep
@@ -242,6 +293,8 @@ impl DebugSession {
             "stepOut" => self.on_step_out(&req),
             "pause" => self.on_pause(&req),
             "evaluate" => self.on_evaluate(&req),
+            "readMemory" => self.on_read_memory(&req),
+            "writeMemory" => self.on_write_memory(&req),
             "source" => self.on_source(&req),
             "restart" => self.on_restart(&req),
             "disconnect" => {
@@ -359,19 +412,88 @@ impl DebugSession {
     }
 
     fn on_scopes(&mut self, req: &IncomingRequest) -> Vec<Value> {
-        let scopes = vec![
+        let args: ScopesArguments =
+            serde_json::from_value(req.arguments.clone()).unwrap_or_default();
+        if self.program.is_none() {
+            return vec![self.response_err(req, "no program launched")];
+        }
+
+        let mut scopes = vec![
             Scope {
                 name: "Registers".to_owned(),
                 variables_reference: REGISTERS_REF,
                 expensive: false,
+                ..Default::default()
             },
             Scope {
                 name: "Execution".to_owned(),
                 variables_reference: EXECUTION_REF,
                 expensive: false,
+                ..Default::default()
             },
         ];
+
+        if args.frame_id == 0 {
+            // Top frame: live stack + globals.
+            let program = self.program.as_ref().expect("program loaded");
+            let depth = i64::from(C::STACK_START - program.computer.registers.sp);
+            scopes.push(Scope {
+                name: "Stack".to_owned(),
+                variables_reference: STACK_REF,
+                expensive: false,
+                indexed_variables: Some(depth),
+                ..Default::default()
+            });
+        } else if let Some((start, end)) = self.frame_stack_range(args.frame_id) {
+            // Synthesized caller frame: best-effort view of the words it pushed.
+            let handle = self.alloc_dyn(DynRef::FrameStack { start, end });
+            scopes.push(Scope {
+                name: "Frame stack".to_owned(),
+                variables_reference: handle,
+                expensive: false,
+                indexed_variables: Some(i64::from(end - start)),
+                presentation_hint: Some("arguments".to_owned()),
+                ..Default::default()
+            });
+        }
+
+        scopes.push(Scope {
+            name: "Globals".to_owned(),
+            variables_reference: GLOBALS_REF,
+            expensive: false,
+            named_variables: Some(self.globals_count()),
+            ..Default::default()
+        });
+
         vec![self.response(req, json!({ "scopes": scopes }))]
+    }
+
+    /// Number of labels exposed by the globals scope.
+    fn globals_count(&self) -> i64 {
+        self.program
+            .as_ref()
+            .map_or(0, |p| i64::try_from(p.labels.len()).unwrap_or(i64::MAX))
+    }
+
+    /// Best-effort `[start, end)` stack range a synthesized caller frame
+    /// pushed, or `None` when the return-address scan found nothing
+    /// reliable for it.
+    ///
+    /// Frame `j` (1-based) was found at return slot `s = slots[j-1]`; the words
+    /// it pushed for its callee live just above that slot, up to the next outer
+    /// return slot (or the stack base). Returns `None` if the region is empty.
+    fn frame_stack_range(&self, frame_id: i64) -> Option<(Address, Address)> {
+        let program = self.program.as_ref()?;
+        let slots = scan_return_slots(program);
+        let idx = usize::try_from(frame_id - 1).ok()?;
+        let slot = *slots.get(idx)?;
+        let start = slot + 1;
+        let end = slots.get(idx + 1).copied().unwrap_or(C::STACK_START);
+        if start >= end {
+            None
+        } else {
+            Some((start, end))
+        }
     }
 
     fn on_variables(&mut self, req: &IncomingRequest) -> Vec<Value> {
@@ -379,17 +501,95 @@ impl DebugSession {
             Ok(a) => a,
             Err(e) => return vec![self.response_err(req, format!("invalid arguments: {e}"))],
         };
-        let Some(program) = self.program.as_ref() else {
+        if self.program.is_none() {
             return vec![self.response_err(req, "no program launched")];
-        };
+        }
+        let hex = args.format.unwrap_or_default().hex;
+        let start = args.start.unwrap_or(0).max(0);
+        let start = u32::try_from(start).unwrap_or(u32::MAX);
+        let count = args.count.and_then(|c| u32::try_from(c).ok());
+
+        // Multi-cell / frame-stack expansions live in the dynamic table.
+        if args.variables_reference >= DYN_BASE {
+            let Some(dref) = self.dyn_handles.get(&args.variables_reference).cloned() else {
+                // Stale handle from a previous stop: DAP references are only
+                // valid while stopped, so we return an empty list.
+                return vec![self.response(req, json!({ "variables": [] }))];
+            };
+            let program = self.program.as_ref().expect("program loaded");
+            let variables = match dref {
+                DynRef::GlobalLabel { label, base, len } => {
+                    global_label_children(program, &label, base, len, start, count, hex)
+                }
+                DynRef::FrameStack { start: s, end } => {
+                    frame_stack_variables(program, s, end, start, count, hex)
+                }
+            };
+            return vec![self.response(req, json!({ "variables": variables }))];
+        }
 
         let variables = match args.variables_reference {
-            REGISTERS_REF => registers_variables(&program.computer),
-            FLAGS_REF => flags_variables(&program.computer),
-            EXECUTION_REF => execution_variables(&program.computer),
+            REGISTERS_REF => {
+                let program = self.program.as_ref().expect("program loaded");
+                registers_variables(&program.computer, hex)
+            }
+            FLAGS_REF => {
+                let program = self.program.as_ref().expect("program loaded");
+                flags_variables(&program.computer)
+            }
+            EXECUTION_REF => {
+                let program = self.program.as_ref().expect("program loaded");
+                execution_variables(&program.computer)
+            }
+            STACK_REF => {
+                let program = self.program.as_ref().expect("program loaded");
+                stack_variables(program, start, count, hex)
+            }
+            GLOBALS_REF => self.globals_variables(start, count, hex),
             _ => Vec::new(),
         };
         vec![self.response(req, json!({ "variables": variables }))]
+    }
+
+    /// Build the globals (labels) scope, allocating dynamic handles for the
+    /// multi-cell regions so the client can expand them.
+    fn globals_variables(&mut self, start: u32, count: Option<u32>, hex: bool) -> Vec<Variable> {
+        let regions = {
+            let program = self.program.as_ref().expect("program loaded");
+            label_regions(&program.labels)
+        };
+        let count = count.map_or(usize::MAX, |c| c as usize);
+        let mut out = Vec::new();
+        for (label, base, len) in regions.into_iter().skip(start as usize).take(count) {
+            let program = self.program.as_ref().expect("program loaded");
+            let cell = program.computer.memory.get(base).ok();
+            if len <= 1 {
+                out.push(Variable {
+                    name: label,
+                    value: cell.map_or_else(|| "?".to_owned(), |c| format_cell(c, hex)),
+                    kind: Some(cell.map_or("word", cell_type).to_owned()),
+                    memory_reference: Some(base.to_string()),
+                    ..Default::default()
+                });
+            } else {
+                let first = cell.map_or_else(|| "?".to_owned(), |c| format_cell(c, hex));
+                let handle = self.alloc_dyn(DynRef::GlobalLabel {
+                    label: label.clone(),
+                    base,
+                    len,
+                });
+                out.push(Variable {
+                    name: label,
+                    value: format!("[{len} cells] first={first}"),
+                    kind: Some("region".to_owned()),
+                    variables_reference: handle,
+                    memory_reference: Some(base.to_string()),
+                    indexed_variables: Some(i64::from(len)),
+                    ..Default::default()
+                });
+            }
+        }
+        out
     }
 
     fn on_set_variable(&mut self, req: &IncomingRequest) -> Vec<Value> {
@@ -398,31 +598,20 @@ impl DebugSession {
             Err(e) => return vec![self.response_err(req, format!("invalid arguments: {e}"))],
         };
 
+        let hex = args.format.unwrap_or_default().hex;
+        // Resolve the target address for cell scopes before borrowing mutably.
+        let cell_addr = self.resolve_cell_address(args.variables_reference, &args.name);
+
         let outcome = {
             let Some(program) = self.program.as_mut() else {
                 return vec![self.response_err(req, "no program launched")];
             };
-            if args.variables_reference != REGISTERS_REF {
-                Err("only register variables can be set".to_owned())
-            } else if let Some(value) = parse_int(&args.value) {
-                let reg = match args.name.as_str() {
-                    "a" => Some(Reg::A),
-                    "b" => Some(Reg::B),
-                    "pc" => Some(Reg::PC),
-                    "sp" => Some(Reg::SP),
-                    _ => None,
-                };
-                match reg {
-                    Some(reg) => program
-                        .computer
-                        .registers
-                        .set(reg, Cell::Word(value))
-                        .map(|()| format!("{}", program.computer.registers.get(&reg)))
-                        .map_err(|e| e.to_string()),
-                    None => Err(format!("cannot set variable '{}'", args.name)),
-                }
+            if args.variables_reference == REGISTERS_REF {
+                set_register(program, &args.name, &args.value, hex)
+            } else if let Some(addr) = cell_addr {
+                set_cell(program, addr, &args.value, hex)
             } else {
-                Err(format!("invalid integer value '{}'", args.value))
+                Err(format!("cannot set variable '{}'", args.name))
             }
         };
 
@@ -431,6 +620,34 @@ impl DebugSession {
                 vec![self.response(req, json!({ "value": value, "variablesReference": 0 }))]
             }
             Err(msg) => vec![self.response_err(req, msg)],
+        }
+    }
+
+    /// Resolve the memory address a settable cell variable names, for the
+    /// Stack, Globals and Frame-stack scopes. Returns `None` for the
+    /// register scope or unknown references.
+    fn resolve_cell_address(&self, reference: i64, name: &str) -> Option<Address> {
+        let program = self.program.as_ref()?;
+        match reference {
+            STACK_REF => {
+                let n = name.strip_prefix("sp+")?.trim().parse::<u32>().ok()?;
+                Some(program.computer.registers.sp + n)
+            }
+            GLOBALS_REF => {
+                // Only single-cell labels are settable at the scope level.
+                let &base = program.labels.get(name)?;
+                let regions = label_regions(&program.labels);
+                let len = regions
+                    .iter()
+                    .find(|(l, _, _)| l == name)
+                    .map_or(1, |&(_, _, len)| len);
+                (len <= 1).then_some(base)
+            }
+            r if r >= DYN_BASE => match self.dyn_handles.get(&r)? {
+                // Both children encode the absolute address in `name (addr)`.
+                DynRef::GlobalLabel { .. } | DynRef::FrameStack { .. } => parse_addr_suffix(name),
+            },
+            _ => None,
         }
     }
 
@@ -459,6 +676,8 @@ impl DebugSession {
             out.extend(self.terminate_now(EXIT_EXCEPTION));
             return Some(out);
         }
+        // Resuming: any handle handed out during the last stop is now stale.
+        self.invalidate_handles();
         None
     }
 
@@ -527,19 +746,76 @@ impl DebugSession {
             Err(e) => return vec![self.response_err(req, format!("invalid arguments: {e}"))],
         };
 
+        let hex = args.format.unwrap_or_default().hex;
         let result = {
             let Some(program) = self.program.as_ref() else {
                 return vec![self.response_err(req, "no program launched")];
             };
-            evaluate_expression(program, args.expression.trim())
+            evaluate_expression(program, args.expression.trim(), hex)
         };
 
         match result {
-            Some((value, kind)) => vec![self.response(
-                req,
-                json!({ "result": value, "type": kind, "variablesReference": 0 }),
-            )],
-            None => vec![self.response_err(req, "could not evaluate expression")],
+            Ok(eval) => {
+                let mut body = json!({
+                    "result": eval.result,
+                    "type": eval.kind,
+                    "variablesReference": 0,
+                });
+                if let Some(addr) = eval.memory_reference {
+                    body["memoryReference"] = addr.to_string().into();
+                }
+                vec![self.response(req, body)]
+            }
+            Err(msg) => vec![self.response_err(req, msg)],
+        }
+    }
+
+    fn on_read_memory(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        let args: ReadMemoryArguments = match serde_json::from_value(req.arguments.clone()) {
+            Ok(a) => a,
+            Err(e) => return vec![self.response_err(req, format!("invalid arguments: {e}"))],
+        };
+        let Some(program) = self.program.as_ref() else {
+            return vec![self.response_err(req, "no program launched")];
+        };
+        let Ok(base) = args.memory_reference.trim().parse::<i64>() else {
+            return vec![self.response_err(req, "memoryReference must be a decimal cell address")];
+        };
+        if args.count < 0 {
+            return vec![self.response_err(req, "count must be non-negative")];
+        }
+        let (address, data, unreadable) =
+            read_memory(&program.computer, base, args.offset, args.count);
+        let mut body = json!({ "address": address.to_string(), "data": base64_encode(&data) });
+        if unreadable > 0 {
+            body["unreadableBytes"] = unreadable.into();
+        }
+        vec![self.response(req, body)]
+    }
+
+    fn on_write_memory(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        let args: WriteMemoryArguments = match serde_json::from_value(req.arguments.clone()) {
+            Ok(a) => a,
+            Err(e) => return vec![self.response_err(req, format!("invalid arguments: {e}"))],
+        };
+        let Some(program) = self.program.as_mut() else {
+            return vec![self.response_err(req, "no program launched")];
+        };
+        let Ok(base) = args.memory_reference.trim().parse::<i64>() else {
+            return vec![self.response_err(req, "memoryReference must be a decimal cell address")];
+        };
+        let Some(bytes) = base64_decode(&args.data) else {
+            return vec![self.response_err(req, "data is not valid base64")];
+        };
+        match write_memory(
+            &mut program.computer,
+            base,
+            args.offset,
+            &bytes,
+            args.allow_partial,
+        ) {
+            Ok(written) => vec![self.response(req, json!({ "bytesWritten": written }))],
+            Err(msg) => vec![self.response_err(req, msg)],
         }
     }
 
@@ -645,12 +921,14 @@ impl DebugSession {
             Outcome::Pending => Vec::new(),
             Outcome::Stopped(reason) => {
                 self.state = State::Stopped;
+                self.invalidate_handles();
                 vec![self.stopped_event(reason, None, None)]
             }
             Outcome::Terminated(code) => self.terminate_now(code),
             Outcome::Exception(msg) => {
                 self.state = State::Stopped;
                 self.exception_pending = true;
+                self.invalidate_handles();
                 let output = self.make_event(
                     "output",
                     json!({ "category": "console", "output": format!("Exception: {msg}\n") }),
@@ -706,35 +984,9 @@ impl DebugSession {
         let pc = program.computer.registers.pc;
         frames.push(self.frame(0, pc));
 
-        // Best-effort synthesis of caller frames: scan the stack for words that
-        // look like return addresses (the cell just before them is a `call`).
-        let sp = program.computer.registers.sp;
-        let mut id = 1;
-        for addr in sp..C::STACK_START {
-            if frames.len() >= MAX_FRAMES {
-                break;
-            }
-            let Ok(cell) = program.computer.memory.get(addr) else {
-                continue;
-            };
-            let Cell::Word(word) = cell else { continue };
-            let Ok(target) = Address::try_from(*word) else {
-                continue;
-            };
-            if target == 0 {
-                continue;
-            }
-            let is_return = program
-                .computer
-                .memory
-                .get(target - 1)
-                .ok()
-                .and_then(|c| c.extract_instruction().ok())
-                .is_some_and(|i| matches!(i, Instruction::Call(_)));
-            if is_return && program.index.location(target).is_some() {
-                frames.push(self.frame(id, target));
-                id += 1;
-            }
+        // Best-effort synthesis of caller frames from the return-address scan.
+        for (id, (_slot, target)) in scan_frames(program).into_iter().enumerate() {
+            frames.push(self.frame(i64::try_from(id + 1).unwrap_or(i64::MAX), target));
         }
         frames
     }
@@ -852,38 +1104,28 @@ impl DebugSession {
 // Free helpers
 // --------------------------------------------------------------------------
 
-fn registers_variables(computer: &Computer) -> Vec<Variable> {
+fn register_var(name: &str, value: String) -> Variable {
+    Variable {
+        name: name.to_owned(),
+        value,
+        kind: Some("register".to_owned()),
+        ..Default::default()
+    }
+}
+
+fn registers_variables(computer: &Computer, hex: bool) -> Vec<Variable> {
     let regs = &computer.registers;
     vec![
-        Variable {
-            name: "a".to_owned(),
-            value: format!("{}", regs.a),
-            kind: Some("register".to_owned()),
-            variables_reference: 0,
-        },
-        Variable {
-            name: "b".to_owned(),
-            value: format!("{}", regs.b),
-            kind: Some("register".to_owned()),
-            variables_reference: 0,
-        },
-        Variable {
-            name: "pc".to_owned(),
-            value: regs.pc.to_string(),
-            kind: Some("register".to_owned()),
-            variables_reference: 0,
-        },
-        Variable {
-            name: "sp".to_owned(),
-            value: regs.sp.to_string(),
-            kind: Some("register".to_owned()),
-            variables_reference: 0,
-        },
+        register_var("a", format_cell(&regs.a, hex)),
+        register_var("b", format_cell(&regs.b, hex)),
+        register_var("pc", format_address(regs.pc, hex)),
+        register_var("sp", format_address(regs.sp, hex)),
         Variable {
             name: "sr".to_owned(),
             value: format!("0x{:x}", regs.sr.bits()),
             kind: Some("flags".to_owned()),
             variables_reference: FLAGS_REF,
+            ..Default::default()
         },
     ]
 }
@@ -893,7 +1135,7 @@ fn execution_variables(computer: &Computer) -> Vec<Variable> {
         name: "cycles".to_owned(),
         value: computer.cycles.to_string(),
         kind: Some("counter".to_owned()),
-        variables_reference: 0,
+        ..Default::default()
     }]
 }
 
@@ -909,34 +1151,118 @@ fn flags_variables(computer: &Computer) -> Vec<Variable> {
             name: name.to_ascii_lowercase(),
             value: sr.contains(flag).to_string(),
             kind: Some("bool".to_owned()),
-            variables_reference: 0,
+            ..Default::default()
         })
         .collect()
 }
 
-fn evaluate_expression(program: &LoadedProgram, expr: &str) -> Option<(String, String)> {
+/// The result of an `evaluate` request.
+struct Evaluated {
+    result: String,
+    kind: String,
+    memory_reference: Option<Address>,
+}
+
+/// Evaluate an `evaluate` expression. Supported forms:
+///
+/// * `%a`/`%pc`/... — a register value (`register`).
+/// * an integer literal (`0x10`, `-3`) — the literal (`integer`).
+/// * `label`, `label+2`, `4*label` — the resolved **address** value
+///   (`address`), with `memoryReference` set.
+/// * `[<expr>]` — dereference: read the cell at the address `<expr>` computes
+///   to (`cell`), with `memoryReference` set. `<expr>` may itself be a
+///   register-indexed form (`[%sp]`, `[%sp+2]`, `[%a-1]`) or a label/arithmetic
+///   expression.
+fn evaluate_expression(
+    program: &LoadedProgram,
+    expr: &str,
+    hex: bool,
+) -> Result<Evaluated, String> {
     if expr.is_empty() {
-        return None;
+        return Err("empty expression".to_owned());
     }
+    let computer = &program.computer;
+
+    // Dereference: `[<expr>]`.
+    if let Some(inner) = expr.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+        let addr = eval_address(program, inner.trim())?;
+        let cell = computer.memory.get(addr).map_err(|e| e.to_string())?;
+        return Ok(Evaluated {
+            result: format!(
+                "{} ({})",
+                format_cell(cell, hex),
+                format_address(addr, false)
+            ),
+            kind: cell_type(cell).to_owned(),
+            memory_reference: Some(addr),
+        });
+    }
+
     // Register?
     if let Ok(reg) = Reg::from_str(expr) {
-        let value = format!("{}", program.computer.registers.get(&reg));
-        return Some((value, "register".to_owned()));
+        return Ok(Evaluated {
+            result: format_cell(&computer.registers.get(&reg), hex),
+            kind: "register".to_owned(),
+            memory_reference: None,
+        });
     }
-    // Label?
-    if let Some(&address) = program.labels.get(expr) {
-        let cell = program
-            .computer
-            .memory
-            .get(address)
-            .map_or_else(|_| "?".to_owned(), |c| format!("{c}"));
-        return Some((format!("{address} ({cell})"), "address".to_owned()));
-    }
+
     // Integer literal?
     if let Some(value) = parse_int(expr) {
-        return Some((value.to_string(), "integer".to_owned()));
+        return Ok(Evaluated {
+            result: format_word(value, hex),
+            kind: "integer".to_owned(),
+            memory_reference: None,
+        });
     }
-    None
+
+    // Label / arithmetic → the address value.
+    let addr = eval_address(program, expr)?;
+    let cell = computer
+        .memory
+        .get(addr)
+        .map_or_else(|_| "?".to_owned(), |c| format_cell(c, hex));
+    Ok(Evaluated {
+        result: format!("{} ({cell})", format_address(addr, hex)),
+        kind: "address".to_owned(),
+        memory_reference: Some(addr),
+    })
+}
+
+/// Evaluate an address expression (a register-indexed form or a label /
+/// arithmetic expression) against the live computer state.
+fn eval_address(program: &LoadedProgram, input: &str) -> Result<Address, String> {
+    let arg = parse_addr_arg(input)?;
+    let value: i128 = match arg {
+        AddrArg::Expr(node) => node
+            .evaluate::<_, i128>(&program.labels)
+            .map_err(|e| e.to_string())?,
+        AddrArg::Reg(reg) => i128::from(
+            program
+                .computer
+                .registers
+                .get_word(reg)
+                .map_err(|e| e.to_string())?,
+        ),
+        AddrArg::Indexed(reg, is_plus, node) => {
+            let base = i128::from(
+                program
+                    .computer
+                    .registers
+                    .get_word(reg)
+                    .map_err(|e| e.to_string())?,
+            );
+            let offset: i128 = node
+                .evaluate::<_, i128>(&program.labels)
+                .map_err(|e| e.to_string())?;
+            if is_plus {
+                base + offset
+            } else {
+                base - offset
+            }
+        }
+    };
+    Address::try_from(value).map_err(|_| format!("address out of range: {value}"))
 }
 
 fn enclosing_label(labels: &BTreeMap<String, Address>, address: Address) -> String {
@@ -945,6 +1271,455 @@ fn enclosing_label(labels: &BTreeMap<String, Address>, address: Address) -> Stri
         .filter(|(_, &a)| a <= address)
         .max_by_key(|(_, &a)| a)
         .map_or_else(|| format!("@{address}"), |(name, _)| name.clone())
+}
+
+// --------------------------------------------------------------------------
+// Address-expression parsing (adapted from cli::interactive::parse)
+// --------------------------------------------------------------------------
+
+/// A parsed address expression for `evaluate`'s dereference forms.
+enum AddrArg {
+    /// A plain expression (label / literal / arithmetic).
+    Expr(ExpressionNode),
+    /// A bare register (`%sp`).
+    Reg(Reg),
+    /// A register-indexed form (`%sp+2`, `%a-1`); the bool is `+`.
+    Indexed(Reg, bool, ExpressionNode),
+}
+
+fn parse_addr_arg(input: &str) -> Result<AddrArg, String> {
+    use chumsky::prelude::*;
+
+    use crate::parser::shared::{expression, register};
+
+    let indexed = register()
+        .then(choice((just('+').to(true), just('-').to(false))).then(expression()))
+        .map(|(reg, (is_plus, expr))| AddrArg::Indexed(reg, is_plus, expr));
+
+    let parser = choice((
+        indexed,
+        register().map(AddrArg::Reg),
+        expression().map(AddrArg::Expr),
+    ))
+    .then_ignore(end());
+
+    parser.parse(input).into_result().map_err(|errs| {
+        errs.into_iter()
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join("; ")
+    })
+}
+
+// --------------------------------------------------------------------------
+// Stack scan
+// --------------------------------------------------------------------------
+
+/// Scan the stack for `(slot, target)` pairs that look like return addresses:
+/// a `Word` cell whose value points just past a `call` instruction that maps to
+/// source. Returned in ascending slot order (innermost call first), capped at
+/// [`MAX_FRAMES`].
+fn scan_frames(program: &LoadedProgram) -> Vec<(Address, Address)> {
+    let sp = program.computer.registers.sp;
+    let mut out = Vec::new();
+    for addr in sp..C::STACK_START {
+        if out.len() >= MAX_FRAMES {
+            break;
+        }
+        let Ok(Cell::Word(word)) = program.computer.memory.get(addr) else {
+            continue;
+        };
+        let Ok(target) = Address::try_from(*word) else {
+            continue;
+        };
+        if target == 0 {
+            continue;
+        }
+        let is_return = program
+            .computer
+            .memory
+            .get(target - 1)
+            .ok()
+            .and_then(|c| c.extract_instruction().ok())
+            .is_some_and(|i| matches!(i, Instruction::Call(_)));
+        if is_return && program.index.location(target).is_some() {
+            out.push((addr, target));
+        }
+    }
+    out
+}
+
+/// The return-address slots on the stack, ascending.
+fn scan_return_slots(program: &LoadedProgram) -> Vec<Address> {
+    scan_frames(program)
+        .into_iter()
+        .map(|(slot, _)| slot)
+        .collect()
+}
+
+/// Map of return-address slot → target, for annotating stack cells.
+fn return_slot_targets(program: &LoadedProgram) -> BTreeMap<Address, Address> {
+    scan_frames(program).into_iter().collect()
+}
+
+// --------------------------------------------------------------------------
+// Variable builders for the cell-backed scopes
+// --------------------------------------------------------------------------
+
+fn cell_variable(name: String, addr: Address, cell: &Cell, hex: bool) -> Variable {
+    Variable {
+        name,
+        value: format_cell(cell, hex),
+        kind: Some(cell_type(cell).to_owned()),
+        memory_reference: Some(addr.to_string()),
+        ..Default::default()
+    }
+}
+
+/// Build the top frame's Stack scope, top-of-stack (`sp+0`) first, paged by
+/// `start`/`count`.
+fn stack_variables(
+    program: &LoadedProgram,
+    start: u32,
+    count: Option<u32>,
+    hex: bool,
+) -> Vec<Variable> {
+    let sp = program.computer.registers.sp;
+    let total = C::STACK_START.saturating_sub(sp);
+    let returns = return_slot_targets(program);
+    let limit = count.unwrap_or(DEFAULT_PAGE) as usize;
+    let mut out = Vec::new();
+    for n in start..total {
+        if out.len() >= limit {
+            break;
+        }
+        let addr = sp + n;
+        let Ok(cell) = program.computer.memory.get(addr) else {
+            continue;
+        };
+        let mut var = cell_variable(format!("sp+{n}"), addr, cell, hex);
+        if let Some(&target) = returns.get(&addr) {
+            let label = enclosing_label(&program.labels, target);
+            var.value = format!("{} (return to {label})", var.value);
+            var.presentation_hint = Some(json!({ "kind": "data", "attributes": ["readOnly"] }));
+        }
+        out.push(var);
+    }
+    out
+}
+
+/// Indexed children of a multi-cell global region, paged by `start`/`count`.
+fn global_label_children(
+    program: &LoadedProgram,
+    label: &str,
+    base: Address,
+    len: u32,
+    start: u32,
+    count: Option<u32>,
+    hex: bool,
+) -> Vec<Variable> {
+    let limit = count.unwrap_or(DEFAULT_PAGE) as usize;
+    let mut out = Vec::new();
+    for k in start..len {
+        if out.len() >= limit {
+            break;
+        }
+        let addr = base + k;
+        let Ok(cell) = program.computer.memory.get(addr) else {
+            continue;
+        };
+        out.push(cell_variable(
+            format!("{label}+{k} ({addr})"),
+            addr,
+            cell,
+            hex,
+        ));
+    }
+    out
+}
+
+/// The words a synthesized caller frame pushed, `arg1` (just above the return
+/// slot) first.
+fn frame_stack_variables(
+    program: &LoadedProgram,
+    start_addr: Address,
+    end_addr: Address,
+    start: u32,
+    count: Option<u32>,
+    hex: bool,
+) -> Vec<Variable> {
+    let total = end_addr.saturating_sub(start_addr);
+    let limit = count.unwrap_or(DEFAULT_PAGE) as usize;
+    let mut out = Vec::new();
+    for k in start..total {
+        if out.len() >= limit {
+            break;
+        }
+        let addr = start_addr + k;
+        let Ok(cell) = program.computer.memory.get(addr) else {
+            continue;
+        };
+        out.push(cell_variable(
+            format!("arg{} ({addr})", k + 1),
+            addr,
+            cell,
+            hex,
+        ));
+    }
+    out
+}
+
+/// The label regions `(name, base, len)`, sorted by address, each bounded by
+/// the next label's address and the memory size (at least one cell). The full
+/// `len` is reported as `indexedVariables`; per-request paging (see
+/// [`DEFAULT_PAGE`]) keeps large regions like a 5000-word `.space` responsive.
+fn label_regions(labels: &BTreeMap<String, Address>) -> Vec<(String, Address, u32)> {
+    let mut by_addr: Vec<(Address, String)> = labels.iter().map(|(n, &a)| (a, n.clone())).collect();
+    by_addr.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+
+    let mut out = Vec::with_capacity(by_addr.len());
+    for i in 0..by_addr.len() {
+        let (addr, name) = &by_addr[i];
+        let next = by_addr
+            .get(i + 1)
+            .map_or(C::MEMORY_SIZE, |(a, _)| *a)
+            .max(*addr);
+        let len = (next - addr).max(1);
+        out.push((name.clone(), *addr, len));
+    }
+    out
+}
+
+// --------------------------------------------------------------------------
+// setVariable helpers
+// --------------------------------------------------------------------------
+
+fn set_register(
+    program: &mut LoadedProgram,
+    name: &str,
+    value: &str,
+    hex: bool,
+) -> Result<String, String> {
+    let Some(word) = parse_int(value) else {
+        return Err(format!("invalid integer value '{value}'"));
+    };
+    let reg = match name {
+        "a" => Reg::A,
+        "b" => Reg::B,
+        "pc" => Reg::PC,
+        "sp" => Reg::SP,
+        _ => return Err(format!("cannot set variable '{name}'")),
+    };
+    program
+        .computer
+        .registers
+        .set(reg, Cell::Word(word))
+        .map_err(|e| e.to_string())?;
+    Ok(format_cell(&program.computer.registers.get(&reg), hex))
+}
+
+fn set_cell(
+    program: &mut LoadedProgram,
+    addr: Address,
+    value: &str,
+    hex: bool,
+) -> Result<String, String> {
+    let Some(word) = parse_int(value) else {
+        return Err(format!("invalid integer value '{value}'"));
+    };
+    let cell = program
+        .computer
+        .memory
+        .get_mut(addr)
+        .map_err(|e| e.to_string())?;
+    *cell = Cell::Word(word);
+    Ok(format_word(word, hex))
+}
+
+/// Extract the address from a `... (<decimal>)` variable name suffix.
+fn parse_addr_suffix(name: &str) -> Option<Address> {
+    let inner = name.rsplit_once('(')?.1;
+    let inner = inner.strip_suffix(')')?;
+    inner.trim().parse::<Address>().ok()
+}
+
+// --------------------------------------------------------------------------
+// read/write memory (one cell = one i64 word = 8 bytes little-endian)
+// --------------------------------------------------------------------------
+
+/// A single cell as a word for the byte protocol: `Empty` and `Instruction`
+/// cells read as zero (documented — instructions have no meaningful word
+/// value).
+fn cell_word(cell: &Cell) -> i64 {
+    match cell {
+        Cell::Word(w) => *w,
+        Cell::Empty | Cell::Instruction(_) => 0,
+    }
+}
+
+/// Read `count` bytes starting `offset` bytes past `base` (a cell address).
+/// Returns `(first_cell_address, data, unreadable_trailing_bytes)`.
+fn read_memory(computer: &Computer, base: i64, offset: i64, count: i64) -> (i64, Vec<u8>, i64) {
+    let start_byte = base * CELL_BYTES + offset;
+    let mut data = Vec::new();
+    let mut unreadable = 0;
+    for i in 0..count {
+        let p = start_byte + i;
+        let cell_index = p.div_euclid(CELL_BYTES);
+        let byte_in = usize::try_from(p.rem_euclid(CELL_BYTES)).unwrap_or(0);
+        if p < 0 || cell_index >= i64::from(C::MEMORY_SIZE) {
+            unreadable = count - i;
+            break;
+        }
+        let word = Address::try_from(cell_index)
+            .ok()
+            .and_then(|a| computer.memory.get(a).ok())
+            .map_or(0, cell_word);
+        data.push(word.to_le_bytes()[byte_in]);
+    }
+    (start_byte.div_euclid(CELL_BYTES), data, unreadable)
+}
+
+/// Write `bytes` starting `offset` bytes past `base`. Writes whole 8-byte words
+/// as `Cell::Word`; sub-word (unaligned or partial) writes are rejected unless
+/// `allow_partial`, in which case affected words are read-modified-written.
+fn write_memory(
+    computer: &mut Computer,
+    base: i64,
+    offset: i64,
+    bytes: &[u8],
+    allow_partial: bool,
+) -> Result<usize, String> {
+    let start_byte = base * CELL_BYTES + offset;
+    let len = i64::try_from(bytes.len()).map_err(|_| "data too large".to_owned())?;
+    let aligned = start_byte.rem_euclid(CELL_BYTES) == 0 && len % CELL_BYTES == 0;
+    if !aligned && !allow_partial {
+        return Err(
+            "writeMemory must cover whole 8-byte words (set allowPartial to override)".to_owned(),
+        );
+    }
+    for (i, &byte) in bytes.iter().enumerate() {
+        let p = start_byte + i64::try_from(i).map_err(|_| "data too large".to_owned())?;
+        if p < 0 {
+            return Err("write below address 0".to_owned());
+        }
+        let cell_index = p.div_euclid(CELL_BYTES);
+        let byte_in = usize::try_from(p.rem_euclid(CELL_BYTES)).unwrap_or(0);
+        let addr =
+            Address::try_from(cell_index).map_err(|_| format!("write out of range at byte {p}"))?;
+        let cell = computer.memory.get_mut(addr).map_err(|e| e.to_string())?;
+        let mut word = cell_word(cell).to_le_bytes();
+        word[byte_in] = byte;
+        *cell = Cell::Word(i64::from_le_bytes(word));
+    }
+    Ok(bytes.len())
+}
+
+// --------------------------------------------------------------------------
+// Formatting
+// --------------------------------------------------------------------------
+
+fn format_word(word: i64, hex: bool) -> String {
+    if hex {
+        if word < 0 {
+            format!("-0x{:x}", word.unsigned_abs())
+        } else {
+            format!("0x{word:x}")
+        }
+    } else {
+        word.to_string()
+    }
+}
+
+fn format_address(addr: Address, hex: bool) -> String {
+    if hex {
+        format!("0x{addr:x}")
+    } else {
+        addr.to_string()
+    }
+}
+
+fn format_cell(cell: &Cell, hex: bool) -> String {
+    match cell {
+        Cell::Word(w) => format_word(*w, hex),
+        Cell::Empty => format_word(0, hex),
+        Cell::Instruction(i) => format!("{i}"),
+    }
+}
+
+fn cell_type(cell: &Cell) -> &'static str {
+    match cell {
+        Cell::Instruction(_) => "instruction",
+        Cell::Word(_) => "word",
+        Cell::Empty => "empty",
+    }
+}
+
+// --------------------------------------------------------------------------
+// Base64 (RFC 4648, standard alphabet with padding) — no external dependency
+// --------------------------------------------------------------------------
+
+const B64: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+fn base64_encode(data: &[u8]) -> String {
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b = [
+            chunk[0],
+            *chunk.get(1).unwrap_or(&0),
+            *chunk.get(2).unwrap_or(&0),
+        ];
+        let n = (u32::from(b[0]) << 16) | (u32::from(b[1]) << 8) | u32::from(b[2]);
+        out.push(B64[(n >> 18 & 0x3f) as usize] as char);
+        out.push(B64[(n >> 12 & 0x3f) as usize] as char);
+        out.push(if chunk.len() > 1 {
+            B64[(n >> 6 & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            B64[(n & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+fn base64_decode(input: &str) -> Option<Vec<u8>> {
+    fn val(c: u8) -> Option<u32> {
+        match c {
+            b'A'..=b'Z' => Some(u32::from(c - b'A')),
+            b'a'..=b'z' => Some(u32::from(c - b'a' + 26)),
+            b'0'..=b'9' => Some(u32::from(c - b'0' + 52)),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    }
+    let cleaned: Vec<u8> = input.bytes().filter(|b| !b.is_ascii_whitespace()).collect();
+    let mut out = Vec::new();
+    for chunk in cleaned.chunks(4) {
+        if chunk.len() < 2 {
+            return None;
+        }
+        let pad = chunk.iter().rev().take_while(|&&c| c == b'=').count();
+        let mut n = 0u32;
+        for &c in chunk {
+            n = (n << 6) | if c == b'=' { 0 } else { val(c)? };
+        }
+        // The four sextets pack into the low 24 bits; big-endian bytes 1..=3
+        // are the decoded output.
+        let [_, hi, mid, lo] = n.to_be_bytes();
+        out.push(hi);
+        if pad < 2 {
+            out.push(mid);
+        }
+        if pad < 1 {
+            out.push(lo);
+        }
+    }
+    Some(out)
 }
 
 fn parse_int(input: &str) -> Option<i64> {

--- a/emulator/src/dap/protocol.rs
+++ b/emulator/src/dap/protocol.rs
@@ -40,6 +40,8 @@ pub struct Capabilities {
     /// always exactly one instruction, so the granularities are
     /// indistinguishable.
     pub supports_stepping_granularity: bool,
+    pub supports_read_memory_request: bool,
+    pub supports_write_memory_request: bool,
 }
 
 impl Default for Capabilities {
@@ -51,8 +53,18 @@ impl Default for Capabilities {
             supports_restart_request: true,
             supports_terminate_request: true,
             supports_stepping_granularity: false,
+            supports_read_memory_request: true,
+            supports_write_memory_request: true,
         }
     }
+}
+
+/// A value-formatting hint carried by `variables`, `evaluate` and
+/// `setVariable`. Only the `hex` flag is honoured.
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+pub struct ValueFormat {
+    #[serde(default)]
+    pub hex: bool,
 }
 
 /// A source reference (subset).
@@ -123,16 +135,22 @@ pub struct StackFrame {
 }
 
 /// A variable scope.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Scope {
     pub name: String,
     pub variables_reference: i64,
     pub expensive: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub named_variables: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indexed_variables: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub presentation_hint: Option<String>,
 }
 
 /// A single variable.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Variable {
     pub name: String,
@@ -140,13 +158,35 @@ pub struct Variable {
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
     pub variables_reference: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_reference: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub named_variables: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indexed_variables: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub presentation_hint: Option<Value>,
 }
 
-/// Arguments carrying only a `variablesReference`.
+/// Arguments to `scopes`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScopesArguments {
+    #[serde(default)]
+    pub frame_id: i64,
+}
+
+/// Arguments to `variables`.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VariablesArguments {
     pub variables_reference: i64,
+    #[serde(default)]
+    pub start: Option<i64>,
+    #[serde(default)]
+    pub count: Option<i64>,
+    #[serde(default)]
+    pub format: Option<ValueFormat>,
 }
 
 /// Arguments to `setVariable`.
@@ -156,6 +196,8 @@ pub struct SetVariableArguments {
     pub variables_reference: i64,
     pub name: String,
     pub value: String,
+    #[serde(default)]
+    pub format: Option<ValueFormat>,
 }
 
 /// Arguments to `evaluate`.
@@ -165,6 +207,30 @@ pub struct EvaluateArguments {
     #[serde(default)]
     #[allow(dead_code)]
     pub context: Option<String>,
+    #[serde(default)]
+    pub format: Option<ValueFormat>,
+}
+
+/// Arguments to `readMemory`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReadMemoryArguments {
+    pub memory_reference: String,
+    #[serde(default)]
+    pub offset: i64,
+    pub count: i64,
+}
+
+/// Arguments to `writeMemory`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WriteMemoryArguments {
+    pub memory_reference: String,
+    #[serde(default)]
+    pub offset: i64,
+    pub data: String,
+    #[serde(default)]
+    pub allow_partial: bool,
 }
 
 /// Arguments to `source`.

--- a/emulator/src/dap/tests.rs
+++ b/emulator/src/dap/tests.rs
@@ -494,6 +494,360 @@ fn continue_after_termination_is_rejected() {
     assert!(!h.session.is_running());
 }
 
+/// A program exercising the globals scope: code labels, a single `.word`, a
+/// multi-cell `.word` region and a larger `.space` array for paging.
+const GLOBALS_SOURCE: &str = indoc::indoc! {r"
+    main:
+        reset
+
+    value:
+        .word 42
+
+    array:
+        .word 1
+        .word 2
+        .word 3
+
+    tail:
+        .word 99
+
+    big:
+        .space 300
+
+    last:
+        .word 7
+"};
+
+/// Launch the globals program, stopped on entry.
+fn launch_globals(h: &mut Harness) {
+    h.send("initialize", json!({}));
+    h.send(
+        "launch",
+        json!({
+            "program": "/g.s",
+            "entrypoint": "main",
+            "stopOnEntry": true,
+            "files": { "/g.s": GLOBALS_SOURCE },
+        }),
+    );
+    h.send("configurationDone", json!({}));
+}
+
+/// Fetch the scopes for a frame and return the `variablesReference` of the
+/// scope with the given name.
+fn scope_ref(h: &mut Harness, frame_id: i64, name: &str) -> i64 {
+    let out = h.send("scopes", json!({ "frameId": frame_id }));
+    let resp = find_response(&out, "scopes").expect("scopes response");
+    resp["body"]["scopes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["name"] == name)
+        .unwrap_or_else(|| panic!("scope {name} present"))["variablesReference"]
+        .as_i64()
+        .unwrap()
+}
+
+/// Fetch the variables for a reference (optionally paged) as an array.
+fn variables(h: &mut Harness, reference: i64, extra: Value) -> Vec<Value> {
+    let mut args = json!({ "variablesReference": reference });
+    if let Value::Object(map) = extra {
+        for (k, v) in map {
+            args[k] = v;
+        }
+    }
+    let out = h.send("variables", args);
+    let resp = find_response(&out, "variables").expect("variables response");
+    resp["body"]["variables"].as_array().cloned().unwrap()
+}
+
+/// Find a variable by name in a list.
+fn var<'a>(vars: &'a [Value], name: &str) -> &'a Value {
+    vars.iter()
+        .find(|v| v["name"] == name)
+        .unwrap_or_else(|| panic!("variable {name} present"))
+}
+
+/// Break inside `factorielle` (line 8, `cmp 1,%a`) and stop there.
+fn stop_in_factorielle(h: &mut Harness) {
+    h.launch(true);
+    h.send(
+        "setBreakpoints",
+        json!({ "source": { "path": "/fact.s" }, "breakpoints": [{ "line": 8 }] }),
+    );
+    h.send("continue", json!({ "threadId": 1 }));
+    let events = h.drive();
+    assert_eq!(
+        find_event(&events, "stopped").expect("stopped")["body"]["reason"],
+        json!("breakpoint")
+    );
+}
+
+#[test]
+fn stack_scope_shows_pushed_arguments() {
+    let mut h = Harness::new();
+    stop_in_factorielle(&mut h);
+
+    let stack = scope_ref(&mut h, 0, "Stack");
+    let vars = variables(&mut h, stack, json!({}));
+
+    // Top of stack is the return address into main; just above it is the
+    // pushed argument (5).
+    let sp0 = var(&vars, "sp+0");
+    assert!(
+        sp0["value"].as_str().unwrap().contains("return to main"),
+        "sp+0 = {}",
+        sp0["value"]
+    );
+    assert!(sp0["memoryReference"].is_string());
+
+    let sp1 = var(&vars, "sp+1");
+    assert_eq!(sp1["value"], json!("5"));
+    assert!(sp1["memoryReference"].is_string());
+}
+
+#[test]
+fn caller_frame_has_frame_stack_scope() {
+    let mut h = Harness::new();
+    stop_in_factorielle(&mut h);
+
+    // Frame 0 is factorielle; frame 1 is its caller (main). main pushed the
+    // argument 5 for the call, exposed by the best-effort Frame stack scope.
+    let st = h.send("stackTrace", json!({ "threadId": 1 }));
+    let frames = find_response(&st, "stackTrace").unwrap()["body"]["stackFrames"]
+        .as_array()
+        .unwrap()
+        .len();
+    assert!(frames >= 2, "expected a synthesized caller frame");
+
+    let fs = scope_ref(&mut h, 1, "Frame stack");
+    let vars = variables(&mut h, fs, json!({}));
+    assert_eq!(var(&vars, "arg1 (9999)")["value"], json!("5"));
+}
+
+#[test]
+fn globals_scope_single_and_multi_cell() {
+    let mut h = Harness::new();
+    launch_globals(&mut h);
+
+    let globals = scope_ref(&mut h, 0, "Globals");
+    let vars = variables(&mut h, globals, json!({}));
+
+    // Single-cell data label.
+    let value = var(&vars, "value");
+    assert_eq!(value["value"], json!("42"));
+    assert_eq!(value["type"], json!("word"));
+    assert_eq!(value["variablesReference"], json!(0));
+    assert!(value["memoryReference"].is_string());
+
+    // Single-cell code label renders the instruction.
+    assert_eq!(var(&vars, "main")["type"], json!("instruction"));
+
+    // Multi-cell region expands and reports its length.
+    let array = var(&vars, "array");
+    assert_eq!(array["indexedVariables"], json!(3));
+    let array_ref = array["variablesReference"].as_i64().unwrap();
+    assert!(array_ref >= 1000, "multi-cell region gets a dynamic handle");
+
+    let children = variables(&mut h, array_ref, json!({}));
+    assert_eq!(children.len(), 3);
+    assert_eq!(children[0]["value"], json!("1"));
+    assert_eq!(children[1]["value"], json!("2"));
+    assert_eq!(children[2]["value"], json!("3"));
+
+    // Paging: start/count are honoured.
+    let page = variables(&mut h, array_ref, json!({ "start": 1, "count": 1 }));
+    assert_eq!(page.len(), 1);
+    assert_eq!(page[0]["value"], json!("2"));
+
+    // A large .space is paged (default page cap), not dumped whole.
+    let big = var(&vars, "big");
+    assert_eq!(big["indexedVariables"], json!(300));
+    let big_ref = big["variablesReference"].as_i64().unwrap();
+    let big_children = variables(&mut h, big_ref, json!({}));
+    assert_eq!(
+        big_children.len(),
+        256,
+        "default page size caps the response"
+    );
+}
+
+#[test]
+fn set_variable_writes_stack_and_global_cells() {
+    let mut h = Harness::new();
+    // Global cell.
+    launch_globals(&mut h);
+    let globals = scope_ref(&mut h, 0, "Globals");
+    let resp = h.send(
+        "setVariable",
+        json!({ "variablesReference": globals, "name": "value", "value": "1234" }),
+    );
+    let resp = find_response(&resp, "setVariable").expect("setVariable response");
+    assert_eq!(resp["success"], json!(true));
+    assert_eq!(resp["body"]["value"], json!("1234"));
+    // Verify via evaluate.
+    let ev = h.send("evaluate", json!({ "expression": "[value]" }));
+    assert!(find_response(&ev, "evaluate").unwrap()["body"]["result"]
+        .as_str()
+        .unwrap()
+        .starts_with("1234"));
+
+    // Stack cell.
+    let mut h = Harness::new();
+    stop_in_factorielle(&mut h);
+    let stack = scope_ref(&mut h, 0, "Stack");
+    let resp = h.send(
+        "setVariable",
+        json!({ "variablesReference": stack, "name": "sp+1", "value": "77" }),
+    );
+    assert_eq!(
+        find_response(&resp, "setVariable").unwrap()["body"]["value"],
+        json!("77")
+    );
+    let ev = h.send("evaluate", json!({ "expression": "[%sp+1]" }));
+    assert_eq!(
+        find_response(&ev, "evaluate").unwrap()["body"]["result"],
+        json!("77 (9999)")
+    );
+}
+
+#[test]
+fn evaluate_dereference_and_arithmetic() {
+    let mut h = Harness::new();
+    launch_globals(&mut h);
+
+    // `[array]` and `[array+1]` dereference memory.
+    let d0 = h.send("evaluate", json!({ "expression": "[array]" }));
+    assert_eq!(
+        find_response(&d0, "evaluate").unwrap()["body"]["result"]
+            .as_str()
+            .unwrap()
+            .split_whitespace()
+            .next()
+            .unwrap(),
+        "1"
+    );
+    let d1 = h.send("evaluate", json!({ "expression": "[array+1]" }));
+    let r1 = find_response(&d1, "evaluate").unwrap();
+    assert_eq!(
+        r1["body"]["result"]
+            .as_str()
+            .unwrap()
+            .split_whitespace()
+            .next()
+            .unwrap(),
+        "2"
+    );
+    assert!(r1["body"]["memoryReference"].is_string());
+
+    // Bare `array+2` evaluates to the address value.
+    let a = h.send("evaluate", json!({ "expression": "array+2" }));
+    let ra = find_response(&a, "evaluate").unwrap();
+    assert_eq!(ra["body"]["type"], json!("address"));
+    assert!(ra["body"]["memoryReference"].is_string());
+}
+
+#[test]
+fn evaluate_register_indexed_dereference() {
+    let mut h = Harness::new();
+    stop_in_factorielle(&mut h);
+    // `[%sp+1]` is the pushed argument, 5.
+    let ev = h.send("evaluate", json!({ "expression": "[%sp+1]" }));
+    assert_eq!(
+        find_response(&ev, "evaluate").unwrap()["body"]["result"],
+        json!("5 (9999)")
+    );
+}
+
+#[test]
+fn read_and_write_memory_roundtrip() {
+    let mut h = Harness::new();
+    launch_globals(&mut h);
+    // Resolve the address of `value` (holds 42).
+    let ev = h.send("evaluate", json!({ "expression": "value" }));
+    let mref = find_response(&ev, "evaluate").unwrap()["body"]["memoryReference"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+
+    // Read one cell (8 bytes): little-endian 42.
+    let rd = h.send(
+        "readMemory",
+        json!({ "memoryReference": mref, "offset": 0, "count": 8 }),
+    );
+    let data = find_response(&rd, "readMemory").unwrap()["body"]["data"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    // base64 of 42u64 little-endian = "KgAAAAAAAAA=".
+    assert_eq!(data, "KgAAAAAAAAA=");
+
+    // Write 0x0100 = 256 into that cell and read it back.
+    let wr = h.send(
+        "writeMemory",
+        json!({ "memoryReference": mref, "offset": 0, "data": "AAEAAAAAAAA=" }),
+    );
+    assert_eq!(
+        find_response(&wr, "writeMemory").unwrap()["body"]["bytesWritten"],
+        json!(8)
+    );
+    let ev = h.send("evaluate", json!({ "expression": "[value]" }));
+    assert!(find_response(&ev, "evaluate").unwrap()["body"]["result"]
+        .as_str()
+        .unwrap()
+        .starts_with("256"));
+
+    // Offset conversion: reading the next cell via a byte offset of 8 sees
+    // `array`'s first word (1).
+    let rd2 = h.send(
+        "readMemory",
+        json!({ "memoryReference": mref, "offset": 8, "count": 8 }),
+    );
+    assert_eq!(
+        find_response(&rd2, "readMemory").unwrap()["body"]["data"],
+        json!("AQAAAAAAAAA=")
+    );
+}
+
+#[test]
+fn hex_format_rendering() {
+    let mut h = Harness::new();
+    launch_globals(&mut h);
+    let globals = scope_ref(&mut h, 0, "Globals");
+    let vars = variables(&mut h, globals, json!({ "format": { "hex": true } }));
+    // 42 == 0x2a.
+    assert_eq!(var(&vars, "value")["value"], json!("0x2a"));
+
+    // evaluate also honours the hex format.
+    let ev = h.send(
+        "evaluate",
+        json!({ "expression": "0x2a", "format": { "hex": true } }),
+    );
+    assert_eq!(
+        find_response(&ev, "evaluate").unwrap()["body"]["result"],
+        json!("0x2a")
+    );
+}
+
+#[test]
+fn handles_invalidated_after_resume() {
+    let mut h = Harness::new();
+    launch_globals(&mut h);
+    let globals = scope_ref(&mut h, 0, "Globals");
+    let vars = variables(&mut h, globals, json!({}));
+    let array_ref = var(&vars, "array")["variablesReference"].as_i64().unwrap();
+    // Valid while stopped.
+    assert_eq!(variables(&mut h, array_ref, json!({})).len(), 3);
+
+    // Resume; the dynamic handle is now stale and returns an empty list.
+    h.send("continue", json!({ "threadId": 1 }));
+    h.drive();
+    // Relaunch a stop so the session is inspectable again would allocate fresh
+    // handles; the OLD handle must not resolve.
+    let stale = variables(&mut h, array_ref, json!({}));
+    assert!(stale.is_empty(), "stale handle must return no variables");
+}
+
 /// Extract a register's string value from a `variables` response.
 fn register_value(messages: &[Value], name: &str) -> String {
     let resp = find_response(messages, "variables").expect("variables response");


### PR DESCRIPTION
Part 3/9 — stacked on pr2-dap.

Rich memory inspection for the DAP:
- **Stack scope**: `sp+0…` top-first with addresses; return cells annotated `(return to <label>)`; paged.
- **Globals scope**: one variable per label; multi-cell regions (`.word` arrays, `.space`) expand with paging.
- **Frame stack** scope on synthesized caller frames (the words each frame pushed).
- `setVariable` writes stack/global cells; `evaluate` gains `[label]`, `[label+2]`, `[%sp+1]` dereferences and bare address arithmetic.
- `readMemory`/`writeMemory` + `memoryReference` everywhere → VS Code Memory Inspector works (1 cell = 8-byte LE i64). Hex `ValueFormat` honored.

Verified: 24 DAP tests + live harness showing 5→4→3 recursion arguments across fact.s frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
