### PR TITLE
Wire the serial console to the CLI

### DIFF
--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,4 +1,7 @@
+use std::io::{BufRead, BufReader, Write};
 use std::process::exit;
+use std::sync::mpsc::{self, Receiver, TryRecvError};
+use std::thread;
 
 use camino::Utf8PathBuf;
 use clap::{ArgAction, Parser, ValueHint};
@@ -7,9 +10,23 @@ use z33_emulator::diagnostic::{
     preprocessor_error_to_diagnostics, render_to_string, resolve_diagnostic_spans,
 };
 use z33_emulator::preprocessor::{NativeFilesystem, SourceMap, Workspace};
+use z33_emulator::runtime::{Computer, ProcessorError};
 use z33_emulator::{compile, parse};
 
 use crate::interactive::run_interactive;
+
+/// The number of instructions to execute between servicing host I/O. Small
+/// enough that input latency stays imperceptible, large enough that the I/O
+/// bookkeeping is negligible.
+const IO_BATCH: usize = 10_000;
+
+/// A message from the background stdin reader thread.
+enum Input {
+    /// A line read from stdin, including its trailing `\n`.
+    Line(String),
+    /// Stdin reached EOF; no further input will ever arrive.
+    Eof,
+}
 
 #[derive(Parser, Debug)]
 pub struct RunOpt {
@@ -71,9 +88,98 @@ impl RunOpt {
         if self.interactive {
             run_interactive(&mut computer, debug_info);
         } else {
-            computer.run()?;
+            run_with_io(&mut computer)?;
         }
 
         Ok(())
+    }
+}
+
+/// Spawn a thread that reads stdin line by line, forwarding each line (and a
+/// final [`Input::Eof`] marker) over a channel. Blocking reads live off the
+/// main thread so the emulator keeps running while waiting for input.
+fn spawn_stdin_reader() -> Receiver<Input> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut reader = BufReader::new(std::io::stdin());
+        loop {
+            let mut line = String::new();
+            match reader.read_line(&mut line) {
+                // EOF or a read error: signal EOF once and stop reading forever.
+                Ok(0) | Err(_) => {
+                    let _ = tx.send(Input::Eof);
+                    break;
+                }
+                Ok(_) => {
+                    if tx.send(Input::Line(line)).is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+    rx
+}
+
+/// Drain whatever the program has written to the serial console and write it
+/// straight to stdout. Output bypasses `tracing` on purpose: it is raw program
+/// output and must not be mangled by log formatting.
+fn flush_serial_output(computer: &mut Computer) -> anyhow::Result<()> {
+    let output = computer.io.serial.drain_output();
+    if !output.is_empty() {
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+        handle.write_all(&output)?;
+        handle.flush()?;
+    }
+    Ok(())
+}
+
+/// Run the program with the serial console wired to the process's stdio.
+///
+/// The core `Computer::run` loop cannot interleave host I/O, so the CLI owns
+/// the loop: pending stdin lines are pushed into the serial receive queue (one
+/// `push_input` per line, preserving one-interrupt-per-line semantics), then a
+/// bounded burst of instructions runs before draining serial output back to
+/// stdout. `in` never blocks; a program awaiting input simply busy-polls until
+/// a line arrives.
+fn run_with_io(computer: &mut Computer) -> anyhow::Result<()> {
+    let rx = spawn_stdin_reader();
+    // Once stdin hits EOF we latch it and never touch the channel again, so we
+    // never busy-wait on input that will never come.
+    let mut stdin_open = true;
+
+    loop {
+        // Feed any input that has arrived since the last iteration.
+        while stdin_open {
+            match rx.try_recv() {
+                Ok(Input::Line(line)) => computer.io.serial.push_input(line.as_bytes()),
+                Ok(Input::Eof) | Err(TryRecvError::Disconnected) => stdin_open = false,
+                Err(TryRecvError::Empty) => break,
+            }
+        }
+
+        // Advance the program by a bounded burst so input latency stays low.
+        let mut reset = false;
+        for _ in 0..IO_BATCH {
+            match computer.step() {
+                Ok(()) => {}
+                Err(ProcessorError::Reset) => {
+                    reset = true;
+                    break;
+                }
+                Err(e) => {
+                    // Flush any final output before surfacing the error.
+                    flush_serial_output(computer)?;
+                    return Err(e.into());
+                }
+            }
+        }
+
+        flush_serial_output(computer)?;
+
+        if reset {
+            return Ok(());
+        }
     }
 }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -22,8 +22,10 @@ const IO_BATCH: usize = 10_000;
 
 /// A message from the background stdin reader thread.
 enum Input {
-    /// A line read from stdin, including its trailing `\n`.
-    Line(String),
+    /// A line of raw bytes read from stdin, including its trailing `\n`. Bytes
+    /// are forwarded verbatim (the serial console is byte-oriented and must not
+    /// require valid UTF-8).
+    Line(Vec<u8>),
     /// Stdin reached EOF; no further input will ever arrive.
     Eof,
 }
@@ -103,8 +105,11 @@ fn spawn_stdin_reader() -> Receiver<Input> {
     thread::spawn(move || {
         let mut reader = BufReader::new(std::io::stdin());
         loop {
-            let mut line = String::new();
-            match reader.read_line(&mut line) {
+            // Read raw bytes, not a `String`: stdin may carry non-UTF-8 bytes
+            // and the serial console is byte-oriented. `read_line` would error
+            // on the first invalid byte and drop the rest of the input.
+            let mut line = Vec::new();
+            match reader.read_until(b'\n', &mut line) {
                 // EOF or a read error: signal EOF once and stop reading forever.
                 Ok(0) | Err(_) => {
                     let _ = tx.send(Input::Eof);
@@ -153,7 +158,7 @@ fn run_with_io(computer: &mut Computer) -> anyhow::Result<()> {
         // Feed any input that has arrived since the last iteration.
         while stdin_open {
             match rx.try_recv() {
-                Ok(Input::Line(line)) => computer.io.serial.push_input(line.as_bytes()),
+                Ok(Input::Line(line)) => computer.io.serial.push_input(&line),
                 Ok(Input::Eof) | Err(TryRecvError::Disconnected) => stdin_open = false,
                 Err(TryRecvError::Empty) => break,
             }

--- a/crates/cli/src/interactive/mod.rs
+++ b/crates/cli/src/interactive/mod.rs
@@ -102,6 +102,18 @@ enum Command {
     /// Continue the program until the next breakpoint or reset
     Continue,
 
+    /// Send text to the program's serial console input
+    ///
+    /// The text is delivered to the serial receive queue followed by a newline
+    /// (Enter is `\n`), as one delivery (one interrupt for interrupt-driven
+    /// programs). With no argument, only a newline is sent. Queue input before
+    /// `continue` so a program polling for input does not spin forever.
+    Input {
+        /// The text to send. A trailing newline is always appended.
+        #[clap(value_parser, trailing_var_arg = true, allow_hyphen_values = true)]
+        text: Vec<String>,
+    },
+
     /// Show informations about the current debugging session
     Info {
         #[clap(subcommand)]
@@ -247,6 +259,21 @@ impl Session {
     }
 }
 
+/// Drain serial output produced by the guest and write it raw to stdout.
+///
+/// Program output bypasses `tracing` on purpose: it must not be mangled by log
+/// formatting. Write errors are ignored — a broken stdout is not recoverable
+/// here and should not abort the debugging session.
+fn flush_serial_output(computer: &mut Computer) {
+    let output = computer.io.serial.drain_output();
+    if !output.is_empty() {
+        use std::io::Write;
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+        let _ = handle.write_all(&output).and_then(|()| handle.flush());
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) {
     info!("Running in interactive mode. Type \"help\" to list available commands.");
@@ -268,6 +295,11 @@ pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) {
     let mut halted = false;
 
     'read: loop {
+        // Flush any serial output produced by the previous command's execution
+        // before the next prompt renders (covers step / continue / interrupt,
+        // including paths that `continue 'read`).
+        flush_serial_output(computer);
+
         // A macro to unwrap an error, log it and continue the loop
         macro_rules! warn_and_continue {
             ($e:expr) => {
@@ -411,6 +443,15 @@ pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) {
                     break;
                 }
             },
+
+            (Command::Input { text }, _) => {
+                // Reconstruct the line from the parsed words and append Enter.
+                let mut bytes = text.join(" ").into_bytes();
+                bytes.push(b'\n');
+                let len = bytes.len();
+                computer.io.serial.push_input(&bytes);
+                info!("Queued {len} byte(s) to serial input");
+            }
 
             (Command::Info { sub }, _) => match sub {
                 Some(InfoCommand::Breakpoints) => {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -71,9 +71,13 @@ fn main() {
     // Then, setup the tracing formatter for logging and instrumentation
     let registry = tracing_subscriber::Registry::default().with(opt.filter_layer());
 
-    // LSP and DAP use stdout for their protocols, so all logging must go to
-    // stderr.
-    let use_stderr = matches!(opt.command, Subcommand::Lsp(_) | Subcommand::Dap(_));
+    // LSP and DAP use stdout for their protocols, and `run` streams the guest's
+    // serial output on stdout, so for all three logging must go to stderr to
+    // keep stdout clean.
+    let use_stderr = matches!(
+        opt.command,
+        Subcommand::Run(_) | Subcommand::Lsp(_) | Subcommand::Dap(_)
+    );
 
     if opt.json {
         let json_layer = tracing_subscriber::fmt::layer()

--- a/crates/cli/tests/serial.rs
+++ b/crates/cli/tests/serial.rs
@@ -1,0 +1,65 @@
+//! End-to-end tests for the serial console wired to `z33-cli run`.
+//!
+//! These drive the compiled binary directly (via the `CARGO_BIN_EXE_*` env var
+//! cargo provides to integration tests), pipe bytes to its stdin, and assert on
+//! what the guest echoes back to stdout. The interactive (`-i`) path uses
+//! rustyline and reads the terminal device directly, so it cannot be driven
+//! from a pipe and is not covered here.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+/// Path to a file in the repository's top-level `samples/` directory.
+fn sample(name: &str) -> PathBuf {
+    // CARGO_MANIFEST_DIR is crates/cli; samples/ lives at the workspace root.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../samples")
+        .join(name)
+}
+
+/// Run `z33-cli run <sample> main`, feed `input` to stdin, and return stdout.
+///
+/// `RUST_LOG=warn` silences the per-instruction info logging (which otherwise
+/// shares stdout with raw program output) so assertions see only the guest's
+/// serial output.
+fn run_echo(sample_name: &str, input: &[u8]) -> String {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_z33-cli"))
+        .args(["run", sample(sample_name).to_str().unwrap(), "main"])
+        .env("RUST_LOG", "warn")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn z33-cli");
+
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(input)
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("wait for z33-cli");
+    assert!(
+        output.status.success(),
+        "z33-cli exited with {:?}",
+        output.status
+    );
+    String::from_utf8(output.stdout).expect("stdout is utf-8")
+}
+
+#[test]
+fn polling_echo_replays_input_and_exits_on_eot() {
+    // "hi" then Ctrl-D (EOT, byte 4) to end the program.
+    let stdout = run_echo("echo.s", b"hi\x04");
+    assert_eq!(stdout, "hi");
+}
+
+#[test]
+fn polling_echo_handles_multiple_lines() {
+    // A full line (echoed verbatim, newline included) followed by EOT on the
+    // next read. Exercises multi-byte input and EOF-after-partial-line.
+    let stdout = run_echo("echo.s", b"hey\n\x04");
+    assert_eq!(stdout, "hey\n");
+}

--- a/crates/cli/tests/serial.rs
+++ b/crates/cli/tests/serial.rs
@@ -18,12 +18,14 @@ fn sample(name: &str) -> PathBuf {
         .join(name)
 }
 
-/// Run `z33-cli run <sample> main`, feed `input` to stdin, and return stdout.
+/// Run `z33-cli run <sample> main`, feed `input` to stdin, and return the raw
+/// stdout bytes.
 ///
-/// `RUST_LOG=warn` silences the per-instruction info logging (which otherwise
-/// shares stdout with raw program output) so assertions see only the guest's
-/// serial output.
-fn run_echo(sample_name: &str, input: &[u8]) -> String {
+/// Logs go to stderr (routed there for the `run` subcommand precisely so they
+/// never garble the guest's serial output on stdout), which we discard.
+/// `RUST_LOG=warn` additionally quiets the per-instruction info logging so the
+/// discarded stderr stays cheap; it is no longer needed for stdout cleanliness.
+fn run_echo_raw(sample_name: &str, input: &[u8]) -> Vec<u8> {
     let mut child = Command::new(env!("CARGO_BIN_EXE_z33-cli"))
         .args(["run", sample(sample_name).to_str().unwrap(), "main"])
         .env("RUST_LOG", "warn")
@@ -46,7 +48,12 @@ fn run_echo(sample_name: &str, input: &[u8]) -> String {
         "z33-cli exited with {:?}",
         output.status
     );
-    String::from_utf8(output.stdout).expect("stdout is utf-8")
+    output.stdout
+}
+
+/// Like [`run_echo_raw`], but decodes stdout as UTF-8 for text assertions.
+fn run_echo(sample_name: &str, input: &[u8]) -> String {
+    String::from_utf8(run_echo_raw(sample_name, input)).expect("stdout is utf-8")
 }
 
 #[test]
@@ -62,4 +69,13 @@ fn polling_echo_handles_multiple_lines() {
     // next read. Exercises multi-byte input and EOF-after-partial-line.
     let stdout = run_echo("echo.s", b"hey\n\x04");
     assert_eq!(stdout, "hey\n");
+}
+
+#[test]
+fn polling_echo_passes_non_utf8_bytes_through() {
+    // A lone 0xFF byte is not valid UTF-8. The stdin reader must forward raw
+    // bytes (not decode a `String`, which would error and drop the input), so
+    // the byte is echoed verbatim before EOT (byte 4) ends the program.
+    let stdout = run_echo_raw("echo.s", b"\xff\x04");
+    assert_eq!(stdout, b"\xff");
 }


### PR DESCRIPTION
Stacked on #988 (the serial console peripheral). Wires that peripheral's `SerialConsole` (ports 110–111) to `z33-cli` so programs can actually do serial I/O from the terminal.

## Plain `z33-cli run`

Replaces the core `Computer::run` tight loop with a CLI-owned loop so host I/O can interleave with execution:

- A background thread does blocking `read_line` on stdin, forwarding each line (with its trailing `\n`) over an mpsc channel, plus a final EOF marker.
- The main loop drains pending lines into the serial receive queue — **one `push_input` per line**, preserving one-IRQ-per-line semantics for interrupt-driven programs — then runs a bounded burst (`IO_BATCH = 10_000` steps) so input latency stays imperceptible, then drains serial output.
- Program output is written **directly to stdout** (raw `write_all` + `flush`), bypassing `tracing` so it is not mangled by log formatting.
- `ProcessorError::Reset` exits successfully after a final flush; other errors propagate as before.

### EOF semantics

When stdin hits EOF the reader thread emits an EOF marker once and stops; the main loop latches it and never touches the channel again (no busy-wait on stdin). The guest simply never sees the RX-ready bit set again. Cooked line mode on purpose — the terminal handles echo/editing; no termios/crossterm.

## Interactive `-i` debugger

- New `input <text>` command: queues `text` bytes **plus a trailing newline** to the serial rx queue in a single `push_input` (one delivery / one interrupt). With no argument it sends just a newline. Documented in its help; discoverable so users can pre-queue input before `continue`.
- After any guest execution (step / continue / interrupt), serial output is flushed raw to stdout before the next `>> ` prompt renders.
- Tab-completion picks up the new command automatically (the completer is derived from the clap `Command`).

## Tests

Adds `crates/cli/tests/serial.rs`, an integration test that drives the built binary (via `CARGO_BIN_EXE_*`, zero new deps) against `samples/echo.s`: asserts `hi\x04` echoes `hi` and exits, and that a full line + EOT round-trips. The `-i` path can't be driven headlessly (rustyline reads the terminal device directly), so it's covered by review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)