### PR TITLE
Add a serial console to the web IDE

### DIFF
--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -490,6 +490,21 @@ impl Computer {
             .subscribe(address, callback.unchecked_into())
             .unchecked_into()
     }
+
+    /// Push bytes into the serial console's receive buffer. Each call raises a
+    /// single receive-interrupt edge, so push once per keystroke or paste
+    /// chunk.
+    pub fn push_serial_input(&mut self, bytes: &[u8]) {
+        self.inner.io.serial.push_input(bytes);
+    }
+
+    /// Drain and return the bytes the program has written to the serial
+    /// console since the last call. Polled once per step/batch by the caller,
+    /// mirroring the registers/cycles getter model.
+    #[must_use]
+    pub fn drain_serial_output(&mut self) -> Vec<u8> {
+        self.inner.io.serial.drain_output()
+    }
 }
 
 struct MemoryObserver {

--- a/editors/web/app/debug-layout.tsx
+++ b/editors/web/app/debug-layout.tsx
@@ -10,6 +10,7 @@ import { stripLeadingSlash } from "./lib/file-paths";
 import { MemoryPanel } from "./memory-panel";
 import { MultiFileEditor } from "./multi-file-editor";
 import { ResizeHandle } from "./panel-resize-handle";
+import { SerialConsole } from "./serial-console";
 import { useAppStore } from "./stores/app-store";
 import { useFileStore } from "./stores/file-store";
 import { Group, Panel } from "react-resizable-panels";
@@ -91,34 +92,42 @@ const DebugLayoutInner: React.FC<DebugLayoutInnerProps> = ({
         onFileChange={setActiveFile}
         onStop={onStopDebug}
       />
-      <Group orientation="horizontal" id="z33-h" className="flex-1 min-h-0">
-        <Panel defaultSize="65%" minSize="40%" id="z33-editor">
-          <MultiFileEditor
-            filePath={activeFile}
-            readOnly
-            onEditorMount={handleDebugEditorMount}
-          />
+      <Group orientation="vertical" id="z33-v" className="flex-1 min-h-0">
+        <Panel defaultSize="75%" minSize="30%" id="z33-main">
+          <Group orientation="horizontal" id="z33-h" className="h-full">
+            <Panel defaultSize="65%" minSize="40%" id="z33-editor">
+              <MultiFileEditor
+                filePath={activeFile}
+                readOnly
+                onEditorMount={handleDebugEditorMount}
+              />
+            </Panel>
+            <ResizeHandle />
+            <Panel defaultSize="35%" minSize="20%" maxSize="50%" id="z33-right">
+              <div className="flex flex-col h-full border-l">
+                <div className="shrink-0 border-b">
+                  <RegisterPanel
+                    computer={computer}
+                    labels={labels}
+                    following={following}
+                    onFollow={setFollowing}
+                  />
+                </div>
+                <div className="flex-1 min-h-0">
+                  <MemoryPanel
+                    computer={computer}
+                    labels={labels}
+                    following={following}
+                    onFollow={setFollowing}
+                  />
+                </div>
+              </div>
+            </Panel>
+          </Group>
         </Panel>
-        <ResizeHandle />
-        <Panel defaultSize="35%" minSize="20%" maxSize="50%" id="z33-right">
-          <div className="flex flex-col h-full border-l">
-            <div className="shrink-0 border-b">
-              <RegisterPanel
-                computer={computer}
-                labels={labels}
-                following={following}
-                onFollow={setFollowing}
-              />
-            </div>
-            <div className="flex-1 min-h-0">
-              <MemoryPanel
-                computer={computer}
-                labels={labels}
-                following={following}
-                onFollow={setFollowing}
-              />
-            </div>
-          </div>
+        <ResizeHandle orientation="vertical" />
+        <Panel defaultSize="25%" minSize="10%" collapsible id="z33-console">
+          <SerialConsole computer={computer} />
         </Panel>
       </Group>
     </div>

--- a/editors/web/app/lib/computer-proxy.ts
+++ b/editors/web/app/lib/computer-proxy.ts
@@ -194,6 +194,7 @@ export class ComputerProxy implements ComputerInterface {
   #statusSubs = new Set<(s: RunStatus) => void>();
   #pcSubs = new Set<() => void>();
   #cellSubs = new Map<number, Set<(c: Cell) => void>>();
+  #outputSubs = new Set<(bytes: number[]) => void>();
 
   constructor(
     workerClient: EmulatorWorkerClient,
@@ -277,6 +278,22 @@ export class ComputerProxy implements ComputerInterface {
     this.#client.send({ type: "setSpeed", speed });
   }
 
+  /** Send bytes to the serial console; one receive-interrupt edge per call. */
+  sendInput(bytes: number[]): void {
+    this.#client.send({ type: "input", bytes });
+  }
+
+  /**
+   * Subscribe to serial output. The callback fires with each non-empty batch of
+   * bytes the program has written, as they arrive on worker snapshots.
+   */
+  onOutput(cb: (bytes: number[]) => void): Unsubscribe {
+    this.#outputSubs.add(cb);
+    return () => {
+      this.#outputSubs.delete(cb);
+    };
+  }
+
   resolveBreakpoint(
     file: string,
     line: number,
@@ -337,6 +354,10 @@ export class ComputerProxy implements ComputerInterface {
     }
 
     this.applyCells(snapshot.changedCells);
+
+    if (snapshot.output.length > 0) {
+      for (const cb of this.#outputSubs) cb(snapshot.output);
+    }
   }
 
   applyCells(cells: [number, Cell][]): void {

--- a/editors/web/app/lib/emulator-protocol.ts
+++ b/editors/web/app/lib/emulator-protocol.ts
@@ -26,6 +26,11 @@ export interface Snapshot {
   pc: number;
   /** Resolved source location of `%pc`, if it maps to code. */
   location: SourcePosition | null;
+  /**
+   * Bytes the program has written to the serial console since the previous
+   * snapshot. Rides the same throttle + terminal-flush as `changedCells`.
+   */
+  output: number[];
 }
 
 // ---------------------------------------------------------------------------
@@ -52,7 +57,9 @@ export type WorkerRequest =
   | { type: "setSpeed"; speed: number | null }
   | { id: number; type: "resolveBreakpoint"; file: string; line: number }
   | { type: "watchCells"; addresses: number[] }
-  | { type: "unwatchCells"; addresses: number[] };
+  | { type: "unwatchCells"; addresses: number[] }
+  /** Bytes typed/pasted into the serial console; one IRQ edge per message. */
+  | { type: "input"; bytes: number[] };
 
 // ---------------------------------------------------------------------------
 // Worker -> main thread

--- a/editors/web/app/panel-resize-handle.tsx
+++ b/editors/web/app/panel-resize-handle.tsx
@@ -1,12 +1,21 @@
 import { Separator } from "react-resizable-panels";
 import { cn } from "./lib/utils";
 
-export const ResizeHandle: React.FC = () => (
+type ResizeHandleProps = {
+  /** Matches the parent `Group` orientation. Defaults to horizontal. */
+  orientation?: "horizontal" | "vertical";
+};
+
+export const ResizeHandle: React.FC<ResizeHandleProps> = ({
+  orientation = "horizontal",
+}) => (
   <Separator
     className={cn(
       "group relative flex items-center justify-center bg-border",
-      "w-px data-[resize-handle-active]:w-1 hover:w-1",
       "transition-all duration-150 data-[resize-handle-active]:bg-ring",
+      orientation === "horizontal"
+        ? "w-px data-[resize-handle-active]:w-1 hover:w-1"
+        : "h-px data-[resize-handle-active]:h-1 hover:h-1",
     )}
   />
 );

--- a/editors/web/app/serial-console.tsx
+++ b/editors/web/app/serial-console.tsx
@@ -1,0 +1,165 @@
+import { TerminalIcon, Trash2Icon } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { Button } from "./components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "./components/ui/tooltip";
+import type { ComputerProxy } from "./lib/computer-proxy";
+import { cn } from "./lib/utils";
+
+type SerialConsoleProps = {
+  computer: ComputerProxy;
+};
+
+const encoder = new TextEncoder();
+
+/** How close to the bottom (px) still counts as "following" the output. */
+const AUTOSCROLL_THRESHOLD = 24;
+
+/**
+ * A minimal serial terminal wired to the emulator's serial console
+ * (ports 110-111). Program output is decoded and appended to an ephemeral
+ * scrollback; printable keystrokes, Enter, Backspace, Ctrl-<letter> and pastes
+ * are forwarded to the emulator as receive bytes. There is **no local echo** —
+ * only what the program writes back appears.
+ *
+ * Scrollback lives in component state and is reset whenever the `computer`
+ * (i.e. the debug session) changes.
+ */
+export const SerialConsole: React.FC<SerialConsoleProps> = ({ computer }) => {
+  const [text, setText] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  // Tracks whether the view should stick to the bottom on new output.
+  const followRef = useRef(true);
+
+  // Reset scrollback and subscribe to output whenever the session changes. A
+  // fresh streaming decoder per session avoids carrying a partial multi-byte
+  // sequence across sessions.
+  useEffect(() => {
+    setText("");
+    followRef.current = true;
+    const decoder = new TextDecoder();
+    const unsubscribe = computer.onOutput((bytes) => {
+      const chunk = decoder.decode(Uint8Array.from(bytes), { stream: true });
+      if (chunk) setText((prev) => prev + chunk);
+    });
+    return unsubscribe;
+  }, [computer]);
+
+  // Auto-scroll to the bottom after new output, unless the user scrolled up.
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (el && followRef.current) el.scrollTop = el.scrollHeight;
+  }, [text]);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+    followRef.current = distance <= AUTOSCROLL_THRESHOLD;
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.metaKey || event.altKey) return;
+
+      if (event.ctrlKey) {
+        // Map Ctrl-<letter> to its control code (Ctrl-D -> 4 = EOT). Leave
+        // browser shortcuts like Ctrl-C/Ctrl-V (copy/paste) alone.
+        const code = event.key.toUpperCase().codePointAt(0);
+        if (
+          event.key.length === 1 &&
+          code !== undefined &&
+          code >= 65 &&
+          code <= 90
+        ) {
+          if (event.key === "c" || event.key === "v") return;
+          event.preventDefault();
+          computer.sendInput([code - 64]);
+        }
+        return;
+      }
+
+      if (event.key === "Enter") {
+        event.preventDefault();
+        computer.sendInput([0x0a]);
+      } else if (event.key === "Backspace") {
+        event.preventDefault();
+        computer.sendInput([0x08]);
+      } else if (event.key.length === 1) {
+        event.preventDefault();
+        computer.sendInput([...encoder.encode(event.key)]);
+      }
+    },
+    [computer],
+  );
+
+  const handlePaste = useCallback(
+    (event: React.ClipboardEvent<HTMLDivElement>) => {
+      const pasted = event.clipboardData.getData("text");
+      if (!pasted) return;
+      event.preventDefault();
+      // One receive-interrupt edge for the whole paste.
+      computer.sendInput([...encoder.encode(pasted)]);
+    },
+    [computer],
+  );
+
+  const clear = useCallback(() => {
+    setText("");
+    followRef.current = true;
+  }, []);
+
+  return (
+    <div className="flex flex-col h-full border-t bg-background">
+      <div className="flex shrink-0 items-center gap-1.5 border-b px-2.5 py-1">
+        <TerminalIcon className="size-3.5 text-muted-foreground" />
+        <span className="text-xs font-medium text-muted-foreground">
+          Serial console
+        </span>
+        <div className="ml-auto">
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={clear}
+                  aria-label="Clear serial console"
+                >
+                  <Trash2Icon />
+                </Button>
+              }
+            />
+            <TooltipContent>Clear</TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        onKeyDown={handleKeyDown}
+        onPaste={handlePaste}
+        tabIndex={0}
+        role="textbox"
+        aria-label="Serial console output"
+        aria-multiline="true"
+        className={cn(
+          "flex-1 min-h-0 overflow-auto whitespace-pre-wrap break-words",
+          "px-2.5 py-1.5 font-mono text-xs leading-relaxed outline-none",
+          "focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset",
+        )}
+      >
+        {text}
+      </div>
+    </div>
+  );
+};

--- a/editors/web/app/workers/emulator.worker.ts
+++ b/editors/web/app/workers/emulator.worker.ts
@@ -56,6 +56,13 @@ let running = false;
 let breakpoints: number[] = [];
 const watched = new Map<number, () => void>();
 const pendingCells = new Map<number, Cell>();
+/**
+ * Bytes the program has written to the serial console since the last snapshot.
+ * Filled after every step/batch (before the push decision) and drained into the
+ * snapshot, so it rides the same 40ms throttle and terminal flush as
+ * `pendingCells` — no trailing bytes are lost.
+ */
+let outputBuffer: number[] = [];
 let lastSnapshotAt = 0;
 /** Target clock speed in cycles per second; `null` = full speed. */
 let speed: number | null = null;
@@ -86,6 +93,8 @@ function buildSnapshot(status: RunStatus, error?: string): Snapshot {
   const pc = registers.pc;
   const changedCells = [...pendingCells.entries()];
   pendingCells.clear();
+  const output = outputBuffer;
+  outputBuffer = [];
   return {
     registers,
     cycles: computer.cycles(),
@@ -94,7 +103,15 @@ function buildSnapshot(status: RunStatus, error?: string): Snapshot {
     ...(error === undefined ? {} : { error }),
     pc,
     location: sourceIndex?.location_for(pc) ?? null,
+    output,
   };
+}
+
+/** Drain the emulator's serial output into the pending output buffer. */
+function drainOutput(): void {
+  if (!computer) return;
+  const bytes = computer.drain_serial_output();
+  if (bytes.length > 0) outputBuffer.push(...bytes);
 }
 
 function pushSnapshot(status: RunStatus, error?: string): void {
@@ -129,10 +146,14 @@ function executeBatch(
     result = computer.run_batch(maxSteps, Uint32Array.from(breakpoints));
   } catch (error) {
     running = false;
+    drainOutput();
     pushSnapshot("panicked", String(error));
     return null;
   }
 
+  // Drain serial output before the push decision so bytes emitted by this batch
+  // ride the same snapshot as the state that produced them.
+  drainOutput();
   const status = statusFromBatch(result.status);
   if (status !== "running") {
     running = false;
@@ -236,6 +257,7 @@ function stopSession(): void {
   for (const unsubscribe of watched.values()) unsubscribe();
   watched.clear();
   pendingCells.clear();
+  outputBuffer = [];
   computer?.free();
   computer = null;
   sourceIndex = null;
@@ -300,6 +322,7 @@ self.addEventListener("message", (event: MessageEvent<WorkerRequest>) => {
             Math.max(1, message.n),
             Uint32Array.from([]),
           );
+          drainOutput();
           const status = statusFromBatch(result.status);
           // A finished step budget reads back as "running"; surface it as a
           // stopped (paused) state since we are not continuously running.
@@ -308,6 +331,7 @@ self.addEventListener("message", (event: MessageEvent<WorkerRequest>) => {
             result.error ?? undefined,
           );
         } catch (error) {
+          drainOutput();
           pushSnapshot("panicked", String(error));
         }
         break;
@@ -355,6 +379,11 @@ self.addEventListener("message", (event: MessageEvent<WorkerRequest>) => {
       }
       case "unwatchCells": {
         for (const address of message.addresses) unwatch(address);
+        break;
+      }
+      case "input": {
+        // One IRQ edge per message; works whether running or paused.
+        computer?.push_serial_input(Uint8Array.from(message.bytes));
         break;
       }
     }

--- a/editors/web/e2e/serial-console.spec.ts
+++ b/editors/web/e2e/serial-console.spec.ts
@@ -1,0 +1,56 @@
+import { enterDebugMode, expect, loadWorkspace, test } from "./fixtures";
+
+// A polling serial echo: it busy-waits on the serial console and echoes every
+// received byte back to the host, stopping on EOT (Ctrl-D, byte 4).
+const ECHO_PROGRAM = `#define STATUS 110
+#define DATA   111
+#define RX_READY 1
+#define EOT      4
+
+.addr 1000
+main:
+poll:
+    in  [STATUS], %a
+    and RX_READY, %a
+    jeq poll
+
+    in  [DATA], %a
+    cmp EOT, %a
+    jeq done
+    out %a, [DATA]
+    jmp poll
+
+done:
+    reset
+`;
+
+test.describe("Serial console", () => {
+  test("echoes typed input back to the console", async ({ page }) => {
+    await loadWorkspace(page, { "echo.s": ECHO_PROGRAM }, "echo.s");
+    await enterDebugMode(page);
+
+    // Start continuous execution so the program busy-polls for input.
+    await page
+      .getByRole("toolbar", { name: "Debug" })
+      .getByRole("button", { name: "Run", exact: true })
+      .click();
+
+    const console = page.getByRole("textbox", { name: "Serial console output" });
+    await expect(console).toBeVisible();
+
+    // Focus the console and type: the program should echo each byte back.
+    await console.click();
+    await page.keyboard.type("hi");
+
+    await expect(console).toHaveText(/hi/);
+
+    // Ctrl-D (EOT) ends the program.
+    await page.keyboard.press("Control+d");
+    await expect(
+      page.getByRole("toolbar", { name: "Debug" }).getByRole("button", {
+        name: "Run",
+        exact: true,
+      }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
Stacked on #988 (the serial peripheral core). Wires the serial console (ports 110-111) through to the web debugger.

## wasm bindings (`crates/wasm`)
- `Computer::push_serial_input(&[u8])` — surfaced as a `Uint8Array` param; one receive-IRQ edge per call (push once per keystroke/paste chunk).
- `Computer::drain_serial_output() -> Uint8Array` — a polled getter, matching the existing "registers/cycles are polled" model, so it works for both the step and `run_batch` paths without a new `BatchResult` field.

## Protocol (`emulator-protocol.ts`)
- New main→worker message `{ type: "input"; bytes: number[] }`.
- New `Snapshot.output: number[]` field.
- **No new `RunStatus`**: `in` never blocks — a program awaiting input busy-polls, so there is no waiting state to model.

## Worker (`emulator.worker.ts`)
- Module-level `outputBuffer`, appended after every step/`run_batch` execution **before the push decision**, then moved into the snapshot and cleared in `buildSnapshot`. This reuses the exact `pendingCells`→`changedCells` pattern, so serial output rides the existing 40ms snapshot throttle and the guaranteed terminal-snapshot flush — no trailing bytes lost.
- `input` handled whether running or paused; buffer cleared on session teardown.

## Proxy (`computer-proxy.ts`)
- `sendInput(bytes)` posts the input message.
- `onOutput(cb)` fan-out delivers each non-empty `snapshot.output`, mirroring the cell-subscription conventions; stable-ref snapshot cache untouched.

## UI
- New `SerialConsole` component: monospace scrollback that auto-scrolls to the bottom unless the user scrolled up, streaming `TextDecoder`, focusable container capturing printable keys (Enter→`\n`, Backspace→`0x08`, Ctrl-\<letter\>→control code so Ctrl-D=EOT), paste support (one `push_serial_input` per paste), **no local echo**, a Terminal-icon header with a clear-scrollback button, and ephemeral state reset per debug session.
- `debug-layout.tsx`: the horizontal editor/inspector Group is now wrapped in an outer vertical Group with a collapsible ~25% bottom console panel (debug mode only). `ResizeHandle` gained a vertical orientation.

## Tests
- New Playwright e2e: loads a polling echo program, enters debug mode, runs, types `hi`, asserts it echoes back into the console, then Ctrl-D halts the program.

Gates: `cargo fmt`/`clippy`/`test`, web `check`/`knip`/`build`, and all 28 e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)