### PR TITLE
VSCode: map DAP sources to real workspace files

### DIFF
--- a/vscode/src/debug-adapter.ts
+++ b/vscode/src/debug-adapter.ts
@@ -45,11 +45,42 @@ export class Z33DebugAdapter implements vscode.DebugAdapter {
 
   private pumping = false;
 
+  // Path translation between the server's workspace-relative keys (used by the
+  // in-memory filesystem / `LineIndex`) and the paths VS Code speaks. Built in
+  // `handleLaunch` from the collected workspace URIs. Because that build awaits
+  // async file I/O — and the server emits `initialized` during `initialize`, so
+  // configuration-phase `setBreakpoints` can arrive before the launch dispatch
+  // finishes — we queue every non-launch message that comes in while the launch
+  // is in flight (see `launching`/`queued`) and flush it afterwards. That
+  // guarantees both these maps and the server's loaded program exist before any
+  // queued request reaches the server.
+  //
+  // `relToClient`: relative key → real client path (`uri.fsPath` for `file:`
+  // URIs, otherwise `uri.toString()` — VS Code opens both). `clientToRel`:
+  // client representation → relative key (`fsPath` and URI string for `file:`,
+  // URI string only for virtual schemes — keying `fsPath` there would collide
+  // across authorities).
+  private readonly relToClient = new Map<string, string>();
+  private readonly clientToRel = new Map<string, string>();
+
+  // While `handleLaunch` is in flight, incoming non-launch messages are queued
+  // here instead of dispatched, then flushed in order once the launch dispatch
+  // completes (success or failure).
+  private launching = false;
+  private readonly queued: vscode.DebugProtocolMessage[] = [];
+
   constructor(private readonly server: WasmDapServer) {}
 
   handleMessage(message: vscode.DebugProtocolMessage): void {
     if (isLaunchRequest(message)) {
+      this.launching = true;
       void this.handleLaunch(message);
+      return;
+    }
+    if (this.launching) {
+      // Maps (and the loaded program) aren't ready yet; defer until the launch
+      // dispatch completes so message order is preserved.
+      this.queued.push(message);
       return;
     }
     this.dispatch(message);
@@ -58,7 +89,8 @@ export class Z33DebugAdapter implements vscode.DebugAdapter {
   private async handleLaunch(message: LaunchRequest): Promise<void> {
     try {
       const args = message.arguments ?? {};
-      const { files, program } = await collectWorkspaceFiles(args.program);
+      const { files, program, uris } = await collectWorkspaceFiles(args.program);
+      this.buildPathMaps(uris);
 
       const augmented: LaunchRequest = {
         ...message,
@@ -69,13 +101,48 @@ export class Z33DebugAdapter implements vscode.DebugAdapter {
       // A failed launch (e.g. file read error) must fail the request visibly,
       // otherwise VS Code shows a spinner forever.
       this.emitErrorResponse(message, "launch", errorMessage(error));
+    } finally {
+      // Flush anything that arrived during the launch, in order. Clear the flag
+      // first so `dispatch` runs normally (and any message that somehow arrives
+      // mid-flush is handled directly rather than re-queued).
+      this.launching = false;
+      while (this.queued.length > 0) {
+        const next = this.queued.shift();
+        if (next !== undefined) {
+          this.dispatch(next);
+        }
+      }
+    }
+  }
+
+  /** (Re)build the client↔relative-key path maps from the collected URIs. */
+  private buildPathMaps(uris: Map<string, vscode.Uri>): void {
+    this.relToClient.clear();
+    this.clientToRel.clear();
+    for (const [relative, uri] of uris) {
+      // Prefer a filesystem path for `file:` URIs; fall back to the URI string
+      // for virtual schemes (e.g. `vscode-vfs://` on vscode.dev), which VS Code
+      // also accepts in `Source.path`.
+      const clientPath = uri.scheme === "file" ? uri.fsPath : uri.toString();
+      this.relToClient.set(relative, clientPath);
+      // Map the client representation(s) back to the relative key. For `file:`
+      // URIs VS Code may send either `fsPath` or the URI string, so key on
+      // both. For virtual schemes VS Code sends `uri.toString()`; we must NOT
+      // key on `fsPath` there because `Uri.fsPath` drops the URI authority, so
+      // two roots on different authorities with the same tail path would
+      // collide (last write wins → wrong-file breakpoints).
+      if (uri.scheme === "file") {
+        this.clientToRel.set(uri.fsPath, relative);
+      }
+      this.clientToRel.set(uri.toString(), relative);
     }
   }
 
   /** Feed one message to the server, emit its output, then drive the run loop. */
   private dispatch(message: unknown): void {
+    const rewritten = this.rewriteIncomingSource(message);
     try {
-      const responses = this.server.handle_message(message);
+      const responses = this.server.handle_message(rewritten);
       for (const response of responses) {
         this.emit(response);
       }
@@ -128,7 +195,82 @@ export class Z33DebugAdapter implements vscode.DebugAdapter {
   }
 
   private emit(message: unknown): void {
+    this.rewriteOutgoingSources(message);
     this.sendEmitter.fire(message as vscode.DebugProtocolMessage);
+  }
+
+  /**
+   * Reverse-map a request's `arguments.source.path` from the client path VS
+   * Code sends back to the server's relative key, so `setBreakpoints`,
+   * `source` and friends resolve to the right in-memory file (rather than
+   * relying on `LineIndex`'s ambiguous base-name fallback). Unknown paths pass
+   * through unchanged.
+   *
+   * Non-mutating: VS Code retains and reuses the request object it hands to
+   * `handleMessage` (persistent `Source.raw` state in its debug model), so we
+   * must not write into it. When a rewrite applies we return a shallow-cloned
+   * chain with the swapped path; otherwise we return the original message.
+   */
+  private rewriteIncomingSource(message: unknown): unknown {
+    if (typeof message !== "object" || message === null) {
+      return message;
+    }
+    const args = (message as { arguments?: unknown }).arguments;
+    if (typeof args !== "object" || args === null) {
+      return message;
+    }
+    const source = (args as { source?: unknown }).source;
+    if (typeof source !== "object" || source === null) {
+      return message;
+    }
+    const src = source as { path?: unknown };
+    if (typeof src.path !== "string") {
+      return message;
+    }
+    const relative = this.clientToRel.get(src.path);
+    if (relative === undefined) {
+      return message;
+    }
+    return {
+      ...(message as object),
+      arguments: {
+        ...(args as object),
+        source: { ...(source as object), path: relative },
+      },
+    };
+  }
+
+  /**
+   * Rewrite server-side relative `Source.path` values to real client paths so
+   * VS Code opens the actual workspace file instead of a read-only `debug:`
+   * virtual document. Walks the whole message and rewrites any object under a
+   * `source` key carrying a string `path` — stack frames (`stackTrace`),
+   * `Breakpoint.source` (`setBreakpoints` responses / `breakpoint` events) and
+   * `output` events. Paths with no known key are left untouched so the DAP
+   * `source`-request fallback still applies (e.g. `#include`d files).
+   */
+  private rewriteOutgoingSources(value: unknown): void {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        this.rewriteOutgoingSources(item);
+      }
+      return;
+    }
+    if (typeof value !== "object" || value === null) {
+      return;
+    }
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      if (key === "source" && typeof child === "object" && child !== null) {
+        const source = child as { path?: unknown };
+        if (typeof source.path === "string") {
+          const mapped = this.relToClient.get(source.path);
+          if (mapped !== undefined) {
+            source.path = mapped;
+          }
+        }
+      }
+      this.rewriteOutgoingSources(child);
+    }
   }
 
   /** Emit a failed DAP response for a request (matched by `request_seq`). */

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -20,7 +20,7 @@ import { Z33DebugAdapter } from "./debug-adapter.js";
 import {
   collectWorkspaceFiles,
   FILE_GLOB,
-  includeWorkspaceFolderInPaths,
+  uriForWorkspaceRelativePath,
 } from "./workspace-paths.js";
 
 const WORKSPACE_FILES_METHOD = "z33/workspaceFiles";
@@ -149,13 +149,12 @@ async function activateInner(context: vscode.ExtensionContext): Promise<void> {
 
   // Handler for the run code lens: start a debug session with the lens's
   // label as the entrypoint. The lens carries the server's workspace-relative
-  // path; map it back to the real file URI (the debug adapter matches
-  // `program` against `uri.toString()`).
+  // path; resolve it directly against the workspace folders (the debug adapter
+  // matches `program` against `uri.toString()`). No `findFiles` here — web
+  // hosts' search providers are unreliable, and the lens path is exact anyway.
   context.subscriptions.push(
     vscode.commands.registerCommand(RUN_COMMAND, async (args: { path: string; label: string }) => {
-      const includeFolder = includeWorkspaceFolderInPaths();
-      const uris = await vscode.workspace.findFiles(FILE_GLOB);
-      const uri = uris.find((u) => vscode.workspace.asRelativePath(u, includeFolder) === args.path);
+      const uri = await uriForWorkspaceRelativePath(args.path);
       if (uri === undefined) {
         void vscode.window.showErrorMessage(`Z33: could not find ${args.path} in the workspace`);
         return;

--- a/vscode/src/workspace-paths.ts
+++ b/vscode/src/workspace-paths.ts
@@ -10,8 +10,92 @@ export const FILE_GLOB = "**/*.{s,S}";
  * The LSP push (extension.ts) and the debug adapter must agree so their file
  * maps line up, hence this shared helper.
  */
-export function includeWorkspaceFolderInPaths(): boolean {
+function includeWorkspaceFolderInPaths(): boolean {
   return (vscode.workspace.workspaceFolders?.length ?? 0) > 1;
+}
+
+/** Directories a manual workspace walk must never descend into. */
+const WALK_EXCLUDED_DIRS = new Set(["node_modules", ".git"]);
+
+/**
+ * Find every `.s`/`.S` file in the workspace. `findFiles` first; if it comes
+ * back empty, fall back to a manual `fs.readDirectory` walk of each workspace
+ * folder. On web hosts the search goes through whatever `FileSearchProvider`
+ * the virtual filesystem registers, and some don't handle our brace glob (or
+ * any glob) — the walk only needs the FileSystemProvider, which always exists.
+ */
+async function findSourceFiles(): Promise<vscode.Uri[]> {
+  const found = await vscode.workspace.findFiles(FILE_GLOB);
+  if (found.length > 0) {
+    return found;
+  }
+  const walked: vscode.Uri[] = [];
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    await walkForSourceFiles(folder.uri, walked);
+  }
+  return walked;
+}
+
+async function walkForSourceFiles(dir: vscode.Uri, out: vscode.Uri[]): Promise<void> {
+  let entries: [string, vscode.FileType][];
+  try {
+    entries = await vscode.workspace.fs.readDirectory(dir);
+  } catch {
+    return; // unreadable directory: skip, don't fail the whole collection
+  }
+  for (const [name, type] of entries) {
+    if (type === vscode.FileType.Directory) {
+      if (!WALK_EXCLUDED_DIRS.has(name) && !name.startsWith(".")) {
+        await walkForSourceFiles(vscode.Uri.joinPath(dir, name), out);
+      }
+    } else if (type === vscode.FileType.File && (name.endsWith(".s") || name.endsWith(".S"))) {
+      out.push(vscode.Uri.joinPath(dir, name));
+    }
+  }
+}
+
+/**
+ * Resolve a server-side workspace-relative path (as carried by e.g. the run
+ * code lens) back to a real workspace URI by joining it onto each workspace
+ * folder and probing with `fs.stat`. Deliberately avoids `findFiles`, which is
+ * unreliable on web hosts (see `findSourceFiles`). With multiple roots the
+ * relative path may or may not carry the folder-name prefix (the LSP push
+ * prefixes it, the server's own root-URI relativization doesn't), so both
+ * spellings are probed.
+ */
+export async function uriForWorkspaceRelativePath(
+  relativePath: string,
+): Promise<vscode.Uri | undefined> {
+  const folders = vscode.workspace.workspaceFolders ?? [];
+  // Probe the folder the leading path segment names first: with multiple
+  // roots the pushed keys are folder-prefixed, and a verbatim probe against an
+  // earlier folder that coincidentally contains a same-named subtree would
+  // shadow the intended file.
+  for (const folder of folders) {
+    const prefix = `${folder.name}/`;
+    if (relativePath.startsWith(prefix)) {
+      const uri = vscode.Uri.joinPath(folder.uri, relativePath.slice(prefix.length));
+      if (await fileExists(uri)) {
+        return uri;
+      }
+    }
+  }
+  for (const folder of folders) {
+    const uri = vscode.Uri.joinPath(folder.uri, relativePath);
+    if (await fileExists(uri)) {
+      return uri;
+    }
+  }
+  return undefined;
+}
+
+async function fileExists(uri: vscode.Uri): Promise<boolean> {
+  try {
+    await vscode.workspace.fs.stat(uri);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -20,15 +104,22 @@ export function includeWorkspaceFolderInPaths(): boolean {
  * to the matching relative key so the in-memory FS lookup succeeds; the LSP
  * push ignores that field.
  *
+ * `uris` maps each relative key back to its real `vscode.Uri`; the debug
+ * adapter needs it to translate DAP `Source` paths between the server's
+ * relative keys and the client's file/URI paths (the LSP push ignores it).
+ *
  * Both the LSP seed (extension.ts) and the debug adapter go through this single
  * implementation so include resolution and program lookup agree on keys
  * (folder-prefixed only when there are multiple roots).
  */
-export async function collectWorkspaceFiles(
-  program?: string,
-): Promise<{ files: Record<string, string>; program: string }> {
+export async function collectWorkspaceFiles(program?: string): Promise<{
+  files: Record<string, string>;
+  program: string;
+  uris: Map<string, vscode.Uri>;
+}> {
   const files: Record<string, string> = {};
-  const uris = await vscode.workspace.findFiles(FILE_GLOB);
+  const uriByKey = new Map<string, vscode.Uri>();
+  const uris = await findSourceFiles();
   const decoder = new TextDecoder();
   const includeFolder = includeWorkspaceFolderInPaths();
   let resolvedProgram = program ?? "";
@@ -37,6 +128,7 @@ export async function collectWorkspaceFiles(
     const relative = vscode.workspace.asRelativePath(uri, includeFolder);
     const bytes = await vscode.workspace.fs.readFile(uri);
     files[relative] = decoder.decode(bytes);
+    uriByKey.set(relative, uri);
 
     // Match the configured program to its workspace-relative key.
     if (program !== undefined && program.length > 0) {
@@ -46,5 +138,5 @@ export async function collectWorkspaceFiles(
     }
   }
 
-  return { files, program: resolvedProgram };
+  return { files, program: resolvedProgram, uris: uriByKey };
 }


### PR DESCRIPTION
Starting the debugger in the VS Code extension showed stack frames in a read-only virtual document instead of the real workspace file (Zed was unaffected). The wasm DAP server only knows workspace-relative paths — its in-memory filesystem keys — and VS Code treats a relative `Source.path` as unopenable, falling back to the `source` request and a `debug:`-scheme document.

### Path translation at the adapter boundary

* `collectWorkspaceFiles` now also returns a relative-key → `vscode.Uri` map.
* **Outgoing** messages get any `source`-keyed object's `path` rewritten from the relative key to `uri.fsPath` (`file:` scheme) or `uri.toString()` (virtual schemes — VS Code accepts URI strings in `Source.path`, which covers vscode.dev).
* **Incoming** `arguments.source.path` (`setBreakpoints`, `source`, …) is reverse-mapped to the relative key, so breakpoints resolve exactly instead of via `LineIndex`'s base-name fallback. The rewrite is non-mutating since VS Code retains the request objects it hands over, and the reverse map is not keyed on `fsPath` for virtual schemes (`Uri.fsPath` drops the authority, which could collide across multi-root authorities).
* Unmatched paths pass through in both directions, keeping the `source`-request fallback working for anything not in the map.
* Non-launch messages arriving while the launch request is being augmented (async file collection) are queued and flushed afterwards, so configuration-phase `setBreakpoints` can no longer race the path maps or the program load.

The Rust DAP module stays relative-key based on purpose (transport-agnostic); the native `z33-cli dap` used by Zed needs none of this.

### Web hosts: drop the `findFiles` dependency

Testing on the web surfaced `Z33: could not find samples/fact.s in the workspace` from the run code lens: `workspace.findFiles` goes through the virtual filesystem's `FileSearchProvider` there, which can mishandle the `**/*.{s,S}` brace glob and return nothing (also silently emptying the debug file map). The lens handler now resolves its server-relative path directly against the workspace folders with an `fs.stat` probe (prefix-matched folder first in multi-root, so a shadowing subtree in an earlier folder can't win), and `collectWorkspaceFiles` falls back to a manual `readDirectory` walk when `findFiles` comes back empty.

### Testing

* `cd vscode && pnpm run check && pnpm run build`
* Verified end-to-end in `@vscode/test-web` driven by Playwright: the ▶ Run lens starts a debug session paused on entry in the real `samples/fact.s` editor tab (no virtual document), with working breakpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)