### PR TITLE
DAP: fix the source view in debug mode in VSCode

### DIFF
--- a/emulator/src/dap/index.rs
+++ b/emulator/src/dap/index.rs
@@ -30,6 +30,7 @@ pub(super) struct Location {
 
 struct FileInfo {
     path: String,
+    source: String,
     /// Byte offset of the start of each line (line 1 starts at
     /// `line_starts[0]`).
     line_starts: Vec<usize>,
@@ -38,7 +39,7 @@ struct FileInfo {
 }
 
 impl FileInfo {
-    fn new(path: String, source: &str) -> Self {
+    fn new(path: String, source: String) -> Self {
         let mut line_starts = vec![0usize];
         for (offset, byte) in source.bytes().enumerate() {
             if byte == b'\n' {
@@ -47,6 +48,7 @@ impl FileInfo {
         }
         Self {
             path,
+            source,
             line_starts,
             lines_with_code: BTreeMap::new(),
         }
@@ -94,7 +96,7 @@ impl LineIndex {
                 let idx = files.len();
                 files.push(FileInfo::new(
                     file_db.name(original_file_id),
-                    file_db.source(original_file_id),
+                    file_db.source(original_file_id).to_owned(),
                 ));
                 idx
             });
@@ -145,6 +147,12 @@ impl LineIndex {
     /// The stored path of a file by index.
     pub(super) fn path(&self, file_index: usize) -> &str {
         &self.files[file_index].path
+    }
+
+    /// Return the source content of a file matching `path`, if any.
+    pub(super) fn source_of(&self, path: &str) -> Option<&str> {
+        self.find_file(path)
+            .map(|idx| self.files[idx].source.as_str())
     }
 
     /// Resolve a breakpoint request (`path`, 1-based `line`) to the adjusted

--- a/emulator/src/dap/mod.rs
+++ b/emulator/src/dap/mod.rs
@@ -51,7 +51,7 @@ pub use self::index::LineIndex;
 use self::protocol::{
     Breakpoint, Capabilities, EvaluateArguments, IncomingRequest, LaunchArguments,
     ReadMemoryArguments, Scope, ScopesArguments, SetBreakpointsArguments, SetVariableArguments,
-    Source, StackFrame, Variable, VariablesArguments, WriteMemoryArguments,
+    Source, SourceArguments, StackFrame, Variable, VariablesArguments, WriteMemoryArguments,
 };
 use crate::constants as C;
 use crate::constants::Address;
@@ -317,6 +317,7 @@ impl DebugSession {
             "evaluate" => self.on_evaluate(&req),
             "readMemory" => self.on_read_memory(&req),
             "writeMemory" => self.on_write_memory(&req),
+            "source" => self.on_source(&req),
             "restart" => self.on_restart(&req),
             "disconnect" => {
                 self.exit_requested = true;
@@ -845,6 +846,25 @@ impl DebugSession {
         ) {
             Ok(written) => vec![self.response(req, json!({ "bytesWritten": written }))],
             Err(msg) => vec![self.response_err(req, msg)],
+        }
+    }
+
+    fn on_source(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        let args: SourceArguments = match serde_json::from_value(req.arguments.clone()) {
+            Ok(a) => a,
+            Err(e) => return vec![self.response_err(req, format!("invalid arguments: {e}"))],
+        };
+        let content = {
+            let Some(program) = self.program.as_ref() else {
+                return vec![self.response_err(req, "no program launched")];
+            };
+            args.source
+                .and_then(|s| s.path.or(s.name))
+                .and_then(|p| program.index.source_of(&p).map(str::to_owned))
+        };
+        match content {
+            Some(content) => vec![self.response(req, json!({ "content": content }))],
+            None => vec![self.response_err(req, "source not found")],
         }
     }
 

--- a/emulator/src/dap/protocol.rs
+++ b/emulator/src/dap/protocol.rs
@@ -226,3 +226,10 @@ pub struct WriteMemoryArguments {
     #[serde(default)]
     pub allow_partial: bool,
 }
+
+/// Arguments to `source`.
+#[derive(Debug, Deserialize)]
+pub struct SourceArguments {
+    #[serde(default)]
+    pub source: Option<Source>,
+}

--- a/emulator/src/dap/tests.rs
+++ b/emulator/src/dap/tests.rs
@@ -1091,3 +1091,47 @@ fn register_value(messages: &[Value], name: &str) -> String {
         .expect("register present")
         .to_owned()
 }
+
+/// VS Code sends a `source` request (with `sourceReference: 0` and only a
+/// path) whenever it cannot open a frame's `Source.path` itself — e.g. the
+/// relative paths of `#include`d files in the web extension. Regression test:
+/// this must return the file's content, not "unsupported request".
+#[test]
+fn source_request_by_path() {
+    let mut h = Harness::new();
+    h.send("initialize", json!({}));
+    h.send(
+        "launch",
+        json!({
+            "program": "/main.s",
+            "entrypoint": "main",
+            "stopOnEntry": true,
+            "files": {
+                "/main.s": "#include \"lib.s\"\nmain:\n    call helper\n    reset\n",
+                "/lib.s": "helper:\n    rtn\n",
+            },
+        }),
+    );
+    h.send("configurationDone", json!({}));
+
+    // Mimic VS Code's fallback shape: sourceReference 0, path-only lookup.
+    let out = h.send(
+        "source",
+        json!({
+            "source": { "name": "lib.s", "path": "/lib.s", "sourceReference": 0 },
+            "sourceReference": 0,
+        }),
+    );
+    let resp = find_response(&out, "source").expect("source response");
+    assert_eq!(
+        resp["success"],
+        json!(true),
+        "source request must succeed: {resp}"
+    );
+    assert_eq!(resp["body"]["content"], json!("helper:\n    rtn\n"));
+
+    // Unknown paths still fail cleanly.
+    let out = h.send("source", json!({ "source": { "path": "/nope.s" } }));
+    let resp = find_response(&out, "source").expect("source response");
+    assert_eq!(resp["success"], json!(false));
+}


### PR DESCRIPTION
Fixes the v0.8.0 regression: **"Could not load source 'samples/handler.s': unsupported request: source."**

The round-1 deletion (#970) was justified per spec — `Source.sourceReference` is never set, and clients should only send `source` when it is > 0 — but real VS Code has an undocumented fallback: whenever it cannot open a frame's `Source.path` itself (exactly what happens with the relative paths of `#include`d files in the web extension), it sends `source` with `sourceReference: 0` and a path. The old handler served that flow and had zero tests, which is how the deletion survived review.

This reverts the deletion 1:1 (dispatch arm, `on_source`, `SourceArguments`, `LineIndex::source_of`, `FileInfo.source`) and adds `dap::tests::source_request_by_path`, which replays the VS Code-shaped request (path-only lookup + clean failure for unknown paths) so it cannot regress silently again.

Suggest cutting **v0.8.1** once merged, since v0.8.0 shipped the regression to both marketplaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQHT83zq4xXNN4dNqMuZPt