### PR TITLE
Web: fix unreachable last option in toolbar Select dropdowns

### DIFF
--- a/editors/web/app/components/ui/select.tsx
+++ b/editors/web/app/components/ui/select.tsx
@@ -50,7 +50,11 @@ function SelectContent({
   sideOffset = 4,
   align = "center",
   alignOffset = 0,
-  alignItemWithTrigger = true,
+  // Keep the popup a plain dropdown anchored below/above the trigger. The
+  // base-ui "align selected item over the trigger" mode clips (and breaks
+  // scrolling for) the popup when the selected item is far down the list and
+  // the trigger sits near a viewport edge — as the toolbar selects do.
+  alignItemWithTrigger = false,
   ...props
 }: SelectPrimitive.Popup.Props &
   Pick<


### PR DESCRIPTION
## Problem

The clock-speed `Select` in the debug toolbar showed a scroll indicator but wouldn't scroll, leaving the last option unreachable — reproducible whenever the currently-selected value was the last option (e.g. `2 Hz`).

## Cause

The base-ui `Select` defaulted to `alignItemWithTrigger`, which positions the *selected* item directly over the trigger. When the selected value is the last option and the trigger sits near the top of the viewport (as the debug/edit toolbar selects do), the popup has no room to extend upward, falls back to scroll-arrow overlays that don't meaningfully scroll, and the last option can't be reached.

## Fix

Default `alignItemWithTrigger` to `false` in `SelectContent`, so the popup behaves as a plain dropdown anchored below/above the trigger with normal scrolling. All options stay reachable regardless of which is selected. This also covers the edit-toolbar selects, which share the same near-top placement.

## Verification

- Reproduced in-browser: entered debug mode, selected `2 Hz` (last option), reopened the dropdown — all 5 options (Max / 1 kHz / 100 Hz / 10 Hz / 2 Hz) are visible and selectable, no stuck scroll indicator.
- `pnpm run check` (oxlint + oxfmt) passes with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)