### PR TITLE
Parse full expressions inside parentheses

### DIFF
--- a/crates/emulator/src/parser/assembly.rs
+++ b/crates/emulator/src/parser/assembly.rs
@@ -517,6 +517,66 @@ mod tests {
     }
 
     #[test]
+    fn parse_directive_parenthesized_expression() {
+        // Regression: `( ... )` used to only wrap a bare atom, so an operator
+        // expression inside parentheses failed to parse.
+        let result = parse(".word (1 << 8)");
+        assert!(
+            result.diagnostics.is_empty(),
+            "diagnostics: {:?}",
+            result
+                .diagnostics
+                .iter()
+                .map(|d| &d.message)
+                .collect::<Vec<_>>()
+        );
+        let line = &result.program.inner.lines[0].inner;
+        match &line.content {
+            Some(Located {
+                inner: LineContent::Directive { kind, argument },
+                ..
+            }) => {
+                assert_eq!(kind.inner, DirectiveKind::Word);
+                assert!(matches!(
+                    argument.inner,
+                    DirectiveArgument::Expression(ExpressionNode::LeftShift(..))
+                ));
+            }
+            other => panic!("expected directive, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_instruction_parenthesized_immediate() {
+        let result = parse("    ld (1 << 8), %a");
+        assert!(
+            result.diagnostics.is_empty(),
+            "diagnostics: {:?}",
+            result
+                .diagnostics
+                .iter()
+                .map(|d| &d.message)
+                .collect::<Vec<_>>()
+        );
+        let line = &result.program.inner.lines[0].inner;
+        match &line.content {
+            Some(Located {
+                inner: LineContent::Instruction { kind, arguments },
+                ..
+            }) => {
+                assert_eq!(kind.inner, InstructionKind::Ld);
+                assert_eq!(arguments.len(), 2);
+                assert!(matches!(
+                    arguments[0].inner,
+                    InstructionArgument::Value(ExpressionNode::LeftShift(..))
+                ));
+                assert_eq!(arguments[1].inner, InstructionArgument::Register(Reg::A));
+            }
+            other => panic!("expected instruction, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn parse_hex_literal() {
         let result = parse(".word 0xFF");
         assert!(

--- a/crates/emulator/src/parser/condition.rs
+++ b/crates/emulator/src/parser/condition.rs
@@ -427,6 +427,15 @@ mod tests {
     }
 
     #[test]
+    fn parenthesized_arithmetic_in_condition_test() {
+        // Conditions embed the shared expression parser, so a parenthesized
+        // operator expression (e.g. `#if (1 << 8) == 256`) must parse.
+        assert!(evaluate("(1 << 8) == 256"));
+        assert!(evaluate("(1 + 2) * 3 == 9"));
+        assert!(evaluate("1 + (2 * 3) == 7"));
+    }
+
+    #[test]
     fn logical_operations_test() {
         assert!(evaluate("true && true"));
         assert!(!evaluate("true && false"));

--- a/crates/emulator/src/parser/shared.rs
+++ b/crates/emulator/src/parser/shared.rs
@@ -255,125 +255,132 @@ pub fn register<'a>() -> impl Parser<'a, &'a str, Reg, Extra<'a>> + Clone {
 #[must_use]
 #[allow(clippy::too_many_lines)]
 pub fn expression<'a>() -> impl Parser<'a, &'a str, ExpressionNode, Extra<'a>> + Clone {
-    // Parenthesized expressions need recursion
-    let atom = recursive(|expr| {
+    // The whole precedence ladder is wrapped in `recursive` so that a
+    // parenthesized atom recurses into the TOP-LEVEL expression parser (the
+    // outermost bitwise-or tier) rather than back into the atom tier. Without
+    // this, `( ... )` could only wrap a bare atom and operator expressions like
+    // `(1 << 8)` failed to parse.
+    recursive(|expr| {
         let number = number_literal().map(|v| ExpressionNode::Literal(ExpressionValue::from(v)));
 
         let variable = identifier().map(|i: &str| ExpressionNode::Variable(i.into()));
 
+        // A parenthesized group closes over the full expression (`expr`), so
+        // any operator expression is valid between the parentheses.
         let paren = expr.delimited_by(just('(').then(hspace()), hspace().then(just(')')));
 
-        number.or(variable).or(paren)
-    });
+        let atom = number.or(variable).or(paren);
 
-    // Unary operators
-    let unary = choice((
-        just('-')
-            .ignore_then(hspace())
-            .ignore_then(atom.clone())
-            .map_with(|rhs, e| {
-                ExpressionNode::Invert(Box::new(rhs).with_location(span_to_range(e.span())))
-            }),
-        just('~')
-            .ignore_then(hspace())
-            .ignore_then(atom.clone())
-            .map_with(|rhs, e| {
-                ExpressionNode::BinaryNot(Box::new(rhs).with_location(span_to_range(e.span())))
-            }),
-        atom,
-    ));
+        // Unary operators
+        let unary = choice((
+            just('-')
+                .ignore_then(hspace())
+                .ignore_then(atom.clone())
+                .map_with(|rhs, e| {
+                    ExpressionNode::Invert(Box::new(rhs).with_location(span_to_range(e.span())))
+                }),
+            just('~')
+                .ignore_then(hspace())
+                .ignore_then(atom.clone())
+                .map_with(|rhs, e| {
+                    ExpressionNode::BinaryNot(Box::new(rhs).with_location(span_to_range(e.span())))
+                }),
+            atom,
+        ));
 
-    // Multiplication / Division
-    let op = just('*').to(true).or(just('/').to(false));
-    let product = unary.clone().foldl_with(
-        hspace()
-            .ignore_then(op)
-            .then_ignore(hspace())
-            .then(unary)
-            .repeated(),
-        |lhs, (is_mul, rhs), e| {
-            let span = e.span();
-            let lhs = Box::new(lhs).with_location(span.start..span.start);
-            let rhs = Box::new(rhs).with_location(span.end..span.end);
-            if is_mul {
-                ExpressionNode::Multiply(lhs, rhs)
-            } else {
-                ExpressionNode::Divide(lhs, rhs)
-            }
-        },
-    );
-
-    // Addition / Subtraction
-    let op = just('+').to(true).or(just('-').to(false));
-    let sum = product.clone().foldl_with(
-        hspace()
-            .ignore_then(op)
-            .then_ignore(hspace())
-            .then(product)
-            .repeated(),
-        |lhs, (is_add, rhs), e| {
-            let span = e.span();
-            let lhs = Box::new(lhs).with_location(span.start..span.start);
-            let rhs = Box::new(rhs).with_location(span.end..span.end);
-            if is_add {
-                ExpressionNode::Sum(lhs, rhs)
-            } else {
-                ExpressionNode::Substract(lhs, rhs)
-            }
-        },
-    );
-
-    // Shifts
-    let op = just("<<").to(true).or(just(">>").to(false));
-    let shift = sum.clone().foldl_with(
-        hspace()
-            .ignore_then(op)
-            .then_ignore(hspace())
-            .then(sum)
-            .repeated(),
-        |lhs, (is_left, rhs), e| {
-            let span = e.span();
-            let lhs = Box::new(lhs).with_location(span.start..span.start);
-            let rhs = Box::new(rhs).with_location(span.end..span.end);
-            if is_left {
-                ExpressionNode::LeftShift(lhs, rhs)
-            } else {
-                ExpressionNode::RightShift(lhs, rhs)
-            }
-        },
-    );
-
-    // Bitwise AND (must not match &&)
-    let band = shift.clone().foldl_with(
-        hspace()
-            .ignore_then(just('&').then_ignore(just('&').not()))
-            .then_ignore(hspace())
-            .ignore_then(shift)
-            .repeated(),
-        |lhs, rhs, e| {
-            let span = e.span();
-            let lhs = Box::new(lhs).with_location(span.start..span.start);
-            let rhs = Box::new(rhs).with_location(span.end..span.end);
-            ExpressionNode::BinaryAnd(lhs, rhs)
-        },
-    );
-
-    // Bitwise OR (must not match ||)
-    band.clone()
-        .foldl_with(
+        // Multiplication / Division
+        let op = just('*').to(true).or(just('/').to(false));
+        let product = unary.clone().foldl_with(
             hspace()
-                .ignore_then(just('|').then_ignore(just('|').not()))
+                .ignore_then(op)
                 .then_ignore(hspace())
-                .ignore_then(band)
+                .then(unary)
+                .repeated(),
+            |lhs, (is_mul, rhs), e| {
+                let span = e.span();
+                let lhs = Box::new(lhs).with_location(span.start..span.start);
+                let rhs = Box::new(rhs).with_location(span.end..span.end);
+                if is_mul {
+                    ExpressionNode::Multiply(lhs, rhs)
+                } else {
+                    ExpressionNode::Divide(lhs, rhs)
+                }
+            },
+        );
+
+        // Addition / Subtraction
+        let op = just('+').to(true).or(just('-').to(false));
+        let sum = product.clone().foldl_with(
+            hspace()
+                .ignore_then(op)
+                .then_ignore(hspace())
+                .then(product)
+                .repeated(),
+            |lhs, (is_add, rhs), e| {
+                let span = e.span();
+                let lhs = Box::new(lhs).with_location(span.start..span.start);
+                let rhs = Box::new(rhs).with_location(span.end..span.end);
+                if is_add {
+                    ExpressionNode::Sum(lhs, rhs)
+                } else {
+                    ExpressionNode::Substract(lhs, rhs)
+                }
+            },
+        );
+
+        // Shifts
+        let op = just("<<").to(true).or(just(">>").to(false));
+        let shift = sum.clone().foldl_with(
+            hspace()
+                .ignore_then(op)
+                .then_ignore(hspace())
+                .then(sum)
+                .repeated(),
+            |lhs, (is_left, rhs), e| {
+                let span = e.span();
+                let lhs = Box::new(lhs).with_location(span.start..span.start);
+                let rhs = Box::new(rhs).with_location(span.end..span.end);
+                if is_left {
+                    ExpressionNode::LeftShift(lhs, rhs)
+                } else {
+                    ExpressionNode::RightShift(lhs, rhs)
+                }
+            },
+        );
+
+        // Bitwise AND (must not match &&)
+        let band = shift.clone().foldl_with(
+            hspace()
+                .ignore_then(just('&').then_ignore(just('&').not()))
+                .then_ignore(hspace())
+                .ignore_then(shift)
                 .repeated(),
             |lhs, rhs, e| {
                 let span = e.span();
                 let lhs = Box::new(lhs).with_location(span.start..span.start);
                 let rhs = Box::new(rhs).with_location(span.end..span.end);
-                ExpressionNode::BinaryOr(lhs, rhs)
+                ExpressionNode::BinaryAnd(lhs, rhs)
             },
-        )
-        .boxed()
+        );
+
+        // Bitwise OR (must not match ||)
+        band.clone()
+            .foldl_with(
+                hspace()
+                    .ignore_then(just('|').then_ignore(just('|').not()))
+                    .then_ignore(hspace())
+                    .ignore_then(band)
+                    .repeated(),
+                |lhs, rhs, e| {
+                    let span = e.span();
+                    let lhs = Box::new(lhs).with_location(span.start..span.start);
+                    let rhs = Box::new(rhs).with_location(span.end..span.end);
+                    ExpressionNode::BinaryOr(lhs, rhs)
+                },
+            )
+            .boxed()
+    })
+    .boxed()
 }
 
 // ---------------------------------------------------------------------------
@@ -400,4 +407,66 @@ pub fn parse_register_str(input: &str) -> Result<Reg, String> {
             .collect::<Vec<_>>()
             .join("; ")
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::super::expression::{EmptyContext, Node};
+    use super::parse_expression_str;
+
+    #[track_caller]
+    fn eval(input: &str) -> i128 {
+        let node = parse_expression_str(input).expect("parse failed");
+        node.evaluate::<EmptyContext, i128>(&EmptyContext)
+            .expect("evaluation failed")
+    }
+
+    #[test]
+    fn parenthesized_operator_expressions_parse() {
+        // Regression: before parens recursed into the full expression parser
+        // (instead of only the atom parser), each of these failed with
+        // "unexpected '<'/'+'/'*', expected ')'".
+        assert_eq!(eval("(1 << 8)"), 256);
+        assert_eq!(eval("(1 + 8)"), 9);
+        assert_eq!(eval("(2 * 3) + 1"), 7);
+    }
+
+    #[test]
+    fn parens_override_precedence() {
+        // Each case differs from the unparenthesized reading, pinning that the
+        // parentheses actually regroup across every precedence tier.
+        assert_eq!(eval("(1 + 2) * 3"), 9); // vs `1 + 2 * 3` == 7
+        assert_eq!(eval("1 + (2 * 3)"), 7);
+        assert_eq!(eval("(1 + 1) << 2"), 8); // vs `1 + 1 << 2` == 5
+        assert_eq!(eval("(1 | 2) & 3"), 3);
+        assert_eq!(eval("(1 | 4) & 2"), 0); // vs `1 | 4 & 2` == 1
+    }
+
+    #[test]
+    fn nested_and_unary_parens() {
+        assert_eq!(eval("((1 + 2))"), 3);
+        assert_eq!(eval("-(1 + 2)"), -3);
+        assert_eq!(eval("(1 + (2 * (3 + 1)))"), 9);
+    }
+
+    #[test]
+    fn top_level_precedence_is_preserved() {
+        assert_eq!(eval("1 + 2 * 3"), 7);
+        assert_eq!(eval("1 << 1 + 1"), 4); // shift binds looser than sum
+        assert_eq!(eval("1 | 2 & 3"), 3); // or binds looser than and
+        assert_eq!(eval("7 - 2 - 1"), 4); // subtraction is left associative
+        assert_eq!(eval("2 * 3 + 4 / 2"), 8);
+    }
+
+    #[test]
+    fn binary_not_still_parses_in_parens() {
+        // `~` parses fine (its *evaluation* is a deliberate `todo!()`), so only
+        // check that a parenthesized bitwise-not produces the expected node.
+        assert!(matches!(
+            parse_expression_str("(~1)"),
+            Ok(Node::BinaryNot(_))
+        ));
+    }
 }

--- a/crates/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__condition_parse_error_test.snap
+++ b/crates/emulator/src/preprocessor/snapshots/z33_emulator__preprocessor__tests__condition_parse_error_test.snap
@@ -1,9 +1,8 @@
 ---
-source: emulator/src/preprocessor/mod.rs
-assertion_line: 860
+source: crates/emulator/src/preprocessor/mod.rs
 expression: report
 ---
-error: invalid condition syntax: found end of input expected any, '*', '/', '+', '-', '<', '>', '&', '|', '=', or '!'
+error: invalid condition syntax: found end of input expected any, '*', '/', '+', '-', '<', '>', '&', '|', '=', '!', or ')'
   ┌─ /invalid.S:2:5
   │
 2 │ #if (1 + 5


### PR DESCRIPTION
## The bug

The shared constant-expression grammar (`crates/emulator/src/parser/shared.rs`) built its precedence ladder *outside* the `recursive` closure. Only the atom tier (`number | variable | paren`) was recursive, so a parenthesized group `( ... )` closed over the **atom** parser rather than the top-level expression. As a result, any operator inside parentheses failed to parse:

- `.word (1 << 8)`
- `ld (1 << 8), %a`
- `#if (1 << 8)`
- `(1 + 2) * 3`, `-(1 + 2)`, etc.

all errored with `unexpected '<'/'+'/'*', expected ')'`, even though the identical *unparenthesized* expression parsed fine. This affected every site that accepts an expression: `.word`, instruction immediates, and `#if` conditions (the condition parser embeds the same shared parser).

Found while writing `#define SR_INTERRUPT_ENABLE (1 << 8)` in the serial-console work (PR #988 ff.). Once both land, those samples can adopt parenthesized `#define`s.

## The fix

Wrap the whole precedence ladder in the `recursive` closure so the paren branch recurses into the outermost (bitwise-or) tier — the full expression — instead of the atom tier. This is a minimal restructure: the tiers, their precedence/associativity, and the per-child span attachment are all unchanged. The `~` BinaryNot **evaluation** remains a deliberate `todo!()` (untouched — this PR is only about parsing).

## Test coverage

- `parser::shared` unit tests: paren regrouping across every precedence tier (`(1 << 8)`, `(1 + 2) * 3` vs `1 + (2 * 3)`, `(1 + 1) << 2`, `(1 | 4) & 2`), nested `((1 + 2))`, unary `-(1 + 2)`, top-level precedence/associativity is preserved, and `(~1)` still parses to `BinaryNot`.
- `parser::assembly` end-to-end: `.word (1 << 8)` and `ld (1 << 8), %a` compile with no diagnostics.
- `parser::condition`: `#if (1 << 8) == 256` and friends parse (shared parser).
- One preprocessor snapshot updated deliberately: the unclosed-paren error (`#if (1 + 5`) now also lists `')'` as an expected continuation — correct, since the parser can now continue the inner expression or close the paren.

Gates: `cargo test --workspace`, `cargo clippy --workspace --all-targets`, `cargo +nightly fmt --all -- --check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)