### PR TITLE
Add a serial terminal panel to the VS Code extension

### DIFF
--- a/editors/vscode/src/debug-adapter.ts
+++ b/editors/vscode/src/debug-adapter.ts
@@ -39,6 +39,24 @@ function isLaunchRequest(message: unknown): message is LaunchRequest {
   );
 }
 
+/** A program-output `output` event (DAP `category: "stdout"`), which the serial
+ * terminal mirrors. Exception/halt summaries use `category: "console"` and are
+ * left alone. */
+function stdoutOutputText(message: unknown): string | undefined {
+  if (typeof message !== "object" || message === null) {
+    return undefined;
+  }
+  const event = message as { type?: unknown; event?: unknown; body?: unknown };
+  if (event.type !== "event" || event.event !== "output") {
+    return undefined;
+  }
+  const body = event.body as { category?: unknown; output?: unknown } | undefined;
+  if (body?.category !== "stdout" || typeof body.output !== "string") {
+    return undefined;
+  }
+  return body.output;
+}
+
 export class Z33DebugAdapter implements vscode.DebugAdapter {
   private readonly sendEmitter = new vscode.EventEmitter<vscode.DebugProtocolMessage>();
   readonly onDidSendMessage: vscode.Event<vscode.DebugProtocolMessage> = this.sendEmitter.event;
@@ -69,7 +87,17 @@ export class Z33DebugAdapter implements vscode.DebugAdapter {
   private launching = false;
   private readonly queued: vscode.DebugProtocolMessage[] = [];
 
-  constructor(private readonly server: WasmDapServer) {}
+  /**
+   * Optional sink for program stdout: when set and it returns `true`, a serial
+   * terminal consumed the output and we suppress the Debug Console echo (so the
+   * bytes aren't shown twice). Returns `false` when no live terminal is
+   * attached, in which case the `output` event is forwarded unchanged so output
+   * is never lost.
+   */
+  constructor(
+    private readonly server: WasmDapServer,
+    private readonly onStdout?: (text: string) => boolean,
+  ) {}
 
   handleMessage(message: vscode.DebugProtocolMessage): void {
     if (isLaunchRequest(message)) {
@@ -195,6 +223,16 @@ export class Z33DebugAdapter implements vscode.DebugAdapter {
   }
 
   private emit(message: unknown): void {
+    // Divert program stdout into the serial terminal when one is attached, and
+    // suppress the Debug Console echo so output isn't shown twice. If no
+    // terminal consumes it (closed by the user, or creation raced the first
+    // bytes), fall through and forward it normally — never lose output.
+    if (this.onStdout !== undefined) {
+      const text = stdoutOutputText(message);
+      if (text !== undefined && this.onStdout(text)) {
+        return;
+      }
+    }
     this.rewriteOutgoingSources(message);
     this.sendEmitter.fire(message as vscode.DebugProtocolMessage);
   }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -17,6 +17,7 @@ import { LanguageClient, type LanguageClientOptions } from "vscode-languageclien
 
 import initDapWasm, { WasmDapServer } from "../dist/pkg/z33_web.js";
 import { Z33DebugAdapter } from "./debug-adapter.js";
+import { SerialTerminalManager } from "./serial-terminal.js";
 import {
   collectWorkspaceFiles,
   FILE_GLOB,
@@ -219,9 +220,30 @@ async function activateInner(context: vscode.ExtensionContext): Promise<void> {
 
   // --- Debug adapter (inline wasm) ---------------------------------------
   await initDapWasm({ module_or_path: wasmBytes });
+
+  // Serial console: one pseudo-terminal per debug session. The adapter funnels
+  // program stdout into the session's terminal (suppressing the Debug Console
+  // echo), and the terminal forwards keystrokes back via `zorglub33/serialInput`.
+  const serial = new SerialTerminalManager();
+  context.subscriptions.push(
+    { dispose: () => serial.dispose() },
+    vscode.debug.onDidStartDebugSession((session) => {
+      if (session.type === "zorglub33") {
+        serial.start(session);
+      }
+    }),
+    vscode.debug.onDidTerminateDebugSession((session) => {
+      if (session.type === "zorglub33") {
+        serial.terminate(session);
+      }
+    }),
+  );
+
   const factory: vscode.DebugAdapterDescriptorFactory = {
-    createDebugAdapterDescriptor() {
-      return new vscode.DebugAdapterInlineImplementation(new Z33DebugAdapter(new WasmDapServer()));
+    createDebugAdapterDescriptor(session) {
+      return new vscode.DebugAdapterInlineImplementation(
+        new Z33DebugAdapter(new WasmDapServer(), (text) => serial.writeStdout(session.id, text)),
+      );
     },
   };
   context.subscriptions.push(

--- a/editors/vscode/src/serial-terminal.ts
+++ b/editors/vscode/src/serial-terminal.ts
@@ -26,6 +26,11 @@ const SERIAL_INPUT_REQUEST = "zorglub33/serialInput";
  * gotcha: `onDidWrite` fires into the void until the terminal is live.
  */
 class SerialPty implements vscode.Pseudoterminal {
+  // Cap the pre-open buffer so a chatty program that outputs long before the
+  // terminal is shown can't grow `pending` without bound. 256 KiB is far more
+  // than any reasonable pre-open burst; older bytes are dropped from the front.
+  private static readonly MAX_PENDING = 256 * 1024;
+
   private readonly writeEmitter = new vscode.EventEmitter<string>();
   readonly onDidWrite: vscode.Event<string> = this.writeEmitter.event;
   private readonly closeEmitter = new vscode.EventEmitter<void>();
@@ -33,6 +38,7 @@ class SerialPty implements vscode.Pseudoterminal {
 
   private opened = false;
   private pending = "";
+  private pendingTruncated = false;
   private accepting = true;
   private closed = false;
 
@@ -46,8 +52,10 @@ class SerialPty implements vscode.Pseudoterminal {
   open(): void {
     this.opened = true;
     if (this.pending.length > 0) {
-      this.writeEmitter.fire(this.pending);
+      const notice = this.pendingTruncated ? "\x1b[2m[... output truncated]\x1b[0m\r\n" : "";
+      this.writeEmitter.fire(notice + this.pending);
       this.pending = "";
+      this.pendingTruncated = false;
     }
   }
 
@@ -65,6 +73,10 @@ class SerialPty implements vscode.Pseudoterminal {
       this.writeEmitter.fire(text);
     } else {
       this.pending += text;
+      if (this.pending.length > SerialPty.MAX_PENDING) {
+        this.pending = this.pending.slice(this.pending.length - SerialPty.MAX_PENDING);
+        this.pendingTruncated = true;
+      }
     }
   }
 
@@ -90,13 +102,16 @@ class SerialPty implements vscode.Pseudoterminal {
       return;
     }
     // Translate terminal conventions to the host's serial convention:
-    //   * Enter arrives as CR (\r) → send LF (\n), the host line convention.
+    //   * Enter arrives as CR (\r), possibly followed by LF (\r\n on a
+    //     Windows-style paste or other CRLF-delivering path) → send a single
+    //     LF (\n), the host line convention. Matching `\r\n?` (not just `\r`)
+    //     avoids turning one CRLF into two host newlines.
     //   * Backspace arrives as DEL (\x7f) → send BS (\x08), matching the web
     //     console.
     // Everything else (including control chars like Ctrl-D = EOT \x04) passes
     // through untouched — that is the whole point: the program decides what to
     // do with them (echo.s exits on EOT).
-    const translated = data.replace(/\r/g, "\n").replace(/\x7f/g, "\x08");
+    const translated = data.replace(/\r\n?/g, "\n").replace(/\x7f/g, "\x08");
     // Forward the whole chunk as ONE request so a paste is a single IRQ edge,
     // matching the emulator's one-edge-per-`push_input` contract.
     this.session
@@ -107,29 +122,53 @@ class SerialPty implements vscode.Pseudoterminal {
   }
 }
 
+/** One workspace-scoped terminal, tracked so a live one is never clobbered. */
+interface WorkspaceEntry {
+  sessionId: string;
+  terminal: vscode.Terminal;
+  /** Set once the owning session's debug adapter has terminated. */
+  ended: boolean;
+}
+
 /**
  * Owns one serial terminal per live debug session and routes stdout to it.
  *
  * Keyed two ways: by session id (so the adapter can find the pty when an
  * `output` event flows) and by workspace (so starting a new session in the same
- * workspace disposes the previous session's terminal — a fresh terminal per
- * session, no unbounded accumulation, while a terminated session's scrollback
- * survives until then).
+ * workspace disposes any *already-ended* previous session's terminal — a fresh
+ * terminal per sequential session, no unbounded accumulation, while a
+ * terminated session's scrollback survives until then). Terminals belonging to
+ * still-running sessions in the same workspace are deliberately left alone:
+ * disposing them unconditionally would kill a live sibling session's terminal
+ * out from under it whenever a second concurrent session starts.
  */
 export class SerialTerminalManager {
   private readonly bySession = new Map<string, SerialPty>();
-  private readonly byWorkspace = new Map<string, vscode.Terminal>();
+  private readonly byWorkspace = new Map<string, WorkspaceEntry[]>();
 
   /** Create (and reveal) the serial terminal for a starting session. */
   start(session: vscode.DebugSession): void {
     const workspaceKey = session.workspaceFolder?.uri.toString() ?? "";
-    // Replace any leftover terminal from a previous run in this workspace.
-    this.byWorkspace.get(workspaceKey)?.dispose();
+    const entries = this.byWorkspace.get(workspaceKey) ?? [];
+
+    // Dispose only the terminals whose owning session has already ended;
+    // keep the rest so concurrent sessions in the same workspace coexist.
+    const live: WorkspaceEntry[] = [];
+    for (const entry of entries) {
+      if (entry.ended) {
+        entry.terminal.dispose();
+      } else {
+        live.push(entry);
+      }
+    }
 
     const pty = new SerialPty(session);
+    // VS Code disambiguates duplicate terminal names (e.g. "Zorglub33 Serial
+    // #2") automatically, so concurrent sessions don't need distinct names.
     const terminal = vscode.window.createTerminal({ name: TERMINAL_NAME, pty });
     this.bySession.set(session.id, pty);
-    this.byWorkspace.set(workspaceKey, terminal);
+    live.push({ sessionId: session.id, terminal, ended: false });
+    this.byWorkspace.set(workspaceKey, live);
     // Reveal without stealing focus from the editor.
     terminal.show(true);
   }
@@ -139,6 +178,14 @@ export class SerialTerminalManager {
     const pty = this.bySession.get(session.id);
     pty?.markTerminated();
     this.bySession.delete(session.id);
+
+    const workspaceKey = session.workspaceFolder?.uri.toString() ?? "";
+    const entry = this.byWorkspace
+      .get(workspaceKey)
+      ?.find((candidate) => candidate.sessionId === session.id);
+    if (entry !== undefined) {
+      entry.ended = true;
+    }
   }
 
   /**
@@ -157,8 +204,10 @@ export class SerialTerminalManager {
   }
 
   dispose(): void {
-    for (const terminal of this.byWorkspace.values()) {
-      terminal.dispose();
+    for (const entries of this.byWorkspace.values()) {
+      for (const entry of entries) {
+        entry.terminal.dispose();
+      }
     }
     this.bySession.clear();
     this.byWorkspace.clear();

--- a/editors/vscode/src/serial-terminal.ts
+++ b/editors/vscode/src/serial-terminal.ts
@@ -1,0 +1,166 @@
+// Serial console terminal for Zorglub33 debug sessions.
+//
+// Each debug session gets a pseudo-terminal ("Zorglub33 Serial") that mirrors
+// the program's serial I/O: keystrokes go to the emulator via the custom
+// `zorglub33/serialInput` DAP request, and program output (the DAP `stdout`
+// output events) is written back into the terminal instead of the Debug
+// Console. There is deliberately NO local echo — the running program echoes
+// what it reads, matching real serial hardware and the web IDE's console.
+//
+// The extension owns the lifecycle (create on session start, mark terminated on
+// session end); the debug adapter owns the outgoing message stream, so it is
+// the one that funnels stdout into the pty (see `Z33DebugAdapter.emit`). The
+// two are connected through the session-id-keyed `SerialTerminalManager`.
+
+import * as vscode from "vscode";
+
+const TERMINAL_NAME = "Zorglub33 Serial";
+const SERIAL_INPUT_REQUEST = "zorglub33/serialInput";
+
+/**
+ * A pseudo-terminal mirroring one debug session's serial console.
+ *
+ * Output arriving before VS Code calls `open()` (i.e. before the terminal is
+ * actually shown on screen) MUST be buffered and flushed on open — otherwise
+ * early program output is silently dropped. This is the classic pseudo-terminal
+ * gotcha: `onDidWrite` fires into the void until the terminal is live.
+ */
+class SerialPty implements vscode.Pseudoterminal {
+  private readonly writeEmitter = new vscode.EventEmitter<string>();
+  readonly onDidWrite: vscode.Event<string> = this.writeEmitter.event;
+  private readonly closeEmitter = new vscode.EventEmitter<void>();
+  readonly onDidClose: vscode.Event<void> = this.closeEmitter.event;
+
+  private opened = false;
+  private pending = "";
+  private accepting = true;
+  private closed = false;
+
+  constructor(private readonly session: vscode.DebugSession) {}
+
+  /** True once the user (or a session-replacing dispose) closed the terminal. */
+  get isClosed(): boolean {
+    return this.closed;
+  }
+
+  open(): void {
+    this.opened = true;
+    if (this.pending.length > 0) {
+      this.writeEmitter.fire(this.pending);
+      this.pending = "";
+    }
+  }
+
+  close(): void {
+    // The user closed the terminal panel (or we disposed it for a new session).
+    // Stop mirroring; the manager treats a closed pty as "not attached" so
+    // output falls back to the Debug Console rather than vanishing.
+    this.closed = true;
+    this.accepting = false;
+  }
+
+  /** Emit an already-CRLF-correct string, buffering until `open()`. */
+  private emit(text: string): void {
+    if (this.opened) {
+      this.writeEmitter.fire(text);
+    } else {
+      this.pending += text;
+    }
+  }
+
+  /** Mirror program stdout. Translates LF → CRLF for terminal display. */
+  write(text: string): void {
+    if (this.closed) {
+      return;
+    }
+    this.emit(text.replace(/\r?\n/g, "\r\n"));
+  }
+
+  /** Note that the session ended: dim notice, keep scrollback, refuse input. */
+  markTerminated(): void {
+    this.accepting = false;
+    if (!this.closed) {
+      // Dim (SGR 2) so it reads as chrome, not program output.
+      this.emit("\r\n\x1b[2m[program terminated]\x1b[0m\r\n");
+    }
+  }
+
+  handleInput(data: string): void {
+    if (!this.accepting) {
+      return;
+    }
+    // Translate terminal conventions to the host's serial convention:
+    //   * Enter arrives as CR (\r) → send LF (\n), the host line convention.
+    //   * Backspace arrives as DEL (\x7f) → send BS (\x08), matching the web
+    //     console.
+    // Everything else (including control chars like Ctrl-D = EOT \x04) passes
+    // through untouched — that is the whole point: the program decides what to
+    // do with them (echo.s exits on EOT).
+    const translated = data.replace(/\r/g, "\n").replace(/\x7f/g, "\x08");
+    // Forward the whole chunk as ONE request so a paste is a single IRQ edge,
+    // matching the emulator's one-edge-per-`push_input` contract.
+    this.session
+      .customRequest(SERIAL_INPUT_REQUEST, { data: translated })
+      .then(undefined, (error: unknown) => {
+        console.error("[zorglub33] serial input failed", error);
+      });
+  }
+}
+
+/**
+ * Owns one serial terminal per live debug session and routes stdout to it.
+ *
+ * Keyed two ways: by session id (so the adapter can find the pty when an
+ * `output` event flows) and by workspace (so starting a new session in the same
+ * workspace disposes the previous session's terminal — a fresh terminal per
+ * session, no unbounded accumulation, while a terminated session's scrollback
+ * survives until then).
+ */
+export class SerialTerminalManager {
+  private readonly bySession = new Map<string, SerialPty>();
+  private readonly byWorkspace = new Map<string, vscode.Terminal>();
+
+  /** Create (and reveal) the serial terminal for a starting session. */
+  start(session: vscode.DebugSession): void {
+    const workspaceKey = session.workspaceFolder?.uri.toString() ?? "";
+    // Replace any leftover terminal from a previous run in this workspace.
+    this.byWorkspace.get(workspaceKey)?.dispose();
+
+    const pty = new SerialPty(session);
+    const terminal = vscode.window.createTerminal({ name: TERMINAL_NAME, pty });
+    this.bySession.set(session.id, pty);
+    this.byWorkspace.set(workspaceKey, terminal);
+    // Reveal without stealing focus from the editor.
+    terminal.show(true);
+  }
+
+  /** Note that a session ended: dim notice in its terminal, stop accepting. */
+  terminate(session: vscode.DebugSession): void {
+    const pty = this.bySession.get(session.id);
+    pty?.markTerminated();
+    this.bySession.delete(session.id);
+  }
+
+  /**
+   * Write program stdout to the session's terminal. Returns `true` if a live
+   * terminal consumed it (the caller then suppresses the Debug Console echo),
+   * `false` if none is attached (caller forwards the event so output is never
+   * lost).
+   */
+  writeStdout(sessionId: string, text: string): boolean {
+    const pty = this.bySession.get(sessionId);
+    if (pty === undefined || pty.isClosed) {
+      return false;
+    }
+    pty.write(text);
+    return true;
+  }
+
+  dispose(): void {
+    for (const terminal of this.byWorkspace.values()) {
+      terminal.dispose();
+    }
+    this.bySession.clear();
+    this.byWorkspace.clear();
+  }
+}


### PR DESCRIPTION
PR 5 of the serial-console stack, on top of #991 (the DAP serial streaming). VS Code TypeScript only — zero Rust changes.

Each `zorglub33` debug session now gets a **"Zorglub33 Serial" pseudo-terminal** that mirrors the program's serial I/O, giving real TTY UX (control chars like Ctrl-D) beyond the Debug Console repl. This is the follow-up flagged in the DAP PR (`zorglub33/serialInput` was the seam).

## What it does

**Lifecycle** (`SerialTerminalManager` in `src/serial-terminal.ts`, wired in `extension.ts`)
- Created on `onDidStartDebugSession` (filtered to `type === "zorglub33"`), revealed with `terminal.show(true)` so it does **not** steal focus from the editor.
- `onDidTerminateDebugSession` writes a dim `[program terminated]` notice and stops accepting input, but leaves the terminal open so scrollback survives.
- Starting a new session in the same workspace disposes the previous terminal — a fresh terminal per session, no unbounded accumulation.
- User manually closing the terminal (`Pseudoterminal.close`) just stops mirroring.

**Input** (`Pseudoterminal.handleInput` → `session.customRequest("zorglub33/serialInput", { data })`)
- Enter arrives as CR (`\r`) → sent as LF (`\n`), the host convention.
- Backspace arrives as DEL (`\x7f`) → translated to BS (`\x08`), matching the web console.
- Control chars (Ctrl-D = EOT `\x04`) pass through untouched — this is the whole point: `echo.s` becomes exitable from VS Code.
- A paste (multi-char string) is forwarded as **one** request = one IRQ edge, matching the drain-loop ISR contract.
- **No local echo** — the program echoes, matching the web IDE and real serial semantics.

**Output** (interception in `Z33DebugAdapter.emit`, the existing outgoing-message path)
- When an `output` event with `category === "stdout"` passes through **and** a live terminal is attached, the text is written to the pty (`\n` → `\r\n`) and the event is **suppressed** so output isn't double-shown in the Debug Console.
- If no terminal is attached (closed by the user, or creation raced the first bytes), the event is **forwarded unchanged** — output is never lost.
- Other categories (`console` halt/exception summaries) keep flowing to the Debug Console untouched.

**`open()` buffering** — output arriving before VS Code actually shows the terminal is buffered in the pty wrapper and flushed on `open()` (classic pseudo-terminal gotcha; early output would otherwise be dropped).

## Wiring shape

The adapter and the terminal are connected through a small session-id-keyed registry (`SerialTerminalManager`). The debug-adapter factory in `extension.ts` knows the `vscode.DebugSession`, so it passes the adapter an `onStdout` sink bound to `session.id` (`(text) => serial.writeStdout(session.id, text)`), which returns `true` when a live terminal consumed the bytes. The lifecycle listeners create/terminate the pty. The Rust side stays untouched (transport-agnostic); the Debug Console repl input path is unchanged and additive.

## Verification

`cd editors/vscode && pnpm run check && pnpm run build` — pass (tsc + oxlint + oxfmt clean; esbuild bundles both entries).

Live in `@vscode/test-web` (browser-driven), running `samples/echo.s`:
- Starting the session creates the **"Zorglub33 Serial"** terminal without stealing editor focus.
- Typing echoes **in the terminal** and **not** in the Debug Console (verified the console stays empty while the terminal shows the echoed bytes — suppression + no local echo).
- **Ctrl-D** exits the program; the terminal shows the dim `[program terminated]` notice and stays open.
- Starting a fresh session disposes the old terminal and opens a new empty one (Terminal 1 → Terminal 2).
- With the terminal **killed**, program output falls back to the **Debug Console** and **repl input still works** (typed `hey` in the repl → program echoed `hey` into the Debug Console).

## UX notes

- Before: all serial output landed in the Debug Console interleaved with `console`-category summaries, and input was repl-only. Now: while a terminal is attached, `stdout` shows only in the terminal; the Debug Console shows just the `console` summaries (halt/exception). Kill the terminal and output reverts to the Debug Console.
- test-web quirk: pass the workspace folder as the **last positional arg** to `@vscode/test-web` and open the plain `http://localhost:3333/` (it auto-mounts under the `vscode-test-web` scheme as "Test Files"); a `?folder=` URI failed to resolve the FS handle across reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)