### PR TITLE
Fix CI on main: anyhow RUSTSEC bump + drift-proof zizmor ignores

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -45,7 +45,8 @@ jobs:
           rustup target add ${{ matrix.arch }}-apple-darwin
 
       - name: Setup Rust build cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        # save-if below restricts cache writes to the main branch
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1 # zizmor: ignore[cache-poisoning]
         with:
           shared-key: ${{ matrix.arch }}-macos
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -95,7 +96,8 @@ jobs:
           rustup target add ${{ matrix.arch }}-unknown-linux-musl
 
       - name: Setup Rust build cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        # save-if below restricts cache writes to the main branch
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1 # zizmor: ignore[cache-poisoning]
         with:
           shared-key: ${{ matrix.arch }}-linux
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -146,7 +148,8 @@ jobs:
           rustup target add ${{ matrix.arch }}-pc-windows-msvc
 
       - name: Setup Rust build cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        # save-if below restricts cache writes to the main branch
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1 # zizmor: ignore[cache-poisoning]
         with:
           shared-key: ${{ matrix.arch }}-pc-windows-msvc
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -198,7 +201,8 @@ jobs:
           mv ./artifacts/{x86_64,aarch64}-{linux,macos,windows}/* ./
 
       - name: Prepare a release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        # preferred over gh CLI for declarative release publishing
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0 # zizmor: ignore[superfluous-actions]
         with:
           files: |
             z33-cli-x86_64-linux.tar.gz

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,11 +1,6 @@
-rules:
-  cache-poisoning:
-    ignore:
-      # save-if restricts cache writes to main branch only
-      - compile.yaml:48
-      - compile.yaml:98
-      - compile.yaml:149
-  superfluous-actions:
-    ignore:
-      # softprops/action-gh-release is preferred over gh CLI for declarative release publishing
-      - compile.yaml:201
+# $schema: https://raw.githubusercontent.com/zizmorcore/zizmor/main/docs/schemas/config.schema.json
+#
+# Findings are suppressed with inline `# zizmor: ignore[rule]` comments next to
+# the relevant lines, so they survive line-number drift. This file only exists
+# to keep a stable location for future repo-wide configuration.
+rules: {}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-trait"


### PR DESCRIPTION
`main` went red after #937: the `cargo deny` job trips RUSTSEC-2026-0190 (anyhow unsound `downcast_mut`, advisory published after the last green run). This bumps anyhow to 1.0.103.

Also makes the zizmor suppressions drift-proof: `.github/zizmor.yml` pinned ignores to exact line numbers (`compile.yaml:98`, `:149`), which silently break whenever lines shift — replaced with inline `# zizmor: ignore[rule]` comments on the flagged lines. Verified locally: zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
