### PR TITLE
VSCode: pin @types/vscode to the engines.vscode floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,8 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+    ignore:
+      # Must stay in sync with engines.vscode in vscode/package.json:
+      # vsce refuses to package when @types/vscode exceeds the engine floor.
+      # Bump both together when raising the minimum VS Code version.
+      - dependency-name: "@types/vscode"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         version: 10.1.0
     devDependencies:
       '@types/vscode':
-        specifier: ^1.125.0
-        version: 1.125.0
+        specifier: ~1.100.0
+        version: 1.100.0
       '@vscode/test-web':
         specifier: ^0.0.81
         version: 0.0.81
@@ -1508,8 +1508,8 @@ packages:
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
-  '@types/vscode@1.125.0':
-    resolution: {integrity: sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==}
+  '@types/vscode@1.100.0':
+    resolution: {integrity: sha512-4uNyvzHoraXEeCamR3+fzcBlh7Afs4Ifjs4epINyUX/jvdk0uzLnwiDY35UKDKnkCHP5Nu3dljl2H8lR6s+rQw==}
 
   '@typespec/ts-http-runtime@0.3.4':
     resolution: {integrity: sha512-CI0NhTrz4EBaa0U+HaaUZrJhPoso8sG7ZFya8uQoBA57fjzrjRSv87ekCjLZOFExN+gXE/z0xuN2QfH4H2HrLQ==}
@@ -4916,7 +4916,7 @@ snapshots:
 
   '@types/validate-npm-package-name@4.0.2': {}
 
-  '@types/vscode@1.125.0': {}
+  '@types/vscode@1.100.0': {}
 
   '@typespec/ts-http-runtime@0.3.4':
     dependencies:

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -132,7 +132,7 @@
     "vscode-languageclient": "^10.1.0"
   },
   "devDependencies": {
-    "@types/vscode": "^1.125.0",
+    "@types/vscode": "~1.100.0",
     "@vscode/test-web": "^0.0.81",
     "@vscode/vsce": "^3.9.2",
     "esbuild": "^0.28.0",


### PR DESCRIPTION
vsce refuses to package when `@types/vscode` exceeds `engines.vscode`, and dependabot bumped it to 1.125.0 (#965) while the engine floor is `^1.100.0` — breaking the vsix job on every main push since.

- Pin `@types/vscode` to `~1.100.0` (tilde, so minor bumps cannot outrun the floor — a caret range would resolve straight back to 1.125).
- Add a dependabot `ignore` for `@types/vscode` with a comment: bump it together with `engines.vscode` when raising the minimum VS Code version.

Verified locally: `tsc --noEmit` against the 1.100 types, the esbuild bundle, and a real `vsce package --no-dependencies` run (1.08 MB vsix) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQHT83zq4xXNN4dNqMuZPt