### PR TITLE
Stream serial I/O through the DAP

### DIFF
--- a/crates/emulator/src/dap/mod.rs
+++ b/crates/emulator/src/dap/mod.rs
@@ -277,6 +277,37 @@ impl DebugSession {
         self.exit_requested
     }
 
+    /// Feed bytes into the serial console's input queue. A single call is one
+    /// interrupt edge (see [`SerialConsole::push_input`]), so callers should
+    /// push one line at a time. Used by the `zorglub33/serialInput` custom
+    /// request and by REPL console input while the program is running; a no-op
+    /// if no program is loaded.
+    pub fn enqueue_serial_input(&mut self, bytes: &[u8]) {
+        if let Some(program) = self.program.as_mut() {
+            program.computer.io.serial.push_input(bytes);
+        }
+    }
+
+    /// Drain the computer's serial output into DAP `output` events.
+    ///
+    /// The serial console is a byte-oriented character device; program output
+    /// is rendered as a single `stdout`-category `output` event decoded with
+    /// [`String::from_utf8_lossy`] (invalid byte sequences become U+FFFD).
+    /// Lossy decoding is deliberate: the alternative (base64/hex) would be
+    /// unreadable in the Debug Console, and Z33 programs emit text. Returns an
+    /// empty vector when nothing is buffered.
+    fn drain_serial_output_events(&mut self) -> Vec<Value> {
+        let bytes = match self.program.as_mut() {
+            Some(program) => program.computer.io.serial.drain_output(),
+            None => return Vec::new(),
+        };
+        if bytes.is_empty() {
+            return Vec::new();
+        }
+        let text = String::from_utf8_lossy(&bytes).into_owned();
+        vec![self.make_event("output", json!({ "category": "stdout", "output": text }))]
+    }
+
     // ----------------------------------------------------------------------
     // Message handling
     // ----------------------------------------------------------------------
@@ -319,6 +350,7 @@ impl DebugSession {
             "writeMemory" => self.on_write_memory(&req),
             "source" => self.on_source(&req),
             "restart" => self.on_restart(&req),
+            "zorglub33/serialInput" => self.on_serial_input(&req),
             "disconnect" => {
                 self.exit_requested = true;
                 self.state = State::Terminated;
@@ -773,6 +805,19 @@ impl DebugSession {
             Err(e) => return vec![self.response_err(req, format!("invalid arguments: {e}"))],
         };
 
+        // REPL console input while the program is running: treat the typed line
+        // as serial input (Enter is `\n`) rather than an expression. Only while
+        // `Running` — when stopped at a breakpoint the user is inspecting state,
+        // so `evaluate` keeps its expression-evaluation behavior there. The
+        // response `result` is empty because the Debug Console already renders
+        // the line the user typed; any device echo streams back as `stdout`.
+        if self.state == State::Running && args.context.as_deref() == Some("repl") {
+            let mut line = args.expression;
+            line.push('\n');
+            self.enqueue_serial_input(line.as_bytes());
+            return vec![self.response(req, json!({ "result": "", "variablesReference": 0 }))];
+        }
+
         let hex = args.format.unwrap_or_default().hex;
         let result = {
             let Some(program) = self.program.as_ref() else {
@@ -897,6 +942,21 @@ impl DebugSession {
         }
     }
 
+    /// Custom `zorglub33/serialInput` request: `{ "data": "<string>" }`. Feeds
+    /// the string's UTF-8 bytes into the serial input queue. This is the seam a
+    /// VS Code pseudo-terminal (or any host wanting a dedicated console) uses
+    /// to deliver input without going through `evaluate`.
+    fn on_serial_input(&mut self, req: &IncomingRequest) -> Vec<Value> {
+        let data = req
+            .arguments
+            .get("data")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        self.enqueue_serial_input(data.as_bytes());
+        vec![self.response(req, Value::Null)]
+    }
+
     // ----------------------------------------------------------------------
     // Execution driving
     // ----------------------------------------------------------------------
@@ -955,24 +1015,34 @@ impl DebugSession {
     }
 
     fn finish_run(&mut self, outcome: Outcome) -> Vec<Value> {
+        // Flush any serial output first so program output (category "stdout")
+        // always precedes the stopped/terminated/exception events, and — on the
+        // `Pending` path — streams to the Debug Console during long print loops
+        // instead of buffering until the next stop. The halt/exception summaries
+        // below use category "console", so they stay visually distinct.
+        let mut out = self.drain_serial_output_events();
         match outcome {
-            Outcome::Pending => Vec::new(),
+            Outcome::Pending => out,
             Outcome::Stopped(reason) => {
                 self.state = State::Stopped;
                 self.invalidate_handles();
-                vec![self.stopped_event(reason, None, None)]
+                out.push(self.stopped_event(reason, None, None));
+                out
             }
-            Outcome::Terminated(code) => self.terminate_now(code),
+            Outcome::Terminated(code) => {
+                out.extend(self.terminate_now(code));
+                out
+            }
             Outcome::Exception(msg) => {
                 self.state = State::Stopped;
                 self.exception_pending = true;
                 self.invalidate_handles();
-                let output = self.make_event(
+                out.push(self.make_event(
                     "output",
                     json!({ "category": "console", "output": format!("Exception: {msg}\n") }),
-                );
-                let stopped = self.stopped_event_named("exception", Some(msg.clone()), Some(msg));
-                vec![output, stopped]
+                ));
+                out.push(self.stopped_event_named("exception", Some(msg.clone()), Some(msg)));
+                out
             }
         }
     }

--- a/crates/emulator/src/dap/mod.rs
+++ b/crates/emulator/src/dap/mod.rs
@@ -220,6 +220,12 @@ pub struct DebugSession {
     /// Monotonic allocator for dynamic handles (never reset, so stale handles
     /// stay invalid once cleared).
     next_dyn: i64,
+    /// Bytes of a valid-but-incomplete trailing UTF-8 sequence carried over
+    /// from the previous serial-output drain, so a multi-byte character split
+    /// across a drain boundary decodes as one character instead of U+FFFD
+    /// replacements (see [`DebugSession::serial_output_events`]). At most 3
+    /// bytes; reset whenever the computer is (re)loaded.
+    serial_utf8_carry: Vec<u8>,
 }
 
 impl Default for DebugSession {
@@ -245,6 +251,7 @@ impl DebugSession {
             launch_args: None,
             dyn_handles: HashMap::new(),
             next_dyn: 0,
+            serial_utf8_carry: Vec::new(),
         }
     }
 
@@ -296,11 +303,39 @@ impl DebugSession {
     /// Lossy decoding is deliberate: the alternative (base64/hex) would be
     /// unreadable in the Debug Console, and Z33 programs emit text. Returns an
     /// empty vector when nothing is buffered.
-    fn drain_serial_output_events(&mut self) -> Vec<Value> {
-        let bytes = match self.program.as_mut() {
+    ///
+    /// A multi-byte UTF-8 character can straddle a drain boundary (the program
+    /// emits its bytes with successive `out` instructions, and a
+    /// [`CHUNK_SIZE`] boundary — or a breakpoint — can fall between them). To
+    /// avoid decoding such a character as two U+FFFD replacements, a trailing
+    /// *valid-but-incomplete* sequence is held back in
+    /// [`Self::serial_utf8_carry`] and prepended to the next drain. Truly
+    /// invalid bytes are never held back (they decode to U+FFFD immediately).
+    ///
+    /// When `flush` is set, the carried-over incomplete sequence is NOT held
+    /// back — it is decoded (lossily, as U+FFFD) right now. Callers pass
+    /// `flush = true` on terminal outcomes (halt/exception), where no further
+    /// bytes will ever arrive to complete the character, so holding it back
+    /// would silently drop it. The streaming (non-flush) path is used while the
+    /// program keeps running.
+    fn serial_output_events(&mut self, flush: bool) -> Vec<Value> {
+        let fresh = match self.program.as_mut() {
             Some(program) => program.computer.io.serial.drain_output(),
-            None => return Vec::new(),
+            None => Vec::new(),
         };
+        // Prepend bytes carried over from a previous drain that ended in the
+        // middle of a multi-byte character.
+        let mut bytes = std::mem::take(&mut self.serial_utf8_carry);
+        bytes.extend(fresh);
+        if bytes.is_empty() {
+            return Vec::new();
+        }
+        // Unless we are flushing, split off any trailing valid-but-incomplete
+        // UTF-8 sequence so its continuation bytes decode with it next time.
+        if !flush {
+            let keep = utf8_decodable_len(&bytes);
+            self.serial_utf8_carry = bytes.split_off(keep);
+        }
         if bytes.is_empty() {
             return Vec::new();
         }
@@ -390,6 +425,7 @@ impl DebugSession {
         match load_program(&args) {
             Ok(program) => {
                 self.stop_on_entry = args.stop_on_entry;
+                self.serial_utf8_carry.clear();
                 self.program = Some(program);
                 self.launch_args = Some(args);
                 let resp = self.response(req, Value::Null);
@@ -931,6 +967,7 @@ impl DebugSession {
                 self.entered = false;
                 self.exception_pending = false;
                 self.pause_requested = false;
+                self.serial_utf8_carry.clear();
                 self.stop_on_entry = args.stop_on_entry;
                 self.state = State::Initialized;
                 let resp = self.response(req, Value::Null);
@@ -1020,7 +1057,14 @@ impl DebugSession {
         // `Pending` path — streams to the Debug Console during long print loops
         // instead of buffering until the next stop. The halt/exception summaries
         // below use category "console", so they stay visually distinct.
-        let mut out = self.drain_serial_output_events();
+        //
+        // On terminal outcomes (halt/exception) no more serial bytes will come,
+        // so any incomplete UTF-8 sequence held back from a previous drain must
+        // be flushed now (lossily) rather than silently dropped. On a plain
+        // `Stopped` the program will resume, so the held-back bytes are kept and
+        // completed by the next drain.
+        let flush = matches!(outcome, Outcome::Terminated(_) | Outcome::Exception(_));
+        let mut out = self.serial_output_events(flush);
         match outcome {
             Outcome::Pending => out,
             Outcome::Stopped(reason) => {
@@ -1230,6 +1274,25 @@ impl DebugSession {
 // --------------------------------------------------------------------------
 // Free helpers
 // --------------------------------------------------------------------------
+
+/// Length of the prefix of `bytes` that should be decoded and emitted now,
+/// holding back only a trailing sequence that is a *valid but incomplete* start
+/// of a multi-byte UTF-8 character (so its continuation bytes can arrive on the
+/// next drain). Invalid bytes are decoded immediately — only an
+/// incomplete-at-end sequence is held back.
+///
+/// [`str::from_utf8`]'s error distinguishes the two cases: `error_len() ==
+/// None` means the input ends mid-character (hold back from `valid_up_to()`);
+/// `Some(_)` means a genuinely invalid byte, which we decode (lossily) now.
+fn utf8_decodable_len(bytes: &[u8]) -> usize {
+    match std::str::from_utf8(bytes) {
+        Ok(_) => bytes.len(),
+        Err(e) => match e.error_len() {
+            Some(_) => bytes.len(),
+            None => e.valid_up_to(),
+        },
+    }
+}
 
 fn register_var(name: &str, value: String) -> Variable {
     Variable {

--- a/crates/emulator/src/dap/protocol.rs
+++ b/crates/emulator/src/dap/protocol.rs
@@ -201,6 +201,11 @@ pub struct SetVariableArguments {
 #[derive(Debug, Deserialize)]
 pub struct EvaluateArguments {
     pub expression: String,
+    /// The context the expression is evaluated in (`"repl"`, `"watch"`,
+    /// `"hover"`, ...). Used to route `repl` input to the serial console while
+    /// the program is running instead of evaluating it as an expression.
+    #[serde(default)]
+    pub context: Option<String>,
     #[serde(default)]
     pub format: Option<ValueFormat>,
 }

--- a/crates/emulator/src/dap/tests.rs
+++ b/crates/emulator/src/dap/tests.rs
@@ -1301,6 +1301,112 @@ fn serial_input_custom_request_round_trip() {
     );
 }
 
+/// Emits the two bytes of `é` (0xC3, 0xA9) with a `reset` in between so a
+/// breakpoint can be placed on the instruction that supplies the second byte —
+/// forcing the two `out`s into separate drains.
+const SPLIT_CHAR_SOURCE: &str = indoc::indoc! {r"
+    main:
+        ld  195, %a
+        out %a, [111]
+        ld  169, %a
+        out %a, [111]
+        reset
+"};
+
+#[test]
+fn split_utf8_character_across_drain_boundary_decodes_once() {
+    let mut h = Harness::new();
+    h.launch_source("/split.s", SPLIT_CHAR_SOURCE, true);
+
+    // Breakpoint on line 4 (`ld 169, %a`), the instruction right after the
+    // first `out`: the 0xC3 lead byte of `é` has been emitted but its 0xA9
+    // continuation byte has not.
+    h.send(
+        "setBreakpoints",
+        json!({
+            "source": { "path": "/split.s" },
+            "breakpoints": [{ "line": 4 }],
+        }),
+    );
+
+    // Run to the breakpoint. The drain there sees only the lone lead byte,
+    // which must be held back rather than emitted as a replacement char.
+    h.send("continue", json!({ "threadId": 1 }));
+    let to_bp = h.drive();
+    assert!(
+        find_event(&to_bp, "stopped").is_some(),
+        "should stop at the breakpoint"
+    );
+    assert!(
+        !stdout_text(&to_bp).contains('\u{FFFD}'),
+        "incomplete lead byte must not be emitted as U+FFFD yet, got {:?}",
+        stdout_text(&to_bp)
+    );
+
+    // Continue to completion: the second `out` supplies 0xA9, completing `é`.
+    h.send("continue", json!({ "threadId": 1 }));
+    let to_end = h.drive();
+    let text = format!("{}{}", stdout_text(&to_bp), stdout_text(&to_end));
+    assert!(text.contains('é'), "expected 'é', got {text:?}");
+    assert!(
+        !text.contains('\u{FFFD}'),
+        "no replacement chars expected, got {text:?}"
+    );
+}
+
+/// Emits a lone 0xFF byte (never a valid UTF-8 start) and halts.
+const BAD_BYTE_SOURCE: &str = indoc::indoc! {r"
+    main:
+        ld  255, %a
+        out %a, [111]
+        reset
+"};
+
+#[test]
+fn invalid_serial_byte_decodes_to_replacement_immediately() {
+    let mut h = Harness::new();
+    h.launch_source("/bad.s", BAD_BYTE_SOURCE, false);
+    let out = h.drive();
+    assert!(
+        stdout_text(&out).contains('\u{FFFD}'),
+        "lone 0xFF should decode to U+FFFD, got {:?}",
+        stdout_text(&out)
+    );
+}
+
+/// Emits only the lead byte of a two-byte character, then halts — the trailing
+/// byte never arrives.
+const TRUNCATED_CHAR_SOURCE: &str = indoc::indoc! {r"
+    main:
+        ld  195, %a
+        out %a, [111]
+        reset
+"};
+
+#[test]
+fn program_halting_mid_character_flushes_held_back_byte() {
+    let mut h = Harness::new();
+    h.launch_source("/trunc.s", TRUNCATED_CHAR_SOURCE, false);
+    let out = h.drive();
+
+    // The held-back lead byte must be flushed (lossily) with the terminating
+    // events, never silently dropped.
+    let out_idx = out
+        .iter()
+        .position(|m| m["event"] == "output" && m["body"]["category"] == "stdout")
+        .expect("held-back byte flushed as a stdout event");
+    let term_idx = out
+        .iter()
+        .position(|m| m["event"] == "terminated")
+        .expect("terminated event");
+    assert!(out_idx < term_idx, "flushed output must precede terminated");
+    assert!(
+        stdout_text(&out).contains('\u{FFFD}'),
+        "held-back lead byte should flush as U+FFFD, got {:?}",
+        stdout_text(&out)
+    );
+}
+
 #[test]
 fn evaluate_without_repl_context_while_stopped_evaluates() {
     let mut h = Harness::new();

--- a/crates/emulator/src/dap/tests.rs
+++ b/crates/emulator/src/dap/tests.rs
@@ -1152,3 +1152,174 @@ fn clean_halt_prints_summary() {
     // The summary precedes termination.
     assert!(find_event(&out, "terminated").is_some());
 }
+
+// --------------------------------------------------------------------------
+// Serial console over the DAP
+// --------------------------------------------------------------------------
+
+/// Polling serial echo (a trimmed copy of `samples/echo.s`): busy-waits for a
+/// byte, echoes it, and halts on EOT (Ctrl-D, byte 4).
+const ECHO_SOURCE: &str = indoc::indoc! {r"
+    main:
+    poll:
+        in  [110], %a
+        and 1, %a
+        jeq poll
+        in  [111], %a
+        cmp 4, %a
+        jeq done
+        out %a, [111]
+        jmp poll
+    done:
+        reset
+"};
+
+/// A program that emits a byte forever: it never halts on its own, so a single
+/// `run_chunk` returns while still running (the `Pending` arm).
+const OUT_LOOP_SOURCE: &str = indoc::indoc! {r"
+    main:
+        ld 72, %a
+    loop:
+        out %a, [111]
+        jmp loop
+"};
+
+impl Harness {
+    /// initialize + launch + configurationDone, WITHOUT driving to completion.
+    /// Used for programs that busy-wait for serial input and never halt on
+    /// their own, where [`Harness::drive`] would loop forever.
+    fn launch_source(&mut self, program: &str, source: &str, stop_on_entry: bool) -> Vec<Value> {
+        self.send("initialize", json!({}));
+        self.send(
+            "launch",
+            json!({
+                "program": program,
+                "entrypoint": "main",
+                "stopOnEntry": stop_on_entry,
+                "files": { program: source },
+            }),
+        );
+        self.send("configurationDone", json!({}))
+    }
+
+    /// Advance the program by one instruction budget.
+    fn pump(&mut self) -> Vec<Value> {
+        self.session.run_chunk()
+    }
+}
+
+/// Concatenate the text of every `stdout`-category `output` event.
+fn stdout_text(messages: &[Value]) -> String {
+    messages
+        .iter()
+        .filter(|m| {
+            m["type"] == "event" && m["event"] == "output" && m["body"]["category"] == "stdout"
+        })
+        .filter_map(|m| m["body"]["output"].as_str())
+        .collect()
+}
+
+#[test]
+fn run_chunk_streams_stdout_while_running() {
+    let mut h = Harness::new();
+    // Not stopping on entry: the out-loop starts running immediately.
+    h.launch_source("/out.s", OUT_LOOP_SOURCE, false);
+    assert!(h.session.is_running(), "out-loop should be running");
+
+    let out = h.pump();
+    // The budget is exhausted without stopping (Pending), yet the bytes written
+    // so far must already have streamed out as a stdout output event.
+    assert!(
+        h.session.is_running(),
+        "program is an infinite loop; still running after one chunk"
+    );
+    let text = stdout_text(&out);
+    assert!(
+        !text.is_empty() && text.chars().all(|c| c == 'H'),
+        "expected streamed 'H' bytes, got {text:?}"
+    );
+    assert!(
+        find_event(&out, "stopped").is_none() && find_event(&out, "terminated").is_none(),
+        "no stop/terminate event on the Pending path"
+    );
+}
+
+#[test]
+fn repl_input_echoes_and_eot_terminates() {
+    let mut h = Harness::new();
+    h.launch_source("/echo.s", ECHO_SOURCE, false);
+    assert!(h.session.is_running());
+
+    // Busy-poll a chunk with no input available: nothing echoed yet.
+    let out = h.pump();
+    assert!(stdout_text(&out).is_empty(), "no input yet, no echo");
+
+    // REPL console input while running is routed to the serial console.
+    let resp = h.send("evaluate", json!({ "expression": "hi", "context": "repl" }));
+    let resp = find_response(&resp, "evaluate").expect("evaluate response");
+    assert_eq!(resp["success"], json!(true));
+
+    // Pump: the echo program reads "hi\n" back out.
+    let out = h.pump();
+    assert!(
+        stdout_text(&out).contains("hi"),
+        "expected echoed input, got {:?}",
+        stdout_text(&out)
+    );
+    assert!(h.session.is_running());
+
+    // EOT (byte 4) ends the program; any preceding output must come first.
+    h.send("zorglub33/serialInput", json!({ "data": "!\u{4}" }));
+    let out = h.pump();
+    let out_idx = out
+        .iter()
+        .position(|m| m["event"] == "output" && m["body"]["category"] == "stdout")
+        .expect("remaining '!' output before terminate");
+    let term_idx = out
+        .iter()
+        .position(|m| m["event"] == "terminated")
+        .expect("terminated after EOT");
+    assert!(out_idx < term_idx, "stdout output must precede terminated");
+    assert!(stdout_text(&out).contains('!'));
+}
+
+#[test]
+fn serial_input_custom_request_round_trip() {
+    let mut h = Harness::new();
+    h.launch_source("/echo.s", ECHO_SOURCE, false);
+
+    let resp = h.send("zorglub33/serialInput", json!({ "data": "z" }));
+    let resp = find_response(&resp, "zorglub33/serialInput").expect("serialInput response");
+    assert_eq!(resp["success"], json!(true));
+
+    // The byte reaches the program and is echoed back.
+    let out = h.pump();
+    assert!(
+        stdout_text(&out).contains('z'),
+        "custom-request input should be echoed, got {:?}",
+        stdout_text(&out)
+    );
+}
+
+#[test]
+fn evaluate_without_repl_context_while_stopped_evaluates() {
+    let mut h = Harness::new();
+    // Stopped on entry: `evaluate` must keep expression-evaluation behavior,
+    // and must NOT route to serial input.
+    h.launch(true);
+
+    let reg = h.send("evaluate", json!({ "expression": "%pc" }));
+    assert_eq!(
+        find_response(&reg, "evaluate").unwrap()["body"]["type"],
+        json!("register")
+    );
+    // A "repl" context while Stopped still evaluates (routing is Running-only).
+    let label = h.send(
+        "evaluate",
+        json!({ "expression": "factorielle", "context": "repl" }),
+    );
+    assert_eq!(
+        find_response(&label, "evaluate").unwrap()["body"]["type"],
+        json!("address")
+    );
+}


### PR DESCRIPTION
Stacked on #988 (the serial console peripheral). Wires the serial console (ports 110-111) into the transport-agnostic `DebugSession` so Z33 programs can do console I/O over a debug session.

## What this does

### stdout streaming
- A private `drain_serial_output_events` helper drains `computer.io.serial.drain_output()` and, when non-empty, emits **one** `output` event with `category: "stdout"` and the bytes as lossy UTF-8 (`String::from_utf8_lossy` — documented: the serial console is a character device, so text decoding beats base64/hex in the Debug Console).
- Called at the top of `finish_run` for **every** outcome, so program output always precedes the `stopped`/`terminated`/`exception` events, and on the `Pending` path of `run_chunk`, so long print loops stream to the Debug Console instead of buffering until a stop. The existing halt/exception summaries use `category: "console"`, so they stay visually distinct.

### REPL input routing
- An `evaluate` request with `context == "repl"` **while the program is Running** is routed to the serial input queue: the typed line + `"\n"` is pushed as input, and a success response with an empty `result` is returned (the Debug Console already renders the typed line; the device echo streams back as `stdout`).
- While **Stopped** (e.g. at a breakpoint), `evaluate` keeps its existing expression-evaluation behavior unchanged — REPL input is never routed while stopped.
- `EvaluateArguments` gains `context: Option<String>` (serde default).

### Input seam
- New `pub fn enqueue_serial_input(&mut self, bytes: &[u8])` (one `push_input` / one IRQ edge).
- New custom request `zorglub33/serialInput` with args `{ "data": "<string>" }` that enqueues the string's UTF-8 bytes. This is the seam a future VS Code pseudo-terminal (or any host wanting a dedicated console) can use to deliver input outside of `evaluate`.

`DebugSession` keeps its **no-I/O** invariant — it still only returns messages. Restart/disconnect/terminate already recreate/reset the computer (serial buffers reset with it), so no changes were needed there.

## Hosts

- **Native (`z33-cli dap`)**: no changes. The pump loop dispatches the repl `evaluate` / custom request as a normal framed request through `handle_message`; verified by reading it.
- **VS Code**: no changes. The inline adapter (`debug-adapter.ts`) dispatches `evaluate` immediately when not launching (the launch queue only defers during launch), so repl input and `output` events pass through and reorder-free. `pnpm run check` and `pnpm run build` pass.
- **Zed**: gets `stdout` output events for free (its console renders `output` events). Console-input-while-running on Zed is untested/unknown here (Zed can't be driven in this environment) — noted as an open item.

## Tests

New Rust tests in the `dap` module:
- `run_chunk_streams_stdout_while_running` — a program that `out`s bytes forever; one `run_chunk` returns a `stdout` output event while still Running (Pending arm).
- `repl_input_echoes_and_eot_terminates` — echo program; `evaluate {context:"repl", expression:"hi"}` comes back as `stdout`; then EOT (byte 4) terminates with the remaining output preceding the `terminated` event.
- `serial_input_custom_request_round_trip` — `zorglub33/serialInput` round-trips and the byte is echoed.
- `evaluate_without_repl_context_while_stopped_evaluates` — regression guard: expression evaluation while Stopped is unchanged.

`cargo fmt --all`, `cargo clippy --workspace --all-targets` (clean), `cargo test --workspace` (all pass), and `editors/vscode` `pnpm run check` all green.

## End-to-end verification (the money shot)

Ran `@vscode/test-web --browserType=none` against a scratch workspace containing `samples/echo.s`, started the `zorglub33` debug session, and drove the Debug Console: typing `hello` and `Z33` each showed the input line, an empty evaluate result, and then the **same text echoed back as stdout** — confirming repl input → serial → streamed `stdout` output works in the real VS Code web extension via the inline DAP adapter, with zero VS Code code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)