### PR TITLE
Run code lens on executable labels + fix VS Code activation

### DIFF
--- a/emulator/src/lsp/backend.rs
+++ b/emulator/src/lsp/backend.rs
@@ -15,12 +15,17 @@ use tower_lsp::lsp_types::{
 };
 use tower_lsp::{jsonrpc, Client, LanguageServer};
 
+use super::document::LabelKind;
 use super::references::OccurrenceKind;
 use super::workspace::WorkspaceManager;
 use super::{completion, hover, position, semantic_tokens, symbols};
 
 /// The custom notification the host uses to push in-memory workspace files.
 pub const WORKSPACE_FILES_METHOD: &str = "z33/workspaceFiles";
+
+/// Client-side command carried by the run code lens. Only emitted when the
+/// client advertised it in the `experimental.commands` capability.
+pub const RUN_COMMAND: &str = "z33.run";
 
 /// LSP backend for Z33 assembly.
 ///
@@ -84,6 +89,90 @@ impl Backend {
 
 /// Parse the params of the `z33/workspaceFiles` notification into a relative
 /// path -> content map. Unknown or malformed entries are silently ignored.
+/// Extract the client-side commands advertised in the `experimental`
+/// client capability: `{"experimental": {"commands": ["z33.run", ...]}}`.
+fn parse_client_commands(
+    experimental: Option<&serde_json::Value>,
+) -> std::collections::HashSet<String> {
+    experimental
+        .and_then(|e| e.get("commands"))
+        .and_then(|c| c.as_array())
+        .map(|cmds| {
+            cmds.iter()
+                .filter_map(|c| c.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Build the code lenses for a document: an informational lens (resolved
+/// address + reference count) on every label defined in it, preceded by a
+/// `z33.run` lens on executable labels when `run_lens_path` is set (i.e. the
+/// client advertised it can execute the command).
+fn build_code_lenses(
+    source: &str,
+    analysis: &super::document::DocumentState,
+    run_lens_path: Option<&camino::Utf8Path>,
+) -> Vec<CodeLens> {
+    let root = analysis.root_file_id();
+    let mut lenses = Vec::new();
+
+    for (name, addr) in analysis.labels() {
+        // Only place a lens on labels defined in this document.
+        let Some(def) = analysis
+            .occurrences_of(name)
+            .find(|o| o.kind == OccurrenceKind::Definition && o.file_id == root)
+        else {
+            continue;
+        };
+        let Some(range) = position::range(source, def.span.clone()) else {
+            continue;
+        };
+
+        // Executable labels get a run lens (start execution with this label
+        // as the entrypoint), when the client can handle it.
+        if let Some(path) = run_lens_path {
+            if analysis.label_kind(name) == Some(LabelKind::Code) {
+                lenses.push(CodeLens {
+                    range,
+                    command: Some(Command {
+                        title: format!("\u{25b6} Run {name}"),
+                        command: RUN_COMMAND.to_string(),
+                        arguments: Some(vec![serde_json::json!({
+                            "path": path,
+                            "label": name,
+                        })]),
+                    }),
+                    data: None,
+                });
+            }
+        }
+
+        let ref_count = analysis
+            .occurrences_of(name)
+            .filter(|o| o.kind != OccurrenceKind::Definition)
+            .count();
+
+        let refs = match ref_count {
+            0 => "0 references".to_string(),
+            1 => "1 reference".to_string(),
+            n => format!("{n} references"),
+        };
+
+        lenses.push(CodeLens {
+            range,
+            command: Some(Command {
+                title: format!("address {addr} | {refs}"),
+                command: String::new(),
+                arguments: None,
+            }),
+            data: None,
+        });
+    }
+
+    lenses
+}
+
 fn parse_workspace_files(params: &serde_json::Value) -> HashMap<Utf8PathBuf, String> {
     let mut files = HashMap::new();
     if let Some(map) = params.get("files").and_then(serde_json::Value::as_object) {
@@ -108,7 +197,18 @@ impl LanguageServer for Backend {
                 .and_then(|folders| folders.into_iter().next())
                 .map(|folder| folder.uri)
         });
-        self.lock().set_root(root_uri);
+        // Client-side commands the client can execute, advertised through the
+        // open-ended `experimental` capability (same convention as
+        // rust-analyzer): `{"experimental": {"commands": ["z33.run", ...]}}`.
+        // Server-produced `Command`s (e.g. the run code lens) are only
+        // emitted when the client declared it can handle them.
+        let client_commands = parse_client_commands(params.capabilities.experimental.as_ref());
+
+        {
+            let mut manager = self.lock();
+            manager.set_root(root_uri);
+            manager.set_client_commands(client_commands);
+        }
 
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
@@ -312,7 +412,7 @@ impl LanguageServer for Backend {
     ) -> jsonrpc::Result<Option<Vec<CodeLens>>> {
         let uri = &params.text_document.uri;
 
-        let (source, analysis) = {
+        let (source, analysis, run_lens_path) = {
             let manager = self.lock();
             let Some(source) = manager.source(uri) else {
                 return Ok(None);
@@ -320,47 +420,16 @@ impl LanguageServer for Backend {
             let Some(analysis) = manager.analysis(uri) else {
                 return Ok(None);
             };
-            (source, analysis)
+            // The run lens only makes sense where a client-side handler
+            // exists (VS Code extension, web IDE). Other clients (e.g. Zed)
+            // get the informational lens only.
+            let run_lens_path = manager
+                .supports_client_command(RUN_COMMAND)
+                .then(|| manager.relative_for_uri(uri));
+            (source, analysis, run_lens_path)
         };
 
-        let root = analysis.root_file_id();
-        let mut lenses = Vec::new();
-
-        for (name, addr) in analysis.labels() {
-            // Only place a lens on labels defined in this document.
-            let Some(def) = analysis
-                .occurrences_of(name)
-                .find(|o| o.kind == OccurrenceKind::Definition && o.file_id == root)
-            else {
-                continue;
-            };
-            let Some(range) = position::range(&source, def.span.clone()) else {
-                continue;
-            };
-
-            let ref_count = analysis
-                .occurrences_of(name)
-                .filter(|o| o.kind != OccurrenceKind::Definition)
-                .count();
-
-            let refs = match ref_count {
-                0 => "0 references".to_string(),
-                1 => "1 reference".to_string(),
-                n => format!("{n} references"),
-            };
-            let title = format!("address {addr} | {refs}");
-
-            lenses.push(CodeLens {
-                range,
-                command: Some(Command {
-                    title,
-                    command: String::new(),
-                    arguments: None,
-                }),
-                data: None,
-            });
-        }
-
+        let lenses = build_code_lenses(&source, &analysis, run_lens_path.as_deref());
         if lenses.is_empty() {
             Ok(None)
         } else {
@@ -437,7 +506,8 @@ mod tests {
     use camino::Utf8PathBuf;
     use serde_json::json;
 
-    use super::parse_workspace_files;
+    use super::{build_code_lenses, parse_client_commands, parse_workspace_files, RUN_COMMAND};
+    use crate::lsp::document::DocumentState;
 
     #[test]
     fn parses_workspace_files_params() {
@@ -469,5 +539,46 @@ mod tests {
         let files = parse_workspace_files(&json!({ "files": { "a.s": 1, "b.s": "ok" } }));
         assert_eq!(files.len(), 1);
         assert!(files.contains_key(&Utf8PathBuf::from("b.s")));
+    }
+
+    #[test]
+    fn parses_client_commands_capability() {
+        let caps = json!({ "commands": ["z33.run", "z33.other"] });
+        let cmds = parse_client_commands(Some(&caps));
+        assert!(cmds.contains(RUN_COMMAND));
+        assert!(cmds.contains("z33.other"));
+
+        assert!(parse_client_commands(None).is_empty());
+        assert!(parse_client_commands(Some(&json!({}))).is_empty());
+        assert!(parse_client_commands(Some(&json!({ "commands": "z33.run" }))).is_empty());
+    }
+
+    #[test]
+    fn run_lens_gated_on_client_capability_and_label_kind() {
+        let src = "main:\n    reset\nvalue:\n    .word 42\n";
+        let analysis = DocumentState::new(src.to_string());
+
+        // Client did not advertise z33.run: informational lenses only.
+        let lenses = build_code_lenses(src, &analysis, None);
+        assert_eq!(lenses.len(), 2);
+        assert!(lenses
+            .iter()
+            .all(|l| l.command.as_ref().unwrap().command.is_empty()));
+
+        // Client advertised it: the code label gains a run lens, the data
+        // label does not.
+        let lenses = build_code_lenses(src, &analysis, Some(camino::Utf8Path::new("main.s")));
+        assert_eq!(lenses.len(), 3);
+        let run: Vec<_> = lenses
+            .iter()
+            .filter(|l| l.command.as_ref().unwrap().command == RUN_COMMAND)
+            .collect();
+        assert_eq!(run.len(), 1);
+        let cmd = run[0].command.as_ref().unwrap();
+        assert_eq!(cmd.title, "\u{25b6} Run main");
+        assert_eq!(
+            cmd.arguments,
+            Some(vec![json!({ "path": "main.s", "label": "main" })])
+        );
     }
 }

--- a/emulator/src/lsp/workspace.rs
+++ b/emulator/src/lsp/workspace.rs
@@ -88,6 +88,10 @@ pub(crate) struct WorkspaceManager {
     /// URIs we last published *non-empty* diagnostics for, so we can clear
     /// them.
     published: HashSet<Url>,
+    /// Client-side commands the client declared it can execute (from the
+    /// `experimental.commands` client capability). Server-produced commands
+    /// (e.g. the run code lens) are only emitted when advertised here.
+    client_commands: HashSet<String>,
 }
 
 impl WorkspaceManager {
@@ -99,6 +103,16 @@ impl WorkspaceManager {
     pub(crate) fn set_root(&mut self, root_uri: Option<Url>) {
         self.native_root = root_uri.as_ref().and_then(url_to_native_path);
         self.root_uri = root_uri;
+    }
+
+    pub(crate) fn set_client_commands(&mut self, commands: HashSet<String>) {
+        self.client_commands = commands;
+    }
+
+    /// Whether the client declared it can execute the given client-side
+    /// command (via the `experimental.commands` capability).
+    pub(crate) fn supports_client_command(&self, command: &str) -> bool {
+        self.client_commands.contains(command)
     }
 
     /// Replace the host-pushed base file map and re-analyze.
@@ -337,7 +351,7 @@ impl WorkspaceManager {
     }
 
     /// Compute the workspace-relative path for a document URI.
-    fn relative_for_uri(&self, uri: &Url) -> Utf8PathBuf {
+    pub(crate) fn relative_for_uri(&self, uri: &Url) -> Utf8PathBuf {
         // Prefer stripping the native root off the file path.
         if let (Some(root), Some(path)) = (&self.native_root, url_to_native_path(uri)) {
             if let Ok(rel) = path.strip_prefix(root) {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -17,6 +17,9 @@
     "Debuggers"
   ],
   "browser": "./dist/extension.js",
+  "activationEvents": [
+    "onLanguage:z33-assembly"
+  ],
   "contributes": {
     "languages": [
       {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -17,9 +17,19 @@ import { LanguageClient, type LanguageClientOptions } from "vscode-languageclien
 
 import initDapWasm, { WasmDapServer } from "../dist/pkg/z33_web.js";
 import { Z33DebugAdapter } from "./debug-adapter.js";
-import { collectWorkspaceFiles, FILE_GLOB } from "./workspace-paths.js";
+import {
+  collectWorkspaceFiles,
+  FILE_GLOB,
+  includeWorkspaceFolderInPaths,
+} from "./workspace-paths.js";
 
 const WORKSPACE_FILES_METHOD = "z33/workspaceFiles";
+/**
+ * Client-side command carried by the server's run code lens. Advertised to
+ * the server via the `experimental.commands` client capability; the server
+ * only emits the lens when it sees the advertisement.
+ */
+const RUN_COMMAND = "z33.run";
 /** Give the wasm worker a generous window to instantiate before giving up. */
 const HANDSHAKE_TIMEOUT_MS = 30_000;
 /** Debounce window for coalescing rapid file-watcher events. */
@@ -113,11 +123,53 @@ async function activateInner(context: vscode.ExtensionContext): Promise<void> {
       { language: "z33-assembly", scheme: "file" },
       { language: "z33-assembly", scheme: "vscode-vfs" },
       { language: "z33-assembly", scheme: "untitled" },
+      // @vscode/test-web mounts the workspace under this scheme; without it
+      // the extension is untestable in a dev web host.
+      { language: "z33-assembly", scheme: "vscode-test-web" },
     ],
   };
 
   client = new LanguageClient("z33-assembly", "Z33 Language Server", worker, clientOptions);
+  // Tell the server which client-side commands we can execute, so it emits
+  // the run code lens (rust-analyzer-style `experimental.commands`).
+  client.registerFeature({
+    fillClientCapabilities(capabilities) {
+      capabilities.experimental = {
+        ...(capabilities.experimental as Record<string, unknown> | undefined),
+        commands: [RUN_COMMAND],
+      };
+    },
+    initialize() {},
+    getState() {
+      return { kind: "static" };
+    },
+    clear() {},
+  });
   await client.start();
+
+  // Handler for the run code lens: start a debug session with the lens's
+  // label as the entrypoint. The lens carries the server's workspace-relative
+  // path; map it back to the real file URI (the debug adapter matches
+  // `program` against `uri.toString()`).
+  context.subscriptions.push(
+    vscode.commands.registerCommand(RUN_COMMAND, async (args: { path: string; label: string }) => {
+      const includeFolder = includeWorkspaceFolderInPaths();
+      const uris = await vscode.workspace.findFiles(FILE_GLOB);
+      const uri = uris.find((u) => vscode.workspace.asRelativePath(u, includeFolder) === args.path);
+      if (uri === undefined) {
+        void vscode.window.showErrorMessage(`Z33: could not find ${args.path} in the workspace`);
+        return;
+      }
+      await vscode.debug.startDebugging(vscode.workspace.getWorkspaceFolder(uri), {
+        type: "z33",
+        request: "launch",
+        name: `Run ${args.label}`,
+        program: uri.toString(),
+        entrypoint: args.label,
+        stopOnEntry: false,
+      });
+    }),
+  );
 
   // Seed the server's include-resolution base map and keep it in sync. Watcher
   // events can arrive in bursts (multi-file save, branch switch); debounce and

--- a/web/app/App.tsx
+++ b/web/app/App.tsx
@@ -1,11 +1,12 @@
 import { useMonaco } from "@monaco-editor/react";
 import type * as monaco from "monaco-editor";
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { DebugLayout } from "./debug-layout";
 import { EditToolbar } from "./edit-toolbar";
 import { FileSidebar } from "./file-sidebar";
 import { useCompilation } from "./hooks/use-compilation";
 import { stripLeadingSlash } from "./lib/file-paths";
+import { setRunCommandHandler } from "./lib/lsp-monaco";
 import { getMonacoFiles } from "./lib/monaco-sync";
 import { MultiFileEditor } from "./multi-file-editor";
 import { useAppStore } from "./stores/app-store";
@@ -26,10 +27,9 @@ const App = () => {
     monacoInstance,
   );
 
-  const handleRun = useCallback(
-    (entrypoint: string) => {
-      if (compilationResult.type !== "success") return;
-      setEntrypoint(activeFile, entrypoint);
+  const runFile = useCallback(
+    (file: string, entrypoint: string) => {
+      setEntrypoint(file, entrypoint);
       // Use the freshest editor contents, keyed by file-store name (no leading
       // slash) to match the emulator worker / LSP URI conventions.
       const files = Object.fromEntries(
@@ -38,13 +38,35 @@ const App = () => {
           content,
         ]),
       );
-      void startDebug(files, activeFile, entrypoint).catch((e: unknown) => {
-        // check() should have caught errors before Run; this is a safety net.
+      void startDebug(files, file, entrypoint).catch((e: unknown) => {
+        // The compile check should have caught errors before Run; this is a
+        // safety net.
         console.error("Failed to start debug session:", e);
       });
     },
-    [compilationResult, activeFile, setEntrypoint, startDebug],
+    [setEntrypoint, startDebug],
   );
+
+  const handleRun = useCallback(
+    (entrypoint: string) => {
+      if (compilationResult.type !== "success") return;
+      runFile(activeFile, entrypoint);
+    },
+    [compilationResult, activeFile, runFile],
+  );
+
+  // The LSP run code lens: start (or restart) a debug session with the lens's
+  // file as the program and its label as the entrypoint. The lens path is the
+  // server's workspace-relative path — the same no-leading-slash convention as
+  // the file store.
+  useEffect(() => {
+    setRunCommandHandler(({ path, label }) => {
+      const { mode, stopDebug } = useAppStore.getState();
+      if (mode.type === "debug") stopDebug();
+      runFile(path, label);
+    });
+    return () => setRunCommandHandler(null);
+  }, [runFile]);
 
   const handleEditorMount = useCallback(
     (editor: monaco.editor.IStandaloneCodeEditor) => {

--- a/web/app/lib/lsp-client.ts
+++ b/web/app/lib/lsp-client.ts
@@ -32,6 +32,9 @@ interface LspClient {
 }
 
 const CLIENT_CAPABILITIES = {
+  // Client-side commands this host can execute (rust-analyzer-style
+  // advertisement); the server gates its run code lens on this.
+  experimental: { commands: ["z33.run"] },
   textDocument: {
     synchronization: { dynamicRegistration: false },
     publishDiagnostics: { relatedInformation: true },

--- a/web/app/lib/lsp-monaco.ts
+++ b/web/app/lib/lsp-monaco.ts
@@ -430,7 +430,34 @@ async function registerSemanticTokens(
 let initialized = false;
 
 /** Register all Z33 language features against the given Monaco instance. */
+/** Arguments carried by the server's `z33.run` code lens. */
+export interface RunCommandArgs {
+  path: string;
+  label: string;
+}
+
+let runCommandHandler: ((args: RunCommandArgs) => void) | null = null;
+
+/**
+ * Install the handler for the run code lens (`z33.run`). The command is
+ * advertised to the server via the `experimental.commands` capability
+ * (lsp-client.ts) and registered with Monaco in `setupLsp`; the app provides
+ * the actual behavior (start a debug session at the label) here.
+ */
+export function setRunCommandHandler(
+  handler: ((args: RunCommandArgs) => void) | null,
+): void {
+  runCommandHandler = handler;
+}
+
 export function setupLsp(m: Monaco): void {
+  // Execution target for the server's run code lens. Registered once,
+  // globally: Monaco's code-lens widget dispatches the lens command through
+  // the command service by id.
+  m.editor.registerCommand("z33.run", (_accessor, args: RunCommandArgs) => {
+    runCommandHandler?.(args);
+  });
+
   if (initialized) return;
   initialized = true;
 

--- a/web/e2e/core-flows.spec.ts
+++ b/web/e2e/core-flows.spec.ts
@@ -19,7 +19,9 @@ test.describe("Core flows", () => {
 
   test("fact.s auto-compiles successfully", async ({ cleanPage: page }) => {
     await waitForCompileSuccess(page);
-    await expect(page.getByRole("button", { name: "Run" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Run", exact: true }),
+    ).toBeVisible();
   });
 
   test("compilation error and recovery", async ({ cleanPage: page }) => {

--- a/web/e2e/fixtures.ts
+++ b/web/e2e/fixtures.ts
@@ -22,7 +22,7 @@ export async function waitForCompileError(page: Page): Promise<void> {
 
 export async function enterDebugMode(page: Page): Promise<void> {
   await waitForCompileSuccess(page);
-  await page.getByRole("button", { name: "Run" }).click();
+  await page.getByRole("button", { name: "Run", exact: true }).click();
   await expect(page.getByRole("toolbar", { name: "Debug" })).toBeVisible();
 }
 

--- a/web/e2e/lsp.spec.ts
+++ b/web/e2e/lsp.spec.ts
@@ -117,4 +117,29 @@ test.describe("LSP", () => {
       timeout: 5_000,
     });
   });
+
+  test("run code lens starts a debug session at the label", async ({
+    page,
+  }) => {
+    test.slow();
+    await loadWorkspace(
+      page,
+      { "main.s": "main:\n    ld 1, %a\n    reset\n" },
+      "main.s",
+    );
+
+    // The server only emits the lens because the web client advertises the
+    // z33.run command; Monaco renders it as a clickable code-lens link.
+    const lens = page.locator(".codelens-decoration a", {
+      hasText: "Run main",
+    });
+    await expect(lens).toBeVisible({ timeout: 15_000 });
+    await lens.click();
+
+    // Clicking must start a debug session with `main` as the entrypoint.
+    await expect(page.getByRole("toolbar", { name: "Debug" })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByRole("region", { name: "Registers" })).toBeVisible();
+  });
 });


### PR DESCRIPTION
Two commits:

**1. VSCode: activate on opening a Z33 file** — a significant pre-existing bug: the manifest had no `activationEvents`, and VS Code only auto-infers `onDebug` from the debuggers contribution. The extension therefore never activated on file-open — hover, diagnostics, completion and lenses were silently dead until the user started a debug session at least once. This shipped broken in every published version; worth a patch release on its own.

**2. LSP: run code lens on executable labels, gated on a client capability.** Labels resolving to an instruction (the existing `LabelKind` classifier) get a `▶ Run <label>` lens whose `z33.run` command starts a debug session with that label as the entrypoint. Since lens commands execute client-side, the server only emits it when the client advertises `z33.run` via the rust-analyzer-style `experimental.commands` client capability:

- **VS Code**: advertises via a `StaticFeature`; the command maps the lens's workspace-relative path back to a file URI and calls `vscode.debug.startDebugging` on the inline adapter.
- **Web IDE**: advertises in `lsp-client.ts`; Monaco dispatches the registered command into the app's run flow (set entrypoint → debug mode; restarts cleanly if already debugging).
- **Zed / generic clients**: no advertisement → informational lens only, no dead button.

Verified: new server tests (capability parsing, lens gating on capability + label kind), full workspace tests + clippy `--all-targets`, web e2e 27/27 including a new lens-click test, and a **live end-to-end run in @vscode/test-web** (screenshot in comments: lenses render, clicking launches the session) — which also required admitting the `vscode-test-web://` scheme in the document selector, included here so the extension stays dev-testable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQHT83zq4xXNN4dNqMuZPt