### PR TITLE
Implement the serial console peripheral

### DIFF
--- a/.config/tracey/config.styx
+++ b/.config/tracey/config.styx
@@ -2,7 +2,7 @@ specs (
   {
     name z33
     include (spec/src/**/*.md)
-    exclude (spec/src/08-calling-convention.md spec/src/09-io-controllers.md spec/src/10-variants/**/*.md spec/src/11-appendices/**/*.md spec/src/00-introduction.md)
+    exclude (spec/src/08-calling-convention.md spec/src/10-variants/**/*.md spec/src/11-appendices/**/*.md spec/src/00-introduction.md)
     impls (
       {
         name rust

--- a/crates/emulator/src/runtime/instructions.rs
+++ b/crates/emulator/src/runtime/instructions.rs
@@ -230,9 +230,14 @@ impl Instruction {
             }
 
             // r[impl inst.in]
-            Self::In(_, _) => {
+            Self::In(port, reg) => {
                 computer.check_privileged()?;
-                todo!();
+                // The operand names a port number, not a memory address, so we
+                // resolve it as an address without dereferencing memory.
+                let port = port.resolve_address(&computer.registers)?;
+                let value = computer.io.read(port);
+                // `in` sets no flags.
+                computer.set_register(*reg, value.into())?;
             }
 
             // r[impl inst.jmp]
@@ -368,9 +373,14 @@ impl Instruction {
             }
 
             // r[impl inst.out]
-            Self::Out(_, _) => {
+            Self::Out(src, port) => {
                 computer.check_privileged()?;
-                todo!()
+                let value = src.extract_word(computer)?;
+                // The destination operand names a port number, not a memory
+                // address.
+                let port = port.resolve_address(&computer.registers)?;
+                // `out` sets no flags.
+                computer.io.write(port, value);
             }
 
             // r[impl inst.pop]

--- a/crates/emulator/src/runtime/io.rs
+++ b/crates/emulator/src/runtime/io.rs
@@ -81,7 +81,6 @@ impl SerialConsole {
     ///
     /// If receive interrupts are enabled ([`Self::irq_on_ready`]), delivering
     /// bytes raises a hardware interrupt.
-    // r[impl io.serial.data.read]
     pub fn push_input(&mut self, bytes: &[u8]) {
         if bytes.is_empty() {
             return;
@@ -94,7 +93,6 @@ impl SerialConsole {
     }
 
     /// Take everything the program has written, leaving the buffer empty.
-    // r[impl io.serial.data.write]
     #[must_use]
     pub fn drain_output(&mut self) -> Vec<u8> {
         std::mem::take(&mut self.output)
@@ -115,8 +113,8 @@ impl SerialConsole {
 
     /// Read the status register, computing the R/T/I bits.
     ///
-    /// Reading the status register clears the I bit (but not a pending edge that
-    /// [`Self::poll_interrupt`] may still deliver).
+    /// Reading the status register clears the I bit (but not a pending edge
+    /// that [`Self::poll_interrupt`] may still deliver).
     // r[impl io.serial.status.tx-ready]
     // r[impl io.serial.status.interrupt]
     fn read_status(&mut self) -> Word {
@@ -147,11 +145,13 @@ impl SerialConsole {
     }
 
     /// Read the data register: pop the front byte, or 0 if the queue is empty.
+    // r[impl io.serial.data.read]
     fn read_data(&mut self) -> Word {
         self.input.pop_front().map_or(0, Word::from)
     }
 
     /// Write the data register: append the low byte to the output buffer.
+    // r[impl io.serial.data.write]
     fn write_data(&mut self, value: Word) {
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let byte = (value & 0xFF) as u8;
@@ -336,6 +336,39 @@ mod tests {
             serial.read(SERIAL_STATUS_PORT) & STATUS_INTERRUPT,
             STATUS_INTERRUPT
         );
+    }
+
+    #[test]
+    fn status_read_preserves_pending_edge() {
+        // The I status bit and the pending interrupt edge are independent:
+        // clearing the former (by reading the status register) does not
+        // consume the latter.
+        // r[verify io.serial.status.read-clears-interrupt]
+        // r[verify io.serial.interrupt.edge]
+        let mut serial = SerialConsole::default();
+        serial.write(SERIAL_STATUS_PORT, CONTROL_RX_INTERRUPT_ENABLE);
+        serial.push_input(b"x");
+
+        // Reading the status register clears the I bit...
+        let status = serial.read(SERIAL_STATUS_PORT);
+        assert_eq!(status & STATUS_INTERRUPT, STATUS_INTERRUPT);
+        let status = serial.read(SERIAL_STATUS_PORT);
+        assert_eq!(status & STATUS_INTERRUPT, 0);
+
+        // ...but the interrupt edge is still delivered.
+        assert!(serial.poll_interrupt());
+    }
+
+    #[test]
+    fn push_input_empty_is_noop() {
+        // An empty delivery raises no interrupt and leaves R clear.
+        // r[verify io.serial.status.rx-ready]
+        let mut serial = SerialConsole::default();
+        serial.write(SERIAL_STATUS_PORT, CONTROL_RX_INTERRUPT_ENABLE);
+        serial.push_input(&[]);
+        assert!(!serial.input_ready());
+        assert!(!serial.poll_interrupt());
+        assert_eq!(serial.read(SERIAL_STATUS_PORT) & STATUS_RX_READY, 0);
     }
 
     #[test]

--- a/crates/emulator/src/runtime/io.rs
+++ b/crates/emulator/src/runtime/io.rs
@@ -1,0 +1,352 @@
+//! Port-mapped I/O devices.
+//!
+//! The Z33 accesses peripherals through the privileged `in`/`out` instructions,
+//! which read from and write to numbered *ports*. Each controller occupies a
+//! contiguous range of ports and exposes a small set of registers (status,
+//! control, data...) following the idiom described in the reference card.
+//!
+//! Only the serial console (ports 110–111) is implemented by the emulator. The
+//! [`Device`] trait is the seam through which future controllers (keyboard,
+//! disk...) can be plugged in.
+
+use std::collections::VecDeque;
+
+use crate::constants::{Address, Word};
+
+/// Port range of the serial console controller (inclusive).
+const SERIAL_STATUS_PORT: Address = 110;
+const SERIAL_DATA_PORT: Address = 111;
+
+/// Status register bits (port 110, read).
+const STATUS_RX_READY: Word = 0b001; // R: input queue non-empty
+const STATUS_TX_READY: Word = 0b010; // T: transmit ready (always 1)
+const STATUS_INTERRUPT: Word = 0b100; // I: controller raised an interrupt
+
+/// Control register bits (port 110, write).
+const CONTROL_RX_INTERRUPT_ENABLE: Word = 0b001; // E: interrupt on receive
+
+/// A port-mapped I/O device.
+///
+/// Devices are addressed by port number. The [`IoBus`] routes `in`/`out`
+/// accesses to whichever device [`handles`](Device::handles) the port. Devices
+/// may also raise hardware interrupts, which are delivered between instructions
+/// (see [`Device::poll_interrupt`]).
+pub trait Device {
+    /// Whether this device answers to the given port.
+    fn handles(&self, port: Address) -> bool;
+
+    /// Read a word from one of the device's registers.
+    fn read(&mut self, port: Address) -> Word;
+
+    /// Write a word to one of the device's registers.
+    fn write(&mut self, port: Address, value: Word);
+
+    /// Consume and return a pending interrupt edge, if any.
+    ///
+    /// Returns `true` at most once per raised interrupt (edge-consumed). The
+    /// device's status-register interrupt bit is independent from this edge and
+    /// is only cleared by reading the status register.
+    fn poll_interrupt(&mut self) -> bool {
+        false
+    }
+}
+
+/// A simple serial console (ports 110–111).
+///
+/// Transmission is instantaneous: writing to the data register appends to an
+/// output buffer that the host drains, and the transmit-ready bit is always
+/// set. Reception is host-driven: the host pushes bytes into an input queue,
+/// which the program pops through the data register. Reads never block.
+#[derive(Debug, Default, Clone)]
+pub struct SerialConsole {
+    /// Bytes received from the host, waiting to be read by the program.
+    input: VecDeque<u8>,
+
+    /// Bytes written by the program, waiting to be drained by the host.
+    output: Vec<u8>,
+
+    /// The E control bit: raise a hardware interrupt when a byte is received.
+    irq_on_ready: bool,
+
+    /// The I status bit: an interrupt has been raised and not yet acknowledged
+    /// (cleared by reading the status register).
+    interrupt_flag: bool,
+
+    /// A pending interrupt edge, consumed once by [`Self::poll_interrupt`].
+    pending_irq: bool,
+}
+
+impl SerialConsole {
+    /// Deliver bytes from the host into the receive queue.
+    ///
+    /// If receive interrupts are enabled ([`Self::irq_on_ready`]), delivering
+    /// bytes raises a hardware interrupt.
+    // r[impl io.serial.data.read]
+    pub fn push_input(&mut self, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
+        }
+        self.input.extend(bytes.iter().copied());
+        // r[impl io.serial.interrupt.raise]
+        if self.irq_on_ready {
+            self.raise_interrupt();
+        }
+    }
+
+    /// Take everything the program has written, leaving the buffer empty.
+    // r[impl io.serial.data.write]
+    #[must_use]
+    pub fn drain_output(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.output)
+    }
+
+    /// Whether there is at least one byte waiting to be read.
+    // r[impl io.serial.status.rx-ready]
+    #[must_use]
+    pub fn input_ready(&self) -> bool {
+        !self.input.is_empty()
+    }
+
+    /// Raise a hardware interrupt: set the I status bit and arm the edge.
+    fn raise_interrupt(&mut self) {
+        self.interrupt_flag = true;
+        self.pending_irq = true;
+    }
+
+    /// Read the status register, computing the R/T/I bits.
+    ///
+    /// Reading the status register clears the I bit (but not a pending edge that
+    /// [`Self::poll_interrupt`] may still deliver).
+    // r[impl io.serial.status.tx-ready]
+    // r[impl io.serial.status.interrupt]
+    fn read_status(&mut self) -> Word {
+        let mut status = STATUS_TX_READY;
+        if self.input_ready() {
+            status |= STATUS_RX_READY;
+        }
+        if self.interrupt_flag {
+            status |= STATUS_INTERRUPT;
+        }
+        // r[impl io.serial.status.read-clears-interrupt]
+        self.interrupt_flag = false;
+        status
+    }
+
+    /// Write the control register.
+    // r[impl io.serial.control.rx-interrupt-enable]
+    fn write_control(&mut self, value: Word) {
+        let enabled = value & CONTROL_RX_INTERRUPT_ENABLE != 0;
+        self.irq_on_ready = enabled;
+        // Enabling receive interrupts while bytes are already queued raises the
+        // interrupt straight away, so the program never misses input delivered
+        // before it armed the controller.
+        // r[impl io.serial.interrupt.enable-with-queued]
+        if enabled && self.input_ready() {
+            self.raise_interrupt();
+        }
+    }
+
+    /// Read the data register: pop the front byte, or 0 if the queue is empty.
+    fn read_data(&mut self) -> Word {
+        self.input.pop_front().map_or(0, Word::from)
+    }
+
+    /// Write the data register: append the low byte to the output buffer.
+    fn write_data(&mut self, value: Word) {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let byte = (value & 0xFF) as u8;
+        self.output.push(byte);
+    }
+}
+
+impl Device for SerialConsole {
+    fn handles(&self, port: Address) -> bool {
+        port == SERIAL_STATUS_PORT || port == SERIAL_DATA_PORT
+    }
+
+    fn read(&mut self, port: Address) -> Word {
+        match port {
+            SERIAL_STATUS_PORT => self.read_status(),
+            SERIAL_DATA_PORT => self.read_data(),
+            _ => 0,
+        }
+    }
+
+    fn write(&mut self, port: Address, value: Word) {
+        match port {
+            SERIAL_STATUS_PORT => self.write_control(value),
+            SERIAL_DATA_PORT => self.write_data(value),
+            _ => {}
+        }
+    }
+
+    // r[impl io.serial.interrupt.edge]
+    fn poll_interrupt(&mut self) -> bool {
+        std::mem::take(&mut self.pending_irq)
+    }
+}
+
+/// The I/O bus: routes port accesses to the attached devices.
+///
+/// Devices are held as concrete typed fields (not `Box<dyn Device>`) so hosts
+/// can reach into them without downcasting; the [`Device`] trait is only the
+/// routing seam.
+#[derive(Debug, Default, Clone)]
+pub struct IoBus {
+    /// The serial console (ports 110–111).
+    pub serial: SerialConsole,
+}
+
+impl IoBus {
+    /// Read from the port, routing to the device that handles it.
+    ///
+    /// Unmapped ports read as 0.
+    // r[impl io.unmapped]
+    #[must_use]
+    pub fn read(&mut self, port: Address) -> Word {
+        if self.serial.handles(port) {
+            self.serial.read(port)
+        } else {
+            0
+        }
+    }
+
+    /// Write to the port, routing to the device that handles it.
+    ///
+    /// Writes to unmapped ports are ignored.
+    // r[impl io.unmapped]
+    pub fn write(&mut self, port: Address, value: Word) {
+        if self.serial.handles(port) {
+            self.serial.write(port, value);
+        }
+    }
+
+    /// Consume a pending interrupt edge from any device.
+    // r[impl io.interrupt.delivery]
+    pub fn poll_interrupt(&mut self) -> bool {
+        self.serial.poll_interrupt()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn status_reflects_rx_and_tx() {
+        // r[verify io.serial.status.rx-ready]
+        // r[verify io.serial.status.tx-ready]
+        let mut serial = SerialConsole::default();
+        // Empty queue: only T is set.
+        assert_eq!(serial.read(SERIAL_STATUS_PORT), STATUS_TX_READY);
+        assert!(!serial.input_ready());
+
+        serial.push_input(b"a");
+        assert!(serial.input_ready());
+        // R and T are set, I is not (interrupts disabled).
+        assert_eq!(
+            serial.read(SERIAL_STATUS_PORT),
+            STATUS_RX_READY | STATUS_TX_READY
+        );
+    }
+
+    #[test]
+    fn status_read_clears_interrupt_bit() {
+        // r[verify io.serial.status.interrupt]
+        // r[verify io.serial.status.read-clears-interrupt]
+        let mut serial = SerialConsole::default();
+        serial.write(SERIAL_STATUS_PORT, CONTROL_RX_INTERRUPT_ENABLE);
+        serial.push_input(b"x");
+
+        let status = serial.read(SERIAL_STATUS_PORT);
+        assert_eq!(status & STATUS_INTERRUPT, STATUS_INTERRUPT);
+        // A second read no longer reports the interrupt.
+        let status = serial.read(SERIAL_STATUS_PORT);
+        assert_eq!(status & STATUS_INTERRUPT, 0);
+    }
+
+    #[test]
+    fn data_pop_and_empty_reads_zero() {
+        // r[verify io.serial.data.read]
+        let mut serial = SerialConsole::default();
+        serial.push_input(b"hi");
+        assert_eq!(serial.read(SERIAL_DATA_PORT), Word::from(b'h'));
+        assert_eq!(serial.read(SERIAL_DATA_PORT), Word::from(b'i'));
+        // Queue drained: reads return 0 and never block.
+        assert_eq!(serial.read(SERIAL_DATA_PORT), 0);
+        assert!(!serial.input_ready());
+    }
+
+    #[test]
+    fn data_write_masks_to_byte_and_drains() {
+        // r[verify io.serial.data.write]
+        let mut serial = SerialConsole::default();
+        serial.write(SERIAL_DATA_PORT, Word::from(b'A'));
+        // High bits are dropped: 0x141 & 0xFF == 0x41 == 'A'.
+        serial.write(SERIAL_DATA_PORT, 0x141);
+        assert_eq!(serial.drain_output(), b"AA");
+        // Draining leaves the buffer empty.
+        assert!(serial.drain_output().is_empty());
+    }
+
+    #[test]
+    fn unmapped_ports_are_lenient() {
+        // r[verify io.unmapped]
+        let mut bus = IoBus::default();
+        assert_eq!(bus.read(0), 0);
+        assert_eq!(bus.read(999), 0);
+        // Writing to an unmapped port is a no-op and does not touch the serial
+        // console.
+        bus.write(0, 42);
+        assert!(bus.serial.drain_output().is_empty());
+    }
+
+    #[test]
+    fn poll_interrupt_is_edge_consumed() {
+        // r[verify io.serial.interrupt.edge]
+        // r[verify io.serial.interrupt.raise]
+        // r[verify io.serial.control.rx-interrupt-enable]
+        let mut serial = SerialConsole::default();
+        serial.write(SERIAL_STATUS_PORT, CONTROL_RX_INTERRUPT_ENABLE);
+        serial.push_input(b"z");
+        // The edge is delivered exactly once.
+        assert!(serial.poll_interrupt());
+        assert!(!serial.poll_interrupt());
+        // Without interrupts enabled, pushing raises no edge.
+        let mut serial = SerialConsole::default();
+        serial.push_input(b"z");
+        assert!(!serial.poll_interrupt());
+    }
+
+    #[test]
+    fn enabling_interrupt_with_queued_input_raises() {
+        // r[verify io.serial.interrupt.enable-with-queued]
+        let mut serial = SerialConsole::default();
+        // Bytes arrive before interrupts are enabled: no edge yet.
+        serial.push_input(b"q");
+        assert!(!serial.poll_interrupt());
+        // Enabling E while input is queued raises the interrupt.
+        serial.write(SERIAL_STATUS_PORT, CONTROL_RX_INTERRUPT_ENABLE);
+        assert!(serial.poll_interrupt());
+        assert_eq!(
+            serial.read(SERIAL_STATUS_PORT) & STATUS_INTERRUPT,
+            STATUS_INTERRUPT
+        );
+    }
+
+    #[test]
+    fn bus_routes_serial_ports() {
+        // r[verify io.interrupt.delivery]
+        let mut bus = IoBus::default();
+        bus.serial.push_input(b"k");
+        assert_eq!(bus.read(SERIAL_DATA_PORT), Word::from(b'k'));
+        bus.write(SERIAL_DATA_PORT, Word::from(b'k'));
+        assert_eq!(bus.serial.drain_output(), b"k");
+        // No interrupt pending by default.
+        assert!(!bus.poll_interrupt());
+    }
+}

--- a/crates/emulator/src/runtime/mod.rs
+++ b/crates/emulator/src/runtime/mod.rs
@@ -10,6 +10,7 @@ use crate::constants as C;
 pub(crate) mod arguments;
 mod exception;
 mod instructions;
+pub mod io;
 mod memory;
 pub mod registers;
 
@@ -17,6 +18,7 @@ pub use self::arguments::ExtractValue;
 use self::arguments::{ExtractError, Ind, ResolveAddress};
 pub use self::exception::Exception;
 pub(crate) use self::instructions::Instruction;
+pub use self::io::{Device, IoBus, SerialConsole};
 pub use self::memory::{Cell, Memory};
 use self::memory::{CellError, MemoryError};
 use self::registers::StatusRegister;
@@ -54,6 +56,7 @@ pub struct Computer {
     pub registers: Registers,
     pub memory: Memory,
     pub cycles: usize,
+    pub io: IoBus,
 }
 
 impl std::fmt::Debug for Computer {
@@ -124,17 +127,21 @@ impl Computer {
             Ok(cost)
         }
 
-        let cost = inner(self).or_else(|e| {
-            if let ProcessorError::Exception(e) = e {
-                self.recover_from_exception(&e)
-                    .map_err(ProcessorError::Exception)
-                    // r[impl exec.cycles.exception]
-                    .map(|()| 1) // TODO: fixed cost for exceptions?
-            } else {
-                Err(e)
+        match inner(self) {
+            Ok(cost) => {
+                self.cycles += cost;
+                // The instruction completed normally; hardware interrupts are
+                // only delivered between instructions.
+                self.poll_hardware_interrupt()?;
             }
-        })?;
-        self.cycles += cost;
+            Err(ProcessorError::Exception(e)) => {
+                self.recover_from_exception(&e)
+                    .map_err(ProcessorError::Exception)?;
+                // r[impl exec.cycles.exception]
+                self.cycles += 1; // TODO: fixed cost for exceptions?
+            }
+            Err(e) => return Err(e),
+        }
         trace!("Register state {:?}", self.registers);
         Ok(())
     }
@@ -183,6 +190,25 @@ impl Computer {
         }
         // r[impl exc.handling.jump]
         self.registers.pc = C::INTERRUPT_HANDLER;
+        Ok(())
+    }
+
+    /// Deliver a pending hardware interrupt, if any, between instructions.
+    ///
+    /// A hardware interrupt is only delivered when interrupts are enabled
+    /// (`%sr.IE`). The interrupt-enable check happens *before* polling the bus,
+    /// so a pending interrupt edge is preserved (not consumed) while interrupts
+    /// are masked and gets delivered once they are re-enabled. Delivery reuses
+    /// the standard exception path, which clears `IE` for hardware interrupts.
+    // r[impl io.interrupt.delivery]
+    fn poll_hardware_interrupt(&mut self) -> Result<()> {
+        if self.registers.sr.contains(StatusRegister::INTERRUPT_ENABLE) && self.io.poll_interrupt()
+        {
+            self.recover_from_exception(&Exception::HardwareInterrupt)
+                .map_err(ProcessorError::Exception)?;
+            // r[impl exec.cycles.exception]
+            self.cycles += 1;
+        }
         Ok(())
     }
 

--- a/crates/emulator/tests/exceptions.rs
+++ b/crates/emulator/tests/exceptions.rs
@@ -566,9 +566,8 @@ fn exception_step_count_check() {
 fn in_is_privileged() {
     // r[verify inst.in]
     // r[verify exc.code.privileged-instruction]
-    // `in` is defined but unimplemented (todo!()); its privilege check runs
-    // first, so executing it in user mode raises the exception instead of
-    // reaching the panic.
+    // `in` is privileged; its privilege check runs first, so executing it in
+    // user mode raises the exception before any I/O access happens.
     let state = run_program(
         indoc! {"
             .addr 100
@@ -610,7 +609,7 @@ fn in_is_privileged() {
 fn out_is_privileged() {
     // r[verify inst.out]
     // r[verify exc.code.privileged-instruction]
-    // Same as `in`: privilege check fires before the todo!() body.
+    // Same as `in`: the privilege check fires before any I/O access.
     let state = run_program(
         indoc! {"
             .addr 100

--- a/crates/emulator/tests/io.rs
+++ b/crates/emulator/tests/io.rs
@@ -138,7 +138,7 @@ fn hardware_interrupt_is_delivered_between_instructions() {
             .addr 1000
             main:
                 out 1, [110]        // enable rx interrupts (E bit)
-                ld 768, %sr         // supervisor (512) + interrupt-enable (256)
+                or 1 << 8, %sr      // switch on interrupt-enable (bit 8; supervisor stays set)
             idle:
                 jmp idle
         "},
@@ -153,7 +153,7 @@ fn hardware_interrupt_is_delivered_between_instructions() {
     // %sr.IE is not set yet so nothing is delivered.
     computer.step().unwrap();
     assert_eq!(computer.registers.pc, 1001);
-    // Step 2: `ld 768, %sr` enables interrupts; the pending interrupt is then
+    // Step 2: `or 1 << 8, %sr` enables interrupts; the pending interrupt is then
     // delivered between this instruction and the next.
     computer.step().unwrap();
 
@@ -185,7 +185,7 @@ fn masked_interrupt_edge_is_preserved() {
             main:
                 out 1, [110]        // enable rx interrupts, but %sr.IE is clear
                 nop
-                ld 768, %sr         // now enable interrupts
+                or 1 << 8, %sr      // now enable interrupts (bit 8)
             idle:
                 jmp idle
         "},
@@ -196,7 +196,7 @@ fn masked_interrupt_edge_is_preserved() {
     computer.step().unwrap(); // out: arms E -> raises edge; IE still clear
     computer.step().unwrap(); // nop: IE still clear, edge preserved
     assert_eq!(computer.registers.pc, 1002);
-    computer.step().unwrap(); // ld %sr: IE set -> edge delivered
+    computer.step().unwrap(); // or %sr: IE set -> edge delivered
     assert_eq!(computer.registers.pc, C::INTERRUPT_HANDLER);
 }
 
@@ -298,7 +298,7 @@ fn echo_sample_interrupt_driven_batched() {
     let idle = *debug_info.labels.get("idle").expect("idle label");
 
     computer.step().unwrap(); // out RX_IRQ_ENABLE, [CONTROL]
-    computer.step().unwrap(); // ld SR_SUPERVISOR_IE, %sr
+    computer.step().unwrap(); // or SR_INTERRUPT_ENABLE, %sr
     assert_eq!(computer.registers.pc, idle);
 
     // Deliver "hi" and Ctrl-D in a single push: one interrupt edge covers all
@@ -321,7 +321,7 @@ fn echo_sample_interrupt_driven() {
     // Run the setup (arm the controller + enable interrupts) up to the idle
     // loop.
     computer.step().unwrap(); // out RX_IRQ_ENABLE, [CONTROL]
-    computer.step().unwrap(); // ld SR_SUPERVISOR_IE, %sr
+    computer.step().unwrap(); // or SR_INTERRUPT_ENABLE, %sr
     assert_eq!(computer.registers.pc, idle);
 
     let mut halted = false;

--- a/crates/emulator/tests/io.rs
+++ b/crates/emulator/tests/io.rs
@@ -6,11 +6,10 @@
 use indoc::indoc;
 use pretty_assertions::assert_eq;
 use z33_emulator::compiler::DebugInfo;
-use z33_emulator::constants as C;
 use z33_emulator::preprocessor::{InMemoryFilesystem, Workspace};
 use z33_emulator::runtime::registers::StatusRegister;
 use z33_emulator::runtime::{Cell, Computer, ProcessorError};
-use z33_emulator::{compile, parse};
+use z33_emulator::{compile, constants as C, parse};
 
 /// Compile a program to a ready-to-run [`Computer`] and its debug info.
 fn build(source: &str, entrypoint: &str) -> (Computer, DebugInfo) {
@@ -208,6 +207,102 @@ fn echo_sample_polling() {
     // End-to-end: the polling echo sample reflects its input back to the host.
     let (mut computer, _) = build(include_str!("../../../samples/echo.s"), "main");
     computer.io.serial.push_input(b"hi\x04"); // "hi" then Ctrl-D
+    run(&mut computer);
+    assert_eq!(computer.io.serial.drain_output(), b"hi");
+}
+
+#[test]
+fn in_and_out_leave_flags_unchanged() {
+    // r[verify inst.in]
+    // r[verify inst.out]
+    // `in`/`out` set no flags: force every flag on beforehand and check that
+    // none of them moved after issuing both instructions.
+    let (mut computer, _) = build(
+        indoc! {"
+            .addr 1000
+            main:
+                ld 42, %a
+                out %a, [111]
+                in  [111], %a
+                reset
+        "},
+        "main",
+    );
+    computer.registers.sr = StatusRegister::all();
+    let before = computer.registers.sr;
+    run(&mut computer);
+    assert_eq!(computer.registers.sr, before);
+}
+
+#[test]
+fn hardware_interrupt_is_not_delivered_on_the_exception_recovery_step() {
+    // r[verify io.interrupt.delivery]
+    // r[verify exc.handling.save-state]
+    // A software exception (trap) and a pending hardware interrupt must not
+    // collide on the same step: the trap's save area (100-102) must survive
+    // intact until a later step delivers the interrupt.
+    let (mut computer, _) = build(
+        indoc! {"
+            .addr 200
+            handler:
+                nop
+                reset
+
+            .addr 1000
+            main:
+                ld 256, %sr     // interrupt-enable (supervisor stays set)
+                trap
+                reset
+        "},
+        "main",
+    );
+
+    // Step 1: enable interrupts. No pending edge yet, so nothing is delivered.
+    computer.step().unwrap();
+    assert!(computer
+        .registers
+        .sr
+        .contains(StatusRegister::INTERRUPT_ENABLE));
+
+    // Arm a pending serial interrupt edge *after* IE was enabled, so it
+    // cannot be delivered as a side effect of the previous step.
+    computer.io.write(110, 1); // enable rx interrupts (E bit)
+    computer.io.serial.push_input(b"z"); // raises the edge
+
+    // Step 2: `trap` triggers a software exception. Its recovery must not
+    // also deliver the pending hardware interrupt on this same step.
+    computer.step().unwrap();
+    assert_eq!(computer.registers.pc, C::INTERRUPT_HANDLER);
+    assert_eq!(word_at(&computer, C::INTERRUPT_PC_SAVE), 1002);
+    assert_eq!(word_at(&computer, C::INTERRUPT_SR_SAVE), 256);
+    assert_eq!(word_at(&computer, C::INTERRUPT_EXCEPTION), 4); // trap
+
+    // Step 3: executing the handler's first instruction (`nop`) completes
+    // normally, so the pending hardware interrupt is now delivered, clobbering
+    // the save area with the interrupt's own state.
+    computer.step().unwrap();
+    assert_eq!(computer.registers.pc, C::INTERRUPT_HANDLER);
+    assert_eq!(word_at(&computer, C::INTERRUPT_EXCEPTION), 0); // hardware interrupt
+}
+
+#[test]
+fn echo_sample_interrupt_driven_batched() {
+    // A single multi-byte delivery raises only one interrupt edge; the
+    // sample's handler must drain the receive queue to see every byte
+    // instead of assuming one byte per interrupt.
+    // r[verify io.serial.interrupt.raise]
+    let (mut computer, debug_info) =
+        build(include_str!("../../../samples/echo-interrupt.s"), "main");
+    let idle = *debug_info.labels.get("idle").expect("idle label");
+
+    computer.step().unwrap(); // out RX_IRQ_ENABLE, [CONTROL]
+    computer.step().unwrap(); // ld SR_SUPERVISOR_IE, %sr
+    assert_eq!(computer.registers.pc, idle);
+
+    // Deliver "hi" and Ctrl-D in a single push: one interrupt edge covers all
+    // three bytes.
+    computer.io.serial.push_input(b"hi\x04");
+
     run(&mut computer);
     assert_eq!(computer.io.serial.drain_output(), b"hi");
 }

--- a/crates/emulator/tests/io.rs
+++ b/crates/emulator/tests/io.rs
@@ -250,7 +250,9 @@ fn hardware_interrupt_is_not_delivered_on_the_exception_recovery_step() {
 
             .addr 1000
             main:
-                ld 256, %sr     // interrupt-enable (supervisor stays set)
+                ld 256, %sr     // interrupt-enable only (%sr is overwritten, clearing
+                                // SUPERVISOR; trap needs no privilege and the handler
+                                // entry re-sets it)
                 trap
                 reset
         "},

--- a/crates/emulator/tests/io.rs
+++ b/crates/emulator/tests/io.rs
@@ -1,0 +1,255 @@
+//! Integration tests for the serial console peripheral and the `in`/`out`
+//! instructions.
+
+#![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use z33_emulator::compiler::DebugInfo;
+use z33_emulator::constants as C;
+use z33_emulator::preprocessor::{InMemoryFilesystem, Workspace};
+use z33_emulator::runtime::registers::StatusRegister;
+use z33_emulator::runtime::{Cell, Computer, ProcessorError};
+use z33_emulator::{compile, parse};
+
+/// Compile a program to a ready-to-run [`Computer`] and its debug info.
+fn build(source: &str, entrypoint: &str) -> (Computer, DebugInfo) {
+    let fs = InMemoryFilesystem::new([("/main.S".into(), source.into())]);
+    let mut workspace = Workspace::new(&fs, "/main.S");
+    let preprocessed = workspace.preprocess().expect("preprocess failed").source;
+    let result = parse(&preprocessed);
+    assert!(
+        result.diagnostics.is_empty(),
+        "parse errors: {:?}",
+        result
+            .diagnostics
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+    let compile_result = compile(
+        &result.program.inner,
+        &result.diagnostics,
+        Some(entrypoint),
+        0,
+    );
+    assert!(
+        compile_result.diagnostics.is_empty(),
+        "compilation errors: {:?}",
+        compile_result
+            .diagnostics
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+    (
+        compile_result.computer.expect("no errors but no computer"),
+        compile_result.debug_info,
+    )
+}
+
+/// Read the word stored at a memory address (asserting it holds a word).
+fn word_at(computer: &Computer, address: C::Address) -> C::Word {
+    match computer.memory.get(address).unwrap() {
+        Cell::Word(w) => *w,
+        Cell::Empty => 0,
+        Cell::Instruction(_) => panic!("expected a word at address {address}"),
+    }
+}
+
+/// Run to completion (until `reset`), asserting no error along the way.
+fn run(computer: &mut Computer) {
+    match computer.run() {
+        Ok(()) => {}
+        Err(e) => panic!("unexpected error: {e}"),
+    }
+}
+
+#[test]
+fn out_writes_bytes_to_serial() {
+    // r[verify inst.out]
+    // r[verify io.serial.data.write]
+    let (mut computer, _) = build(
+        indoc! {"
+            .addr 1000
+            main:
+                out 72, [111]   // 'H'
+                out 105, [111]  // 'i'
+                reset
+        "},
+        "main",
+    );
+    run(&mut computer);
+    assert_eq!(computer.io.serial.drain_output(), b"Hi");
+}
+
+#[test]
+fn in_reads_bytes_from_serial() {
+    // r[verify inst.in]
+    // r[verify io.serial.data.read]
+    let (mut computer, _) = build(
+        indoc! {"
+            .addr 1000
+            main:
+                in [111], %a
+                st %a, [10]
+                in [111], %a
+                st %a, [11]
+                reset
+        "},
+        "main",
+    );
+    computer.io.serial.push_input(b"Zx");
+    run(&mut computer);
+    assert_eq!(word_at(&computer, 10), 90); // 'Z'
+    assert_eq!(word_at(&computer, 11), 120); // 'x'
+                                             // The queue is now empty; a further read would yield 0.
+    assert!(!computer.io.serial.input_ready());
+}
+
+#[test]
+fn in_never_blocks_on_empty_queue() {
+    // r[verify inst.in]
+    // Reading an empty serial console returns 0 immediately instead of blocking.
+    let (mut computer, _) = build(
+        indoc! {"
+            .addr 1000
+            main:
+                in [111], %a
+                st %a, [10]
+                reset
+        "},
+        "main",
+    );
+    run(&mut computer);
+    assert_eq!(word_at(&computer, 10), 0);
+}
+
+#[test]
+fn hardware_interrupt_is_delivered_between_instructions() {
+    // r[verify io.interrupt.delivery]
+    // r[verify exc.code.hardware-interrupt]
+    // r[verify io.serial.interrupt.enable-with-queued]
+    let (mut computer, _) = build(
+        indoc! {"
+            .addr 200
+            handler:
+                reset
+
+            .addr 1000
+            main:
+                out 1, [110]        // enable rx interrupts (E bit)
+                ld 768, %sr         // supervisor (512) + interrupt-enable (256)
+            idle:
+                jmp idle
+        "},
+        "main",
+    );
+
+    // Deliver a byte before interrupts are enabled: enabling E while a byte is
+    // queued raises the interrupt (enable-with-queued).
+    computer.io.serial.push_input(b"A");
+
+    // Step 1: `out 1, [110]` arms the controller (raises the interrupt), but
+    // %sr.IE is not set yet so nothing is delivered.
+    computer.step().unwrap();
+    assert_eq!(computer.registers.pc, 1001);
+    // Step 2: `ld 768, %sr` enables interrupts; the pending interrupt is then
+    // delivered between this instruction and the next.
+    computer.step().unwrap();
+
+    // We jumped to the handler at 200.
+    assert_eq!(computer.registers.pc, C::INTERRUPT_HANDLER);
+    // The exception code (address 102) is 0: a hardware interrupt.
+    assert_eq!(word_at(&computer, C::INTERRUPT_EXCEPTION), 0);
+    // Interrupts were disabled on hardware-interrupt entry.
+    assert!(!computer
+        .registers
+        .sr
+        .contains(StatusRegister::INTERRUPT_ENABLE));
+    // ...but we are still (and now definitely) in supervisor mode.
+    assert!(computer.registers.sr.contains(StatusRegister::SUPERVISOR));
+}
+
+#[test]
+fn masked_interrupt_edge_is_preserved() {
+    // A pending interrupt raised while %sr.IE is clear is not lost: it is
+    // delivered as soon as interrupts are re-enabled.
+    // r[verify io.interrupt.delivery]
+    let (mut computer, _) = build(
+        indoc! {"
+            .addr 200
+            handler:
+                reset
+
+            .addr 1000
+            main:
+                out 1, [110]        // enable rx interrupts, but %sr.IE is clear
+                nop
+                ld 768, %sr         // now enable interrupts
+            idle:
+                jmp idle
+        "},
+        "main",
+    );
+    computer.io.serial.push_input(b"A"); // raises the edge (E already implied)
+
+    computer.step().unwrap(); // out: arms E -> raises edge; IE still clear
+    computer.step().unwrap(); // nop: IE still clear, edge preserved
+    assert_eq!(computer.registers.pc, 1002);
+    computer.step().unwrap(); // ld %sr: IE set -> edge delivered
+    assert_eq!(computer.registers.pc, C::INTERRUPT_HANDLER);
+}
+
+#[test]
+fn echo_sample_polling() {
+    // r[verify inst.in]
+    // r[verify inst.out]
+    // End-to-end: the polling echo sample reflects its input back to the host.
+    let (mut computer, _) = build(include_str!("../../../samples/echo.s"), "main");
+    computer.io.serial.push_input(b"hi\x04"); // "hi" then Ctrl-D
+    run(&mut computer);
+    assert_eq!(computer.io.serial.drain_output(), b"hi");
+}
+
+#[test]
+fn echo_sample_interrupt_driven() {
+    // End-to-end: the interrupt-driven echo sample reflects input pushed one
+    // byte at a time (each delivery raises its own interrupt).
+    // r[verify io.interrupt.delivery]
+    let (mut computer, debug_info) =
+        build(include_str!("../../../samples/echo-interrupt.s"), "main");
+    let idle = *debug_info.labels.get("idle").expect("idle label");
+
+    // Run the setup (arm the controller + enable interrupts) up to the idle
+    // loop.
+    computer.step().unwrap(); // out RX_IRQ_ENABLE, [CONTROL]
+    computer.step().unwrap(); // ld SR_SUPERVISOR_IE, %sr
+    assert_eq!(computer.registers.pc, idle);
+
+    let mut halted = false;
+    for &byte in b"hi\x04" {
+        computer.io.serial.push_input(&[byte]);
+        // Let the interrupt fire and the handler run until we are back idling
+        // (byte serviced) or the machine resets (Ctrl-D).
+        for _ in 0..100 {
+            match computer.step() {
+                Ok(()) => {}
+                Err(ProcessorError::Reset) => {
+                    halted = true;
+                    break;
+                }
+                Err(e) => panic!("unexpected error: {e}"),
+            }
+            if !computer.io.serial.input_ready() && computer.registers.pc == idle {
+                break;
+            }
+        }
+        if halted {
+            break;
+        }
+    }
+
+    assert!(halted, "the sample should reset on Ctrl-D");
+    assert_eq!(computer.io.serial.drain_output(), b"hi");
+}

--- a/samples/echo-interrupt.s
+++ b/samples/echo-interrupt.s
@@ -19,8 +19,9 @@
 #define EXCEPTION 102   // where the CPU stores the exception code
 #define HARDWARE_INTERRUPT 0    // exception code for a device interrupt
 
-// %sr layout: supervisor is bit 9 (512), interrupt-enable is bit 8 (256).
-#define SR_SUPERVISOR_IE 768
+// %sr layout: supervisor is bit 9, already set at boot; interrupt-enable is
+// bit 8. Build the mask with a bit shift instead of a magic number.
+#define SR_INTERRUPT_ENABLE 1 << 8      // %sr bit 8: interrupt enable
 
 .addr 200
 handler:
@@ -50,6 +51,6 @@ halt:
 .addr 1000
 main:
     out RX_IRQ_ENABLE, [CONTROL]    // arm an interrupt on receive
-    ld  SR_SUPERVISOR_IE, %sr       // stay supervisor, enable interrupts
+    or  SR_INTERRUPT_ENABLE, %sr    // switch on interrupts (we boot in supervisor mode)
 idle:
     jmp idle                        // do nothing until interrupted

--- a/samples/echo-interrupt.s
+++ b/samples/echo-interrupt.s
@@ -1,15 +1,19 @@
 // Interrupt-driven serial echo.
 //
 // Instead of busy-polling, this program arms the serial console to raise a
-// hardware interrupt whenever a byte arrives, then idles. The handler at
-// address 200 echoes each received byte. Sending EOT (Ctrl-D, byte 4) ends the
-// program.
+// hardware interrupt whenever data arrives, then idles. The handler at
+// address 200 drains the receive queue, echoing each byte it finds — a
+// single interrupt may correspond to several bytes delivered at once (e.g. a
+// whole pasted line), so the handler polls the R bit rather than assuming
+// one byte per interrupt. Sending EOT (Ctrl-D, byte 4) ends the program.
 //
 // Run with:   z33-cli run samples/echo-interrupt.s main
 
+#define STATUS  110     // read: status register
 #define CONTROL 110     // write: control register (E bit enables rx interrupts)
 #define DATA    111     // read: rx data, write: tx data
 #define RX_IRQ_ENABLE 1 // control bit 0: interrupt when a byte is received
+#define RX_READY 1      // status bit 0: a byte is waiting to be read
 #define EOT     4       // Ctrl-D: end of transmission
 
 #define EXCEPTION 102   // where the CPU stores the exception code
@@ -25,10 +29,16 @@ handler:
     cmp HARDWARE_INTERRUPT, %a
     jne return                  // not a device interrupt: ignore it
 
+drain:
+    in  [STATUS], %a            // is another byte waiting?
+    and RX_READY, %a
+    jeq return                  // queue empty: done draining
+
     in  [DATA], %a              // read the received byte
     cmp EOT, %a                 // Ctrl-D ends the session
     jeq halt
     out %a, [DATA]              // echo it back
+    jmp drain                   // keep draining the queue
 
 return:
     pop %a
@@ -39,7 +49,7 @@ halt:
 
 .addr 1000
 main:
-    out RX_IRQ_ENABLE, [CONTROL]    // raise an interrupt on every byte received
+    out RX_IRQ_ENABLE, [CONTROL]    // arm an interrupt on receive
     ld  SR_SUPERVISOR_IE, %sr       // stay supervisor, enable interrupts
 idle:
     jmp idle                        // do nothing until interrupted

--- a/samples/echo-interrupt.s
+++ b/samples/echo-interrupt.s
@@ -1,0 +1,45 @@
+// Interrupt-driven serial echo.
+//
+// Instead of busy-polling, this program arms the serial console to raise a
+// hardware interrupt whenever a byte arrives, then idles. The handler at
+// address 200 echoes each received byte. Sending EOT (Ctrl-D, byte 4) ends the
+// program.
+//
+// Run with:   z33-cli run samples/echo-interrupt.s main
+
+#define CONTROL 110     // write: control register (E bit enables rx interrupts)
+#define DATA    111     // read: rx data, write: tx data
+#define RX_IRQ_ENABLE 1 // control bit 0: interrupt when a byte is received
+#define EOT     4       // Ctrl-D: end of transmission
+
+#define EXCEPTION 102   // where the CPU stores the exception code
+#define HARDWARE_INTERRUPT 0    // exception code for a device interrupt
+
+// %sr layout: supervisor is bit 9 (512), interrupt-enable is bit 8 (256).
+#define SR_SUPERVISOR_IE 768
+
+.addr 200
+handler:
+    push %a
+    ld  [EXCEPTION], %a         // why were we interrupted?
+    cmp HARDWARE_INTERRUPT, %a
+    jne return                  // not a device interrupt: ignore it
+
+    in  [DATA], %a              // read the received byte
+    cmp EOT, %a                 // Ctrl-D ends the session
+    jeq halt
+    out %a, [DATA]              // echo it back
+
+return:
+    pop %a
+    rti
+
+halt:
+    reset
+
+.addr 1000
+main:
+    out RX_IRQ_ENABLE, [CONTROL]    // raise an interrupt on every byte received
+    ld  SR_SUPERVISOR_IE, %sr       // stay supervisor, enable interrupts
+idle:
+    jmp idle                        // do nothing until interrupted

--- a/samples/echo.s
+++ b/samples/echo.s
@@ -1,0 +1,27 @@
+// Polling serial echo.
+//
+// Busy-waits on the serial console (ports 110-111), echoing every byte it
+// receives back to the host. Sending EOT (Ctrl-D, byte 4) ends the program.
+//
+// Run with:   z33-cli run samples/echo.s main
+
+#define STATUS 110      // read: status register, write: control register
+#define DATA   111      // read: rx data,        write: tx data
+#define RX_READY 1      // status bit 0: a byte is waiting to be read
+#define EOT      4       // Ctrl-D: end of transmission
+
+.addr 1000
+main:
+poll:
+    in  [STATUS], %a    // read the status register
+    and RX_READY, %a    // isolate the R bit
+    jeq poll            // nothing received yet: keep polling
+
+    in  [DATA], %a      // pop the received byte
+    cmp EOT, %a         // was it Ctrl-D?
+    jeq done            // yes: stop
+    out %a, [DATA]      // no: echo it back
+    jmp poll
+
+done:
+    reset

--- a/spec/src/04-instructions/07-io.md
+++ b/spec/src/04-instructions/07-io.md
@@ -1,8 +1,8 @@
 # I/O Instructions
 
-The Z33 uses port-mapped I/O. These instructions are **privileged** and can only be executed in supervisor mode.
+The Z33 uses port-mapped I/O. These instructions are **privileged** and can only be executed in supervisor mode. The operand designates a **port number**, not a memory address; no memory is dereferenced.
 
-> **Note:** The `in` and `out` instructions are defined in the ISA but are **not currently implemented** in the emulator. Executing either instruction in the emulator will cause a runtime panic (`todo!()`). The semantics described here are based on the reference card.
+The emulator implements these instructions and routes them to its I/O controllers (see [I/O Controllers](../09-io-controllers.md)). Accesses to ports that no controller handles read as 0 and ignore writes.
 
 ## `in` — Input from I/O Port
 

--- a/spec/src/09-io-controllers.md
+++ b/spec/src/09-io-controllers.md
@@ -156,7 +156,7 @@ r[io.serial.control.rx-interrupt-enable]
 Writing the control register with the E bit set arms receive interrupts; writing it clear disarms them.
 
 r[io.serial.interrupt.raise]
-While receive interrupts are armed (E set), each byte delivered into the receive queue raises a hardware interrupt.
+While receive interrupts are armed (E set), delivering data into the receive queue raises a hardware interrupt. A single delivery may carry several bytes at once (for example, a host flushing a whole line or paste in one go), in which case it still raises only one interrupt; likewise, several pending interrupts collapse into a single edge to the processor. Handlers therefore cannot assume one byte per interrupt: they should poll the R bit and drain the receive queue until it is empty before returning.
 
 r[io.serial.interrupt.enable-with-queued]
 Arming receive interrupts (writing E from 0 to 1) while the receive queue is already non-empty raises a hardware interrupt immediately, so a program never misses input that arrived before it enabled interrupts.

--- a/spec/src/09-io-controllers.md
+++ b/spec/src/09-io-controllers.md
@@ -1,8 +1,18 @@
 # I/O Controllers
 
-*This chapter is informative. The I/O controllers are defined in the reference card but are not implemented in the current emulator.*
-
 The Z33 uses **port-mapped I/O**. Controllers are accessed using the privileged `in` and `out` instructions, with port addresses identifying specific controller registers.
+
+The keyboard and disk controllers below are **informative**: they are defined in the reference card but are not implemented by the current emulator. The **serial controller** *is* implemented.
+
+## General Behavior
+
+r[io.unmapped]
+Reading from a port that no controller handles yields 0, and writing to such a port is ignored. No exception is raised for unmapped ports.
+
+r[io.interrupt.delivery]
+A controller may raise a **hardware interrupt** (exception code 0). The interrupt is delivered *between instructions*: after an instruction completes, if the interrupt-enable bit (`%sr.IE`) is set and a controller has a pending interrupt, the processor enters the exception handler as described in [Exceptions and Interrupts](06-exceptions.md). If `%sr.IE` is clear, the pending interrupt is held and delivered as soon as interrupts are re-enabled.
+
+Since there is a single exception vector and all hardware interrupts report code 0, the handler must inspect each controller's status register (its I bit) to discover which device requires servicing.
 
 ## Keyboard Controller
 
@@ -99,3 +109,71 @@ Bit:  ...  3    2    1    0
 Each port holds one byte of data representing either:
 - The sector location in C/H/S format (when the L bit is set in the control register), or
 - Data to be read from or written to the disk
+
+## Serial Controller
+
+The serial controller occupies ports **110–111**. Unlike the keyboard and disk controllers, it **is implemented** by the emulator: it models a byte-oriented console connected to the host. Received bytes are queued for the program to read; transmitted bytes are buffered for the host to display.
+
+Transmission is **instantaneous** — writing a byte never blocks, and the transmit-ready bit is always set. Reception is host-driven: the host delivers bytes into the receive queue, which the program drains one byte at a time.
+
+### Status Register — Port 110 (Read-only)
+
+```
+Bit:  ...  2    1    0
+       ...  I    T    R
+```
+
+| Bit | Name | Description |
+|---|---|---|
+| 0 | R (Ready) | 1 if a received byte is waiting to be read (the receive queue is non-empty) |
+| 1 | T (Transmit) | Always 1 — transmission is instantaneous, so the controller is always ready to send |
+| 2 | I (Interrupt) | 1 if the controller has generated an interrupt |
+
+r[io.serial.status.rx-ready]
+The R bit is 1 exactly when the receive queue is non-empty.
+
+r[io.serial.status.tx-ready]
+The T bit is always 1: a write to the data register never blocks.
+
+r[io.serial.status.interrupt]
+The I bit is 1 when the controller has raised an interrupt that has not yet been acknowledged.
+
+r[io.serial.status.read-clears-interrupt]
+Reading the status register **clears the I bit** (the same idiom as the keyboard and disk controllers).
+
+### Control Register — Port 110 (Write-only)
+
+```
+Bit:  ...  1    0
+       ...  -    E
+```
+
+| Bit | Name | Description |
+|---|---|---|
+| 0 | E (Enable) | 1 to generate a hardware interrupt whenever a byte is received |
+
+r[io.serial.control.rx-interrupt-enable]
+Writing the control register with the E bit set arms receive interrupts; writing it clear disarms them.
+
+r[io.serial.interrupt.raise]
+While receive interrupts are armed (E set), each byte delivered into the receive queue raises a hardware interrupt.
+
+r[io.serial.interrupt.enable-with-queued]
+Arming receive interrupts (writing E from 0 to 1) while the receive queue is already non-empty raises a hardware interrupt immediately, so a program never misses input that arrived before it enabled interrupts.
+
+r[io.serial.interrupt.edge]
+Each raised interrupt is delivered to the processor at most once. Acknowledging the interrupt in the status register (clearing the I bit) is independent from this delivery.
+
+### Data Register — Port 111 (Read)
+
+r[io.serial.data.read]
+Reading the data register removes and returns the byte at the front of the receive queue, as a word in the range 0–255. If the receive queue is empty, the read returns 0. **A read never blocks**, even when no byte is available; programs busy-poll the R bit to wait for input.
+
+### Data Register — Port 111 (Write)
+
+r[io.serial.data.write]
+Writing the data register appends the low 8 bits of the value (`value & 0xFF`) to the transmit buffer for the host to display. The write never blocks.
+
+### Line Convention
+
+The host sends the byte `\n` (line feed, 10) for the Enter key, and programs should emit `\n` to advance to a new line.


### PR DESCRIPTION
## What & why

The Z33 spec mandates port-mapped I/O through the privileged `in`/`out` instructions, which until now were `todo!()` stubs that panicked at runtime. This PR adds a **serial console peripheral** (ports 110–111) and wires up `in`/`out` so programs can do real character I/O.

This is **PR 1 of a stack**: it lands the emulator core, spec, and samples only. CLI, WASM, and DAP/web integration land in follow-up stacked PRs and build on the host-facing API introduced here.

## Register layout (ports 110–111)

| Port | Access | Register | Bits |
|------|--------|----------|------|
| 110 | read | STATUS | 0=R (rx ready), 1=T (tx ready, always 1), 2=I (interrupt) |
| 110 | write | CONTROL | 0=E (raise interrupt on rx) |
| 111 | read | DATA | pops the front rx byte (0 if empty) |
| 111 | write | DATA | appends `value & 0xFF` to the tx buffer |

Reading STATUS clears the I bit (same idiom as the keyboard/disk controllers). Reads never block; writes never block (T is always 1). Unmapped ports read as 0 and ignore writes (no new exception). Hosts send `\n` for Enter.

## Interrupt model

Edge-based. Delivering input while receive interrupts are armed (E set) — or arming them while input is already queued — raises a hardware interrupt (exception code 0). `step()` delivers it *between instructions* when `%sr.IE` is set, reusing the existing exception path (handler at 200, `%pc`→100, `%sr`→101, code→102, SUPERVISOR set, IE cleared, `rti` restores). The IE check precedes the bus poll, so an interrupt raised while interrupts are masked is preserved and delivered once they are re-enabled. Because all hardware interrupts report code 0, handlers inspect each device's I bit to find the source.

## Structure

- New `crates/emulator/src/runtime/io.rs`: a `Device` trait seam plus `IoBus { pub serial: SerialConsole }` — a concrete typed field, not `Box<dyn Device>`, so hosts get typed access without downcasting.
- `Computer` gains `pub io: IoBus` (stays `#[derive(Default)]`).
- Host-facing API: `SerialConsole::push_input(&mut self, &[u8])`, `drain_output(&mut self) -> Vec<u8>`, `input_ready(&self) -> bool`.

## Test coverage

- `SerialConsole`/`IoBus` unit tests: status bits, I-bit clear on status read, data pop / empty-read-0, byte masking, drain, unmapped ports, edge-consumed `poll_interrupt`, enable-with-queued.
- Instruction-level `in`/`out` execution; privilege check (existing `in_is_privileged`/`out_is_privileged` updated — the `todo!()` is gone but the user-mode privilege exception is unchanged).
- Interrupt delivery: IE + queued input → exception path fires (pc 200, code 0, IE cleared); masked-edge-preserved.
- End-to-end: both samples compiled via `include_str!`, driven with `push_input`, output asserted.

Spec is tracey-tracked: `spec/src/09-io-controllers.md` is now included in the tracey config, and the new `io.*` rules are all covered and verified (111/111).

🤖 Generated with [Claude Code](https://claude.com/claude-code)