### PR TITLE
Replace the web serial console with xterm.js

### DIFF
--- a/editors/web/app/serial-console.tsx
+++ b/editors/web/app/serial-console.tsx
@@ -1,11 +1,5 @@
 import { TerminalIcon, Trash2Icon } from "lucide-react";
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import { lazy, Suspense, useCallback, useRef } from "react";
 import { Button } from "./components/ui/button";
 import {
   Tooltip,
@@ -13,109 +7,30 @@ import {
   TooltipTrigger,
 } from "./components/ui/tooltip";
 import type { ComputerProxy } from "./lib/computer-proxy";
-import { cn } from "./lib/utils";
+import type { SerialTerminalHandle } from "./serial-terminal";
+
+// Lazy-load the xterm-backed terminal so xterm (~82 KB gzip) lands in its own
+// chunk and stays out of the initial bundle. It is only needed once the debug
+// panel renders.
+const SerialTerminal = lazy(() => import("./serial-terminal"));
 
 type SerialConsoleProps = {
   computer: ComputerProxy;
 };
 
-const encoder = new TextEncoder();
-
-/** How close to the bottom (px) still counts as "following" the output. */
-const AUTOSCROLL_THRESHOLD = 24;
-
 /**
- * A minimal serial terminal wired to the emulator's serial console
- * (ports 110-111). Program output is decoded and appended to an ephemeral
- * scrollback; printable keystrokes, Enter, Backspace, Ctrl-<letter> and pastes
- * are forwarded to the emulator as receive bytes. There is **no local echo** —
- * only what the program writes back appears.
- *
- * Scrollback lives in component state and is reset whenever the `computer`
- * (i.e. the debug session) changes.
+ * A serial terminal wired to the emulator's serial console (ports 110-111),
+ * backed by xterm.js. Program output is written straight to the terminal;
+ * keystrokes and pastes are translated to receive bytes and forwarded to the
+ * emulator. There is **no local echo** — only what the program writes back
+ * appears. Scrollback is ephemeral: it resets whenever the debug session (the
+ * `computer`) changes.
  */
 export const SerialConsole: React.FC<SerialConsoleProps> = ({ computer }) => {
-  const [text, setText] = useState("");
-  const scrollRef = useRef<HTMLDivElement>(null);
-  // Tracks whether the view should stick to the bottom on new output.
-  const followRef = useRef(true);
-
-  // Reset scrollback and subscribe to output whenever the session changes. A
-  // fresh streaming decoder per session avoids carrying a partial multi-byte
-  // sequence across sessions.
-  useEffect(() => {
-    setText("");
-    followRef.current = true;
-    const decoder = new TextDecoder();
-    const unsubscribe = computer.onOutput((bytes) => {
-      const chunk = decoder.decode(Uint8Array.from(bytes), { stream: true });
-      if (chunk) setText((prev) => prev + chunk);
-    });
-    return unsubscribe;
-  }, [computer]);
-
-  // Auto-scroll to the bottom after new output, unless the user scrolled up.
-  useLayoutEffect(() => {
-    const el = scrollRef.current;
-    if (el && followRef.current) el.scrollTop = el.scrollHeight;
-  }, [text]);
-
-  const handleScroll = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
-    followRef.current = distance <= AUTOSCROLL_THRESHOLD;
-  }, []);
-
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.metaKey || event.altKey) return;
-
-      if (event.ctrlKey) {
-        // Map Ctrl-<letter> to its control code (Ctrl-D -> 4 = EOT). Leave
-        // browser shortcuts like Ctrl-C/Ctrl-V (copy/paste) alone.
-        const code = event.key.toUpperCase().codePointAt(0);
-        if (
-          event.key.length === 1 &&
-          code !== undefined &&
-          code >= 65 &&
-          code <= 90
-        ) {
-          if (event.key === "c" || event.key === "v") return;
-          event.preventDefault();
-          computer.sendInput([code - 64]);
-        }
-        return;
-      }
-
-      if (event.key === "Enter") {
-        event.preventDefault();
-        computer.sendInput([0x0a]);
-      } else if (event.key === "Backspace") {
-        event.preventDefault();
-        computer.sendInput([0x08]);
-      } else if (event.key.length === 1) {
-        event.preventDefault();
-        computer.sendInput([...encoder.encode(event.key)]);
-      }
-    },
-    [computer],
-  );
-
-  const handlePaste = useCallback(
-    (event: React.ClipboardEvent<HTMLDivElement>) => {
-      const pasted = event.clipboardData.getData("text");
-      if (!pasted) return;
-      event.preventDefault();
-      // One receive-interrupt edge for the whole paste.
-      computer.sendInput([...encoder.encode(pasted)]);
-    },
-    [computer],
-  );
+  const terminalRef = useRef<SerialTerminalHandle>(null);
 
   const clear = useCallback(() => {
-    setText("");
-    followRef.current = true;
+    terminalRef.current?.clear();
   }, []);
 
   return (
@@ -143,22 +58,10 @@ export const SerialConsole: React.FC<SerialConsoleProps> = ({ computer }) => {
           </Tooltip>
         </div>
       </div>
-      <div
-        ref={scrollRef}
-        onScroll={handleScroll}
-        onKeyDown={handleKeyDown}
-        onPaste={handlePaste}
-        tabIndex={0}
-        role="textbox"
-        aria-label="Serial console output"
-        aria-multiline="true"
-        className={cn(
-          "flex-1 min-h-0 overflow-auto whitespace-pre-wrap break-words",
-          "px-2.5 py-1.5 font-mono text-xs leading-relaxed outline-none",
-          "focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset",
-        )}
-      >
-        {text}
+      <div className="flex-1 min-h-0 p-1.5">
+        <Suspense fallback={null}>
+          <SerialTerminal computer={computer} ref={terminalRef} />
+        </Suspense>
       </div>
     </div>
   );

--- a/editors/web/app/serial-terminal.tsx
+++ b/editors/web/app/serial-terminal.tsx
@@ -48,13 +48,18 @@ const FONT_FAMILY =
  * escapes dropped (no cursor semantics on a serial line), other control chars
  * forwarded as-is, everything else UTF-8 encoded. Returns `null` when nothing
  * should be sent.
+ *
+ * Newlines are normalized to LF before encoding: a typed Enter arrives as a
+ * lone `\r`, but xterm also normalizes any newlines *inside* a pasted string
+ * to `\r` (never `\r\n`, but handle both defensively) — without this, a
+ * multi-line paste would send raw CR bytes that the LF-oriented emulator
+ * never recognizes as a line terminator.
  */
 function translateInput(data: string): Uint8Array | null {
-  if (data === "\r") return Uint8Array.of(0x0a);
   if (data === "\u007F") return Uint8Array.of(0x08);
   // Escape sequences (arrows, function keys, ...) carry no serial meaning.
   if (data.startsWith("\u001B")) return null;
-  return encoder.encode(data);
+  return encoder.encode(data.replaceAll(/\r\n?/gu, "\n"));
 }
 
 /**

--- a/editors/web/app/serial-terminal.tsx
+++ b/editors/web/app/serial-terminal.tsx
@@ -1,0 +1,164 @@
+import { FitAddon } from "@xterm/addon-fit";
+import { type ITheme, Terminal } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
+import { useEffect, useImperativeHandle, useRef } from "react";
+import type { ComputerProxy } from "./lib/computer-proxy";
+import { useThemeStore } from "./stores/theme-store";
+
+/** Imperative handle exposed to the header (clear button). */
+export type SerialTerminalHandle = {
+  clear: () => void;
+};
+
+type SerialTerminalProps = {
+  computer: ComputerProxy;
+  ref?: React.Ref<SerialTerminalHandle>;
+};
+
+const encoder = new TextEncoder();
+
+/**
+ * Static xterm palettes harmonized with the app's Tailwind theme (the neutral
+ * `--background`/`--foreground` scale, converted to hex — xterm's internal
+ * color math needs real hex, never CSS `var(...)`).
+ */
+const LIGHT_THEME: ITheme = {
+  background: "#ffffff",
+  foreground: "#1c1c1c",
+  cursor: "#1c1c1c",
+  cursorAccent: "#ffffff",
+  selectionBackground: "#b4d5fe",
+};
+
+const DARK_THEME: ITheme = {
+  background: "#171717",
+  foreground: "#fafafa",
+  cursor: "#fafafa",
+  cursorAccent: "#171717",
+  selectionBackground: "#3a3a3a",
+};
+
+/** Match the app's mono stack (Tailwind's default `font-mono`). */
+const FONT_FAMILY =
+  'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace';
+
+/**
+ * Translate an xterm `onData` string into serial receive bytes, following the
+ * serial-port policy: Enter -> LF, Backspace -> BS, arrow/function-key CSI
+ * escapes dropped (no cursor semantics on a serial line), other control chars
+ * forwarded as-is, everything else UTF-8 encoded. Returns `null` when nothing
+ * should be sent.
+ */
+function translateInput(data: string): Uint8Array | null {
+  if (data === "\r") return Uint8Array.of(0x0a);
+  if (data === "\u007F") return Uint8Array.of(0x08);
+  // Escape sequences (arrows, function keys, ...) carry no serial meaning.
+  if (data.startsWith("\u001B")) return null;
+  return encoder.encode(data);
+}
+
+/**
+ * The xterm.js-backed serial terminal. Lazy-loaded so xterm stays out of the
+ * initial bundle. Program output is written straight through (`convertEol`
+ * handles the emulator's LF-only newlines); keystrokes and pastes are
+ * translated to receive bytes and forwarded to the emulator (one `sendInput`
+ * call per `onData` event = one receive-interrupt edge per paste). No local
+ * echo — only what the program writes back appears.
+ */
+const SerialTerminal: React.FC<SerialTerminalProps> = ({ computer, ref }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const terminalRef = useRef<Terminal | null>(null);
+
+  useImperativeHandle(ref, () => ({
+    clear: () => {
+      terminalRef.current?.clear();
+    },
+  }));
+
+  // Create the terminal once and wire up resize handling.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return undefined;
+
+    const { effective } = useThemeStore.getState();
+    const terminal = new Terminal({
+      convertEol: true,
+      cursorBlink: true,
+      scrollback: 5000,
+      fontFamily: FONT_FAMILY,
+      fontSize: 12,
+      theme: effective === "dark" ? DARK_THEME : LIGHT_THEME,
+    });
+    const fit = new FitAddon();
+    terminal.loadAddon(fit);
+    terminal.open(container);
+    terminalRef.current = terminal;
+
+    // Expose the instance for e2e tests.
+    (globalThis as { __z33Terminal?: Terminal }).__z33Terminal = terminal;
+
+    // Fit to the container, guarding against the collapsed-panel pitfall:
+    // fitting at zero size yields NaN/Infinity dimensions and can runaway.
+    const safeFit = () => {
+      if (container.offsetWidth > 0 && container.offsetHeight > 0) fit.fit();
+    };
+    safeFit();
+
+    let raf = 0;
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(safeFit);
+    });
+    observer.observe(container);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      observer.disconnect();
+      terminal.dispose();
+      terminalRef.current = null;
+      const global = globalThis as { __z33Terminal?: Terminal };
+      if (global.__z33Terminal === terminal) delete global.__z33Terminal;
+    };
+  }, []);
+
+  // Live-swap the palette when the effective theme changes.
+  useEffect(() => {
+    const apply = (effective: "dark" | "light") => {
+      const terminal = terminalRef.current;
+      if (terminal) {
+        terminal.options.theme =
+          effective === "dark" ? DARK_THEME : LIGHT_THEME;
+      }
+    };
+    apply(useThemeStore.getState().effective);
+    return useThemeStore.subscribe((state) => {
+      apply(state.effective);
+    });
+  }, []);
+
+  // Reset scrollback and (re)wire I/O whenever the debug session changes.
+  useEffect(() => {
+    const terminal = terminalRef.current;
+    if (!terminal) return undefined;
+
+    terminal.reset();
+
+    const onData = terminal.onData((data) => {
+      const bytes = translateInput(data);
+      if (bytes && bytes.length > 0) computer.sendInput([...bytes]);
+    });
+
+    const unsubscribe = computer.onOutput((bytes) => {
+      terminal.write(Uint8Array.from(bytes));
+    });
+
+    return () => {
+      onData.dispose();
+      unsubscribe();
+    };
+  }, [computer]);
+
+  return <div ref={containerRef} className="h-full w-full" />;
+};
+
+export default SerialTerminal;

--- a/editors/web/e2e/serial-console.spec.ts
+++ b/editors/web/e2e/serial-console.spec.ts
@@ -24,6 +24,33 @@ done:
     reset
 `;
 
+// Read the visible terminal buffer through the test hook the component exposes
+// (`window.__z33Terminal`). xterm renders to a canvas-less DOM grid, so there is
+// no accessible text node to assert on — we read the buffer directly instead.
+async function terminalText(page: import("@playwright/test").Page): Promise<string> {
+  return page.evaluate(() => {
+    const terminal = (globalThis as { __z33Terminal?: unknown }).__z33Terminal as
+      | {
+          buffer: {
+            active: {
+              length: number;
+              getLine: (
+                i: number,
+              ) => { translateToString: (trim: boolean) => string } | undefined;
+            };
+          };
+        }
+      | undefined;
+    if (!terminal) return "";
+    const { active } = terminal.buffer;
+    const lines: string[] = [];
+    for (let i = 0; i < active.length; i++) {
+      lines.push(active.getLine(i)?.translateToString(true) ?? "");
+    }
+    return lines.join("\n");
+  });
+}
+
 test.describe("Serial console", () => {
   test("echoes typed input back to the console", async ({ page }) => {
     await loadWorkspace(page, { "echo.s": ECHO_PROGRAM }, "echo.s");
@@ -35,14 +62,17 @@ test.describe("Serial console", () => {
       .getByRole("button", { name: "Run", exact: true })
       .click();
 
-    const console = page.getByRole("textbox", { name: "Serial console output" });
-    await expect(console).toBeVisible();
+    // Click the terminal screen to focus it (xterm moves focus to its hidden
+    // helper textarea, which receives the keystrokes).
+    const screen = page.locator(".xterm-screen");
+    await expect(screen).toBeVisible();
+    await screen.click();
 
-    // Focus the console and type: the program should echo each byte back.
-    await console.click();
+    // Type: the program should echo each byte back into the terminal buffer.
     await page.keyboard.type("hi");
-
-    await expect(console).toHaveText(/hi/);
+    await expect
+      .poll(() => terminalText(page), { timeout: 10_000 })
+      .toContain("hi");
 
     // Ctrl-D (EOT) ends the program.
     await page.keyboard.press("Control+d");

--- a/editors/web/e2e/serial-console.spec.ts
+++ b/editors/web/e2e/serial-console.spec.ts
@@ -83,4 +83,49 @@ test.describe("Serial console", () => {
       }),
     ).toBeVisible();
   });
+
+  test("normalizes newlines within a paste to line feeds", async ({
+    page,
+  }) => {
+    await loadWorkspace(page, { "echo.s": ECHO_PROGRAM }, "echo.s");
+    await enterDebugMode(page);
+
+    await page
+      .getByRole("toolbar", { name: "Debug" })
+      .getByRole("button", { name: "Run", exact: true })
+      .click();
+
+    const screen = page.locator(".xterm-screen");
+    await expect(screen).toBeVisible();
+    await screen.click();
+
+    // Drive xterm's own `paste()` API instead of `keyboard.type`: real browser
+    // paste events go through the same internal normalization (embedded
+    // newlines become a bare `\r`), so this exercises the exact input our
+    // `translateInput` regression fix targets, without needing a real
+    // clipboard/paste simulation.
+    await page.evaluate(() => {
+      const terminal = (
+        globalThis as { __z33Terminal?: { paste: (data: string) => void } }
+      ).__z33Terminal;
+      terminal?.paste("hi\nbye");
+    });
+
+    // With newlines correctly translated to LF, the echoed bytes produce two
+    // separate lines. A regression that forwards the raw CR byte instead
+    // would make "bye" overwrite "hi" in place (bare CR just returns the
+    // cursor to column 0), collapsing both into a single line.
+    await expect
+      .poll(() => terminalText(page), { timeout: 10_000 })
+      .toMatch(/hi\nbye/);
+
+    // Ctrl-D (EOT) ends the program.
+    await page.keyboard.press("Control+d");
+    await expect(
+      page.getByRole("toolbar", { name: "Debug" }).getByRole("button", {
+        name: "Run",
+        exact: true,
+      }),
+    ).toBeVisible();
+  });
 });

--- a/editors/web/package.json
+++ b/editors/web/package.json
@@ -42,6 +42,8 @@
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-pacer": "^0.22.1",
     "@tanstack/react-virtual": "^3.14.5",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.23.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,12 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.14.5
         version: 3.14.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: 6.0.0
+        version: 6.0.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1660,6 +1666,12 @@ packages:
     resolution: {integrity: sha512-XSxMosEEDO6vLxELAHVkwmhC0qe0ijZni2jB9Rcs8kQsW4lhTDQ/wMzmwFs/buotAWSnpmUp/dRWD2ufG3UYKA==}
     engines: {node: '>= 20'}
     hasBin: true
+
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -4893,6 +4905,10 @@ snapshots:
       keytar: 7.9.0
     transitivePeerDependencies:
       - supports-color
+
+  '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/xterm@6.0.0': {}
 
   accepts@2.0.0:
     dependencies:


### PR DESCRIPTION
PR 6 of the serial stack, stacked on #989 (the homegrown web serial console).

Replaces the hand-rolled scrollback-`<div>` serial console with a real terminal backed by [`@xterm/xterm`](https://www.npmjs.com/package/@xterm/xterm) `6.0.0` + `@xterm/addon-fit`. `ComputerProxy`'s `sendInput`/`onOutput` interface is unchanged — the terminal is a pure consumer.

## Why xterm

The old `<div>` accumulated a `TextDecoder` string and re-rendered React on every output batch, with manual `keydown`/`paste` handlers. xterm gives proper cursor handling, real scrollback, text selection, and correct control-character rendering for free, and `convertEol` handles the emulator's LF-only output so the decoder accumulation is gone entirely.

## Input translation policy

xterm delivers keystrokes and pastes through `onData(data: string)`; each event is translated and forwarded as **one** `sendInput` call (one receive-interrupt edge per paste — matters for interrupt-driven programs). No local echo.

| `onData` input | Sent to serial |
|---|---|
| `"\r"` (Enter) | `0x0A` (LF) |
| `""` (Backspace) | `0x08` (BS) |
| starts with `""` (arrow/function-key CSI) | dropped (no cursor semantics on a serial line) |
| other control chars (`0x03`, `0x04` EOT, …) | forwarded as-is |
| printables / multi-char paste | UTF-8 encoded, one `sendInput` |

## Lazy chunk

xterm is lazy-loaded via `React.lazy`, so it stays out of the initial bundle and lands in its own chunk (loaded when the debug panel first renders).

| build (gzip) | before | after |
|---|---|---|
| main `index.js` | 973.45 KB (single bundle) | 970.12 KB |
| `jsx-runtime` (shared) | — | 4.57 KB |
| **initial total** | **973.45 KB** | **~974.7 KB** |
| `serial-terminal` chunk (lazy) | — | 86.94 KB |
| `serial-terminal.css` (lazy) | — | 0.96 KB |

The ~87 KB of xterm is deferred; initial load is flat (+~1.2 KB of split plumbing).

## Theme

Two static hex `ITheme` palettes harmonized with the app's Tailwind neutral scale (real hex — xterm's color math rejects CSS `var()`). The effective theme is subscribed from `theme-store` and swapped live via `terminal.options.theme`. Verified live in both modes: light `#fff`/`#1c1c1c`, dark `#171717`/`#fafafa`, and the light↔dark swap repaints without recreating the terminal.

## Other details

- `FitAddon` driven by a `ResizeObserver`, guarded against the collapsed-panel zero-size `fit()` pitfall (skips fit at `offsetWidth/Height === 0`).
- Terminal resets per debug session (keyed on the `computer` prop).
- Header (Terminal icon + clear button → `terminal.clear()`) and collapse behavior preserved; no autofocus (click-to-focus only, so Monaco keeps focus).
- e2e reworked: the terminal is exposed as `window.__z33Terminal`; the spec reads `terminal.buffer` via `translateToString` instead of DOM text. Full suite: 28 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
