### PR TITLE
Web: add a configurable clock speed to the debugger (run slowly mode)

### DIFF
--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -296,6 +296,9 @@ pub enum BatchStatus {
 pub struct BatchResult {
     pub status: BatchStatus,
     pub steps: u32,
+    /// Cycles consumed by this batch (1 per instruction + 1 per memory
+    /// operand). Lets the caller pace execution by clock speed.
+    pub cycles: usize,
     pub error: Option<String>,
 }
 
@@ -397,6 +400,7 @@ impl Computer {
         let mut steps: u32 = 0;
         let mut status = BatchStatus::Running;
         let mut error = None;
+        let cycles_before = self.inner.cycles;
 
         while steps < max_steps {
             match self.inner.step() {
@@ -425,6 +429,7 @@ impl Computer {
         BatchResult {
             status,
             steps,
+            cycles: self.inner.cycles - cycles_before,
             error,
         }
     }

--- a/editors/web/app/debug-toolbar.tsx
+++ b/editors/web/app/debug-toolbar.tsx
@@ -1,5 +1,11 @@
-import { PauseIcon, PencilIcon, PlayIcon, StepForwardIcon } from "lucide-react";
-import { memo } from "react";
+import {
+  GaugeIcon,
+  PauseIcon,
+  PencilIcon,
+  PlayIcon,
+  StepForwardIcon,
+} from "lucide-react";
+import { memo, useEffect } from "react";
 import { Badge } from "./components/ui/badge";
 import { Button } from "./components/ui/button";
 import {
@@ -20,7 +26,17 @@ import { useCycles } from "./hooks/use-computer";
 import { useStepRunner } from "./hooks/use-step-runner";
 import { cn } from "./lib/utils";
 import { useAppStore } from "./stores/app-store";
+import { SPEED_OPTIONS, useSpeedStore } from "./stores/speed-store";
 import { ThemeSwitcher } from "./theme-switcher";
+
+/** Stable select key for a speed value ("max" or the number in cycles/s). */
+const speedKey = (speed: number | null): string =>
+  speed === null ? "max" : String(speed);
+
+/** Select `items` map: stable key -> human label (rendered by SelectValue). */
+const SPEED_ITEMS = Object.fromEntries(
+  SPEED_OPTIONS.map((o) => [speedKey(o.speed), o.label]),
+);
 
 type DebugToolbarProps = {
   className?: string;
@@ -69,6 +85,13 @@ const DebugToolbarInner: React.FC<{
   const cycles = useCycles(computer);
   const { halt, panicked, running, stepOnce, run, pause } =
     useStepRunner(computer);
+  const speed = useSpeedStore((s) => s.speed);
+  const setSpeed = useSpeedStore((s) => s.setSpeed);
+
+  // Seed the worker on session start and apply live speed changes mid-run.
+  useEffect(() => {
+    computer.setSpeed(speed);
+  }, [computer, speed]);
 
   const disabled = halt || panicked !== null;
 
@@ -102,6 +125,39 @@ const DebugToolbarInner: React.FC<{
           Run
         </Button>
       )}
+
+      <Select
+        value={speedKey(speed)}
+        items={SPEED_ITEMS}
+        onValueChange={(v) => {
+          const option = SPEED_OPTIONS.find((o) => speedKey(o.speed) === v);
+          if (option) setSpeed(option.speed);
+        }}
+      >
+        <Tooltip>
+          <TooltipTrigger
+            render={<SelectTrigger size="xs" className="w-24 font-mono" />}
+          >
+            <GaugeIcon data-icon="inline-start" />
+            <SelectValue />
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            Clock speed in cycles per second — instructions with memory operands
+            take proportionally longer
+          </TooltipContent>
+        </Tooltip>
+        <SelectContent align="start">
+          {SPEED_OPTIONS.map((o) => (
+            <SelectItem
+              key={speedKey(o.speed)}
+              value={speedKey(o.speed)}
+              className="font-mono text-xs"
+            >
+              {o.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
 
       <div className="mx-2 h-4 w-px bg-border" />
 

--- a/editors/web/app/lib/computer-proxy.ts
+++ b/editors/web/app/lib/computer-proxy.ts
@@ -273,6 +273,10 @@ export class ComputerProxy implements ComputerInterface {
     this.#client.send({ type: "setBreakpoints", addresses });
   }
 
+  setSpeed(speed: number | null): void {
+    this.#client.send({ type: "setSpeed", speed });
+  }
+
   resolveBreakpoint(
     file: string,
     line: number,

--- a/editors/web/app/lib/emulator-protocol.ts
+++ b/editors/web/app/lib/emulator-protocol.ts
@@ -45,6 +45,11 @@ export type WorkerRequest =
   | { type: "pause" }
   | { type: "stop" }
   | { type: "setBreakpoints"; addresses: number[] }
+  /**
+   * Target clock speed in cycles per second; `null` = full speed. Stateful like
+   * `setBreakpoints` and may arrive mid-run.
+   */
+  | { type: "setSpeed"; speed: number | null }
   | { id: number; type: "resolveBreakpoint"; file: string; line: number }
   | { type: "watchCells"; addresses: number[] }
   | { type: "unwatchCells"; addresses: number[] };

--- a/editors/web/app/stores/speed-store.ts
+++ b/editors/web/app/stores/speed-store.ts
@@ -1,0 +1,50 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+/** Clock-speed presets offered by the debug toolbar. */
+export const SPEED_OPTIONS: { label: string; speed: number | null }[] = [
+  { label: "Max", speed: null },
+  { label: "1 kHz", speed: 1000 },
+  { label: "100 Hz", speed: 100 },
+  { label: "10 Hz", speed: 10 },
+  { label: "2 Hz", speed: 2 },
+];
+
+interface SpeedState {
+  /** Target clock speed in cycles per second; `null` = full speed. */
+  speed: number | null;
+  setSpeed: (speed: number | null) => void;
+}
+
+export const useSpeedStore = create<SpeedState>()(
+  persist(
+    (set) => ({
+      speed: null,
+      setSpeed: (speed) => {
+        set({ speed });
+      },
+    }),
+    {
+      name: "z33:speed",
+      // Normalize a persisted speed that is no longer a preset back to full
+      // speed, so the toolbar select always reflects the worker's pacing.
+      merge: (persisted, current) => {
+        let speed: number | null = null;
+        if (
+          persisted &&
+          typeof persisted === "object" &&
+          "speed" in persisted
+        ) {
+          const value = persisted.speed;
+          if (
+            typeof value === "number" &&
+            SPEED_OPTIONS.some((o) => o.speed === value)
+          ) {
+            speed = value;
+          }
+        }
+        return { ...current, speed };
+      },
+    },
+  ),
+);

--- a/editors/web/app/workers/emulator.worker.ts
+++ b/editors/web/app/workers/emulator.worker.ts
@@ -4,6 +4,12 @@
 // `../lib/emulator-protocol`. Continuous "run" is executed here in bounded
 // batches (via the wasm `run_batch`), yielding to the event loop between
 // batches so `pause` / `setBreakpoints` messages are processed promptly.
+//
+// A paced mode ("run slowly") is layered on top: when a target clock speed
+// (cycles per second) is set, each rAF/timeout wake-up runs one batch sized to
+// the cycles owed since the last one, pacing against `performance.now()` using
+// the per-batch cycle cost reported by the emulator. Full speed
+// (`speed === null`) uses the trampoline.
 import type {
   RunStatus,
   Snapshot,
@@ -22,6 +28,11 @@ import wasmUrl from "../../pkg/z33_web_bg.wasm?url";
 const BATCH_SIZE = 50_000;
 /** Minimum interval between pushed snapshots while running (ms). */
 const SNAPSHOT_INTERVAL_MS = 40;
+/**
+ * Bounds catch-up in the paced loop after the tab was hidden (worker rAF pauses
+ * in background tabs, so `dueAt` would otherwise fall far behind wall time).
+ */
+const MAX_CATCHUP_MS = 100;
 
 const ready = init({ module_or_path: wasmUrl });
 
@@ -46,6 +57,10 @@ let breakpoints: number[] = [];
 const watched = new Map<number, () => void>();
 const pendingCells = new Map<number, Cell>();
 let lastSnapshotAt = 0;
+/** Target clock speed in cycles per second; `null` = full speed. */
+let speed: number | null = null;
+/** Virtual time (ms) at which the next batch is due in the paced loop. */
+let dueAt = 0;
 
 function post(message: WorkerResponse): void {
   // oxlint-disable-next-line unicorn/require-post-message-target-origin -- Worker.postMessage takes no targetOrigin
@@ -99,28 +114,102 @@ function scheduleTick(): void {
   trampoline.port2.postMessage(null);
 }
 
-function runTick(): void {
-  if (!running || !computer) return;
+/**
+ * Run one batch of at most `maxSteps` instructions, handling the terminal
+ * outcomes shared by both run loops: on throw or terminal status the run stops
+ * and the final snapshot is pushed, returning `null`. Returns the batch result
+ * when execution should continue.
+ */
+function executeBatch(
+  maxSteps: number,
+): ReturnType<Computer["run_batch"]> | null {
+  if (!computer) return null;
   let result: ReturnType<Computer["run_batch"]>;
   try {
-    result = computer.run_batch(BATCH_SIZE, Uint32Array.from(breakpoints));
+    result = computer.run_batch(maxSteps, Uint32Array.from(breakpoints));
   } catch (error) {
     running = false;
     pushSnapshot("panicked", String(error));
-    return;
+    return null;
   }
 
   const status = statusFromBatch(result.status);
   if (status !== "running") {
     running = false;
     pushSnapshot(status, result.error ?? undefined);
-    return;
+    return null;
   }
+  return result;
+}
+
+function runTick(): void {
+  // A stale trampoline tick can fire after a switch to the paced loop; the
+  // `speed === null` guard makes it a no-op so only one scheduling chain runs.
+  if (!running || !computer || speed !== null) return;
+  if (!executeBatch(BATCH_SIZE)) return;
 
   if (performance.now() - lastSnapshotAt >= SNAPSHOT_INTERVAL_MS) {
     pushSnapshot("running");
   }
   scheduleTick();
+}
+
+// Paced loop scheduling. The rAF/timeout is only a wake-up; accuracy comes from
+// pacing `dueAt` against `performance.now()`. Worker rAF is preferred (it pauses
+// in background tabs, avoiding wasted wake-ups), with a setTimeout fallback.
+const useRaf = typeof self.requestAnimationFrame === "function";
+let slowTickHandle: number | null = null;
+
+function scheduleSlowTick(): void {
+  slowTickHandle = useRaf
+    ? self.requestAnimationFrame(slowTick)
+    : setTimeout(slowTick, 16);
+}
+
+function cancelSlowTick(): void {
+  if (slowTickHandle === null) return;
+  if (useRaf) self.cancelAnimationFrame(slowTickHandle);
+  else clearTimeout(slowTickHandle);
+  slowTickHandle = null;
+}
+
+function slowTick(): void {
+  // A stale rAF/timeout callback can fire after a switch to full speed or a
+  // pause; the `speed === null` / `running` guards make it a no-op.
+  if (!running || !computer || speed === null) return;
+  const now = performance.now();
+  dueAt = Math.max(dueAt, now - MAX_CATCHUP_MS);
+  if (dueAt <= now) {
+    // One batch per wake-up: every instruction costs >= 1 cycle, so
+    // `result.cycles >= steps == budget >= owed` — a single call always
+    // advances `dueAt` past `now`. When instructions cost more than 1 cycle we
+    // overshoot slightly and `dueAt` self-corrects (idle a bit longer); the
+    // long-run rate stays exact. At slow speeds `owed` rounds to 1, keeping
+    // single-instruction granularity.
+    const owed = Math.ceil(((now - dueAt) * speed) / 1000);
+    const result = executeBatch(Math.min(Math.max(1, owed), BATCH_SIZE));
+    if (!result) return;
+    dueAt += (result.cycles * 1000) / speed;
+    if (now - lastSnapshotAt >= SNAPSHOT_INTERVAL_MS) {
+      pushSnapshot("running");
+    }
+  }
+  scheduleSlowTick();
+}
+
+/**
+ * Start (or restart) the scheduling chain matching the current speed. Keeps
+ * exactly one chain alive: any pending slow tick is cancelled, and a stale
+ * trampoline tick no-ops on its `speed === null` guard.
+ */
+function startRunLoop(): void {
+  cancelSlowTick();
+  if (speed === null) {
+    scheduleTick();
+  } else {
+    dueAt = performance.now();
+    scheduleSlowTick();
+  }
 }
 
 function watch(address: number): void {
@@ -142,6 +231,7 @@ function unwatch(address: number): void {
 
 function stopSession(): void {
   running = false;
+  cancelSlowTick();
   breakpoints = [];
   for (const unsubscribe of watched.values()) unsubscribe();
   watched.clear();
@@ -225,12 +315,13 @@ self.addEventListener("message", (event: MessageEvent<WorkerRequest>) => {
       case "run": {
         if (!computer || running) return;
         running = true;
-        scheduleTick();
+        startRunLoop();
         break;
       }
       case "pause": {
         if (!running) return;
         running = false;
+        cancelSlowTick();
         pushSnapshot("paused");
         break;
       }
@@ -240,6 +331,16 @@ self.addEventListener("message", (event: MessageEvent<WorkerRequest>) => {
       }
       case "setBreakpoints": {
         breakpoints = message.addresses;
+        break;
+      }
+      case "setSpeed": {
+        const previous = speed;
+        // Coerce invalid speeds (0, negative, NaN, Infinity, non-numbers) to
+        // full speed: 0 would push `dueAt` to Infinity and silently freeze.
+        const s = message.speed;
+        speed = typeof s === "number" && Number.isFinite(s) && s > 0 ? s : null;
+        // Restart the scheduling chain when the speed changes mid-run.
+        if (running && previous !== speed) startRunLoop();
         break;
       }
       case "resolveBreakpoint": {


### PR DESCRIPTION
Adds a paced "run slowly" mode to the web IDE debugger, so programs can be watched executing at a fixed clock speed instead of only running to completion.

## What

- **Speed selector in the debug toolbar** (Max / 1 kHz / 100 Hz / 10 Hz / 2 Hz), live mid-run in both directions, persisted across sessions (`z33:speed`).
- **Pacing is by cycle cost**, not instruction count: `BatchResult` (wasm) now reports the cycles consumed by a batch, so instructions with memory operands take proportionally longer wall time — matching the cost model taught in the course.
- **Cycle-budget scheduler in the emulator worker**: a rAF wake-up (setTimeout fallback) runs one bounded `run_batch` per tick sized by cycles owed, paced against `performance.now()`. Timer jitter never accumulates — the long-run rate is exact (measured: 64 cycles in 6.4 s at 10 Hz). rAF pausing in background tabs is deliberate (demo mode freezes while hidden; a catch-up clamp prevents a burst on return).
- New stateful `setSpeed` protocol message, validated worker-side (0/negative/NaN coerce to full speed); full speed keeps the existing trampoline path untouched.

## Notes

- At slow rates the UI animates instruction-by-instruction for free through the existing 40 ms snapshot throttle; idle wake-ups push nothing.
- Persisted speeds are normalized to the preset list on rehydration so the UI can never display "Max" while actually paced.

## Testing

- `cargo test --workspace`, `cargo clippy --workspace`, web `pnpm run check` + `build`, Playwright e2e 27/27.
- Verified live in a browser: exact 10 Hz and 2 Hz pacing, preset persistence across sessions, mid-run 2 Hz → Max switch runs to halt immediately, terminal states correct in paced mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DssjtUHc872McAdhENYRTZ