### PR TITLE
CI: automate the release flow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -2,6 +2,10 @@ on:
   push:
     branches: [main]
   pull_request:
+  # The Release workflow dispatches this one on release branches: PRs opened
+  # with GITHUB_TOKEN don't trigger `pull_request` events, so the required
+  # status checks have to be started explicitly.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -3,6 +3,10 @@ on:
     branches: [main]
     tags: ["v*"]
   pull_request:
+  # The Release workflow dispatches this one on release branches (to satisfy
+  # the required status checks) and on fresh tags (to build and publish),
+  # because events created with GITHUB_TOKEN don't trigger workflows.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -263,6 +267,20 @@ jobs:
       contents: write # Required by softprops/action-gh-release to create releases
 
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Check that the tag matches the project version
+        run: |
+          VERSION="$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)"
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [ "$TAG" != "v$VERSION" ]; then
+            echo "::error::tag $TAG does not match the project version $VERSION"
+            exit 1
+          fi
+
       - name: Download the artifacts from the previous job
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -273,17 +291,25 @@ jobs:
           mv ./artifacts/{x86_64,aarch64}-{linux,macos,windows}/* ./
           mv ./artifacts/vscode-extension/z33-assembly.vsix ./artifacts/zed-extension/z33-zed.wasm ./
 
-      - name: Prepare a release
-        # preferred over gh CLI for declarative release publishing
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1 # zizmor: ignore[superfluous-actions]
-        with:
-          files: |
-            z33-cli-x86_64-linux.tar.gz
-            z33-cli-aarch64-linux.tar.gz
-            z33-cli-x86_64-macos.tar.gz
-            z33-cli-aarch64-macos.tar.gz
-            z33-cli-x86_64-windows.exe
-            z33-cli-aarch64-windows.exe
-            z33-assembly.vsix
-            z33-zed.wasm
-          draft: true
+      - name: Generate the checksums
+        run: sha256sum z33-cli-* z33-assembly.vsix z33-zed.wasm > SHA256SUMS
+
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release create "$TAG" \
+            --verify-tag \
+            --title "$TAG" \
+            --generate-notes \
+            --latest \
+            z33-cli-x86_64-linux.tar.gz \
+            z33-cli-aarch64-linux.tar.gz \
+            z33-cli-x86_64-macos.tar.gz \
+            z33-cli-aarch64-macos.tar.gz \
+            z33-cli-x86_64-windows.exe \
+            z33-cli-aarch64-windows.exe \
+            z33-assembly.vsix \
+            z33-zed.wasm \
+            SHA256SUMS

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,178 @@
+name: Release
+
+# Two-phase release flow, designed around the main-branch ruleset (PRs
+# required, signed commits, required status checks):
+#
+#  1. `cut` (manual): bumps every manifest via scripts/set-version.sh, pushes
+#     a `release/vX.Y.Z` branch with a GitHub-signed commit (created through
+#     the GraphQL API, so it satisfies the signature requirement), opens a
+#     pull request, and dispatches the CI workflows on the branch — PRs
+#     opened by GITHUB_TOKEN don't trigger `pull_request` events, so the
+#     required checks have to be started explicitly.
+#
+#  2. `tag` (automatic): when the release PR merges, tags the merge commit
+#     and dispatches the Compile workflow on the tag, which builds all the
+#     artifacts and publishes the GitHub release.
+
+on:
+  # Always dispatch `cut` on main: the release branch is created from the ref
+  # the workflow runs on.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (MAJOR.MINOR.PATCH, no leading v)"
+        required: true
+        type: string
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  cut:
+    name: Open the release pull request
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write # create the release branch and its commit
+      pull-requests: write # open the release PR
+      actions: write # dispatch CI on the release branch
+    env:
+      GH_TOKEN: ${{ github.token }}
+      VERSION: ${{ inputs.version }}
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Validate the requested version
+        run: |
+          if ! grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' <<<"$VERSION"; then
+            echo "::error::version must be MAJOR.MINOR.PATCH without a leading v (got '$VERSION')"
+            exit 1
+          fi
+          if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/v$VERSION" >/dev/null 2>&1; then
+            echo "::error::tag v$VERSION already exists"
+            exit 1
+          fi
+
+      - name: Bump the versions
+        run: scripts/set-version.sh "$VERSION"
+
+      - name: Create the release branch
+        # A leftover branch from a previously failed run is reset instead of
+        # failing, so the job can simply be re-run.
+        run: |
+          if ! gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/heads/release/v$VERSION" \
+            -f sha="$GITHUB_SHA" 2>/dev/null; then
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/git/refs/heads/release/v$VERSION" \
+              -f sha="$GITHUB_SHA" -F force=true
+          fi
+
+      - name: Commit the bumps on the release branch
+        # createCommitOnBranch produces a commit signed by GitHub, which the
+        # required-signatures rule on main accepts once the PR merges.
+        # File contents go through temp files (--rawfile / --slurpfile), not
+        # command-line arguments: the base64 of the generated parser alone is
+        # close to the kernel's 128 KiB per-argument limit.
+        run: |
+          ADDITIONS="$(mktemp)"
+          CONTENTS="$(mktemp)"
+          PAYLOAD="$(mktemp)"
+          echo '[]' >"$ADDITIONS"
+          for file in \
+            Cargo.toml \
+            Cargo.lock \
+            vscode/package.json \
+            zed/extension.toml \
+            tree-sitter-z33/package.json \
+            tree-sitter-z33/tree-sitter.json \
+            tree-sitter-z33/src/parser.c; do
+            base64 -w0 "$file" >"$CONTENTS"
+            jq \
+              --arg path "$file" \
+              --rawfile contents "$CONTENTS" \
+              '. + [{path: $path, contents: $contents}]' \
+              "$ADDITIONS" >"$ADDITIONS.next"
+            mv "$ADDITIONS.next" "$ADDITIONS"
+          done
+          jq -n \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg branch "release/v$VERSION" \
+            --arg headline "Release v$VERSION" \
+            --arg oid "$GITHUB_SHA" \
+            --slurpfile additions "$ADDITIONS" \
+            '{
+              query: "mutation ($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+              variables: {input: {
+                branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+                message: {headline: $headline},
+                expectedHeadOid: $oid,
+                fileChanges: {additions: $additions[0]}
+              }}
+            }' >"$PAYLOAD"
+          gh api graphql --input "$PAYLOAD"
+
+      - name: Open the release pull request
+        run: |
+          if [ -n "$(gh pr list --head "release/v$VERSION" --state open --json number --jq '.[].number')" ]; then
+            echo "release PR already open"
+            exit 0
+          fi
+          BODY="$(printf 'Bumps every manifest to %s.\n\nMerging this pull request tags the merge commit as v%s and publishes the release automatically.' "$VERSION" "$VERSION")"
+          gh pr create \
+            --base main \
+            --head "release/v$VERSION" \
+            --title "Release v$VERSION" \
+            --body "$BODY"
+
+      - name: Dispatch CI on the release branch
+        run: |
+          gh workflow run check.yaml --ref "release/v$VERSION"
+          gh workflow run compile.yaml --ref "release/v$VERSION"
+
+  tag:
+    name: Tag the merged release
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write # create the tag, delete the release branch
+      actions: write # dispatch the build on the tag
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+
+    steps:
+      - name: Create the tag
+        # Tolerates a tag left behind by a previously failed run (as long as
+        # it points at the same commit), so the job can simply be re-run.
+        run: |
+          TAG="${HEAD_REF#release/}"
+          if ! gh api "repos/$GH_REPO/git/refs" \
+            -f ref="refs/tags/$TAG" \
+            -f sha="$MERGE_SHA" 2>/dev/null; then
+            EXISTING="$(gh api "repos/$GH_REPO/git/ref/tags/$TAG" --jq .object.sha)"
+            if [ "$EXISTING" != "$MERGE_SHA" ]; then
+              echo "::error::tag $TAG already exists and points at $EXISTING, not $MERGE_SHA"
+              exit 1
+            fi
+          fi
+
+      - name: Dispatch the build on the tag
+        # Tags created with GITHUB_TOKEN don't trigger `push` workflows, so
+        # the Compile workflow (build + publish) is dispatched explicitly.
+        run: |
+          TAG="${HEAD_REF#release/}"
+          gh workflow run compile.yaml --ref "refs/tags/$TAG"
+
+      - name: Delete the release branch
+        run: gh api -X DELETE "repos/$GH_REPO/git/refs/heads/$HEAD_REF" || true

--- a/README.md
+++ b/README.md
@@ -64,40 +64,16 @@ cargo build --release
 
 ## Releasing
 
-Releasing a new version is done by running doing the following steps:
+Releases are cut from the GitHub Actions UI:
 
- - Change the crate version in the `Cargo.toml`. This can be automated using [`cargo-edit`](https://github.com/killercup/cargo-edit):
-   ```sh
-   # Edit the bump flag accordingly
-   cargo set-version --bump patch
-   # Crate version can be extracted like that
-   VERSION="v$(cargo metadata --format-version=1 | jq -r '.packages[] | select(.name == "z33-cli").version')"
-   ```
- - Commit the changes
-   ```sh
-   git commit -m "${VERSION}" ./Cargo.lock ./Cargo.toml
-   git push
-   ```
- - Create a new git tag and push it
-   ```sh
-   git tag -s "${VERSION}"
-   git push --tags
-   ```
- - Wait for the CI to create the draft GitHub release
- - Finish the release from the GitHub interface
-
-<details><summary>Full script</summary>
-
-```sh
-cargo set-version --bump patch
-VERSION="v$(cargo metadata --format-version=1 | jq -r '.packages[] | select(.name == "z33-cli").version')"
-git commit -m "${VERSION}" ./Cargo.lock ./Cargo.toml
-git push
-git tag -s "${VERSION}"
-git push --tags
-```
-
-</details>
+ 1. Run the **Release** workflow on `main` with the new version number
+    (e.g. `0.8.0`). It bumps every manifest (workspace crates, VS Code
+    extension, Zed extension, tree-sitter grammar) through
+    `scripts/set-version.sh` and opens a `Release vX.Y.Z` pull request
+    with CI running on it.
+ 2. Merge the pull request. The merge commit is tagged automatically,
+    the binaries and extensions are built, and the GitHub release is
+    published with generated notes and a `SHA256SUMS` file.
 
 # License
 

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Sets the project version across every shipped manifest:
+#   - Cargo.toml [workspace.package] (inherited by all crates) + Cargo.lock
+#   - vscode/package.json (the VS Code extension)
+#   - zed/extension.toml (the Zed extension), whose pinned tree-sitter
+#     grammar `rev` is also refreshed to the current HEAD
+#   - tree-sitter-z33/package.json and tree-sitter.json (the grammar),
+#     plus the committed generated parser, which embeds that version
+#
+# Usage: scripts/set-version.sh <version>    e.g. scripts/set-version.sh 0.8.0
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <version>" >&2
+  exit 1
+fi
+
+VERSION="$1"
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: version must be MAJOR.MINOR.PATCH without a leading v (got '$VERSION')" >&2
+  exit 1
+fi
+
+cd "$(dirname "$0")/.."
+
+GRAMMAR_REV="$(git rev-parse HEAD)"
+export VERSION GRAMMAR_REV
+
+# The first `version = "…"` line is the [workspace.package] one.
+perl -0777 -pi -e 's/^version = "[^"]+"/version = "$ENV{VERSION}"/m' Cargo.toml
+
+perl -0777 -pi -e '
+  s/^version = "[^"]+"/version = "$ENV{VERSION}"/m;
+  s/^rev = "[0-9a-f]+"/rev = "$ENV{GRAMMAR_REV}"/m;
+' zed/extension.toml
+
+(cd vscode && npm pkg set version="$VERSION")
+(cd tree-sitter-z33 && npm pkg set version="$VERSION")
+
+TMP="$(mktemp)"
+jq --arg version "$VERSION" '.metadata.version = $version' \
+  tree-sitter-z33/tree-sitter.json >"$TMP"
+mv "$TMP" tree-sitter-z33/tree-sitter.json
+
+# The generated parser embeds the tree-sitter.json version, and CI asserts
+# that the committed src/ matches a fresh `tree-sitter generate`.
+(
+  cd tree-sitter-z33 &&
+    npm install --no-audit --no-fund >/dev/null &&
+    npx tree-sitter generate
+)
+
+cargo update --workspace --quiet
+
+echo "Set version $VERSION (grammar rev $GRAMMAR_REV)"

--- a/tree-sitter-z33/package-lock.json
+++ b/tree-sitter-z33/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "tree-sitter-z33",
+  "version": "0.7.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tree-sitter-z33",
+      "version": "0.7.0",
+      "license": "MIT",
+      "devDependencies": {
+        "tree-sitter-cli": "^0.26.0"
+      }
+    },
+    "node_modules/tree-sitter-cli": {
+      "version": "0.26.10",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.26.10.tgz",
+      "integrity": "sha512-RTse32x5YWOrEtH7wos8ODt3yyB7SKgmGN70jC7R+WcnDA64vrpYU98+LnwrwdXMlxgr0LGQdezZz85DN8Wv0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "tree-sitter": "cli.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    }
+  }
+}

--- a/tree-sitter-z33/package.json
+++ b/tree-sitter-z33/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-z33",
-  "version": "0.0.1",
+  "version": "0.7.0",
   "private": true,
   "description": "Z33 (Zorglub-33) assembly grammar for tree-sitter",
   "repository": "https://github.com/sandhose/z33-emulator",

--- a/tree-sitter-z33/src/parser.c
+++ b/tree-sitter-z33/src/parser.c
@@ -2835,8 +2835,8 @@ TS_PUBLIC const TSLanguage *tree_sitter_z33(void) {
     .max_reserved_word_set_size = 0,
     .metadata = {
       .major_version = 0,
-      .minor_version = 0,
-      .patch_version = 1,
+      .minor_version = 7,
+      .patch_version = 0,
     },
   };
   return &language;

--- a/tree-sitter-z33/tree-sitter.json
+++ b/tree-sitter-z33/tree-sitter.json
@@ -17,7 +17,7 @@
     }
   ],
   "metadata": {
-    "version": "0.0.1",
+    "version": "0.7.0",
     "license": "MIT",
     "description": "Z33 (Zorglub-33) assembly grammar for tree-sitter",
     "authors": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "z33-assembly",
   "displayName": "Z33 Assembly",
   "description": "Z33 (Zorglub-33) assembly language support",
-  "version": "0.0.1",
+  "version": "0.7.0",
   "publisher": "sandhose",
   "license": "MIT",
   "repository": {

--- a/zed/extension.toml
+++ b/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "z33"
 name = "Z33 Assembly"
-version = "0.0.1"
+version = "0.7.0"
 schema_version = 1
 authors = ["Quentin Gliech <gliech@unistra.fr>"]
 description = "Z33 (Zorglub-33) assembly language support"
@@ -20,5 +20,5 @@ languages = ["Z33 Assembly"]
 # (the placeholder below will not resolve until then).
 [grammars.z33]
 repository = "https://github.com/sandhose/z33-emulator"
-rev = "0000000000000000000000000000000000000000"
+rev = "517cd6d6b1e4db9512df706abf1250726c318101"
 path = "tree-sitter-z33"


### PR DESCRIPTION
Releasing was fully manual: bump versions by hand, push a `v*` tag, then publish the draft release CI prepared — and the extension manifests were never bumped at all (everything outside the workspace sat at 0.0.1).

This adds a two-phase **Release** workflow driven from the Actions UI, designed around the main-branch ruleset (PRs required, signed commits, required status checks):

**1. `cut`** (run from the Actions tab with a version input, e.g. `0.8.0`):
- bumps every shipped manifest via the new `scripts/set-version.sh`: workspace `Cargo.toml` + `Cargo.lock`, `vscode/package.json`, `zed/extension.toml` (including refreshing the pinned tree-sitter grammar `rev` to the current HEAD), and `tree-sitter-z33/{package,tree-sitter}.json`;
- pushes a `release/vX.Y.Z` branch whose commit is created through GraphQL `createCommitOnBranch`, so it is **signed by GitHub** and satisfies the required-signatures rule when the merge commit lands;
- opens the release PR and **dispatches `check.yaml` + `compile.yaml` on the branch** — PRs opened with `GITHUB_TOKEN` don't trigger `pull_request` events, so the required status checks are started explicitly (both workflows gain a `workflow_dispatch` trigger).

**2. `tag`** (fires automatically when the release PR merges): tags the merge commit, dispatches the Compile workflow on the tag (tags created with `GITHUB_TOKEN` don't trigger `push` workflows), and deletes the release branch.

The publish job now: verifies the tag matches the workspace version, attaches a `SHA256SUMS` asset, and **publishes directly with `gh release create`** (generated notes, `--latest`, `--verify-tag`) — the `softprops/action-gh-release` action is dropped, and no more draft step (the Zed extension's `latest_github_release`-based CLI download can't see drafts).

**All manifests are synced to the current 0.7.0 in this PR**, so the next cut bumps everything in lockstep.

Caveat worth knowing: the ruleset's *code scanning* gate (zizmor) matches analyses by commit SHA; the dispatched run uploads SARIF for the branch head, which should satisfy it — if it ever doesn't populate on a release PR, an admin merge (your bypass is `pull_request`-scoped) is the escape hatch.

`scripts/set-version.sh` also works locally (perl/jq/npm/cargo only), and zizmor is clean on all four workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQHT83zq4xXNN4dNqMuZPt