### PR TITLE
Hoist shared tool versions into a pnpm catalog

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -139,9 +139,9 @@
     "@vscode/vsce": "^3.9.2",
     "esbuild": "^0.28.0",
     "ovsx": "^1.0.2",
-    "oxfmt": "^0.57.0",
-    "oxlint": "^1.72.0",
-    "typescript": "6.0.3",
-    "wasm-pack": "^0.15.0"
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "typescript": "catalog:",
+    "wasm-pack": "catalog:"
   }
 }

--- a/editors/web/package.json
+++ b/editors/web/package.json
@@ -28,13 +28,13 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
     "knip": "^6.3.0",
-    "oxfmt": "^0.57.0",
-    "oxlint": "^1.72.0",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "oxlint-tsgolint": "^0.24.0",
     "tailwindcss": "^4.3.2",
-    "typescript": "6.0.3",
+    "typescript": "catalog:",
     "vite": "^8.1.3",
-    "wasm-pack": "^0.15.0"
+    "wasm-pack": "catalog:"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,21 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    oxfmt:
+      specifier: ^0.57.0
+      version: 0.57.0
+    oxlint:
+      specifier: ^1.72.0
+      version: 1.72.0
+    typescript:
+      specifier: 6.0.3
+      version: 6.0.3
+    wasm-pack:
+      specifier: ^0.15.0
+      version: 0.15.0
+
 importers:
 
   .: {}
@@ -27,16 +42,16 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       oxfmt:
-        specifier: ^0.57.0
+        specifier: 'catalog:'
         version: 0.57.0
       oxlint:
-        specifier: ^1.72.0
+        specifier: 'catalog:'
         version: 1.72.0(oxlint-tsgolint@0.24.0)
       typescript:
-        specifier: 6.0.3
+        specifier: 'catalog:'
         version: 6.0.3
       wasm-pack:
-        specifier: ^0.15.0
+        specifier: 'catalog:'
         version: 0.15.0
 
   editors/web:
@@ -136,10 +151,10 @@ importers:
         specifier: ^6.3.0
         version: 6.24.0
       oxfmt:
-        specifier: ^0.57.0
+        specifier: 'catalog:'
         version: 0.57.0
       oxlint:
-        specifier: ^1.72.0
+        specifier: 'catalog:'
         version: 1.72.0(oxlint-tsgolint@0.24.0)
       oxlint-tsgolint:
         specifier: ^0.24.0
@@ -148,13 +163,13 @@ importers:
         specifier: ^4.3.2
         version: 4.3.2
       typescript:
-        specifier: 6.0.3
+        specifier: 'catalog:'
         version: 6.0.3
       vite:
         specifier: ^8.1.3
         version: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       wasm-pack:
-        specifier: ^0.15.0
+        specifier: 'catalog:'
         version: 0.15.0
 
   tree-sitter-z33:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,10 +5,14 @@ packages:
   - editors/vscode
   - tree-sitter-z33
 
+catalog:
+  wasm-pack: ^0.15.0
+  oxlint: ^1.72.0
+  oxfmt: ^0.57.0
+  typescript: 6.0.3
+
 ignoredBuiltDependencies:
-  - "@playwright/browser-chromium"
   - esbuild
-  - msw
 
 onlyBuiltDependencies:
   - "@vscode/vsce-sign"


### PR DESCRIPTION
## Summary
- `wasm-pack ^0.15.0`, `oxlint ^1.72.0`, `oxfmt ^0.57.0`, and `typescript 6.0.3` were pinned identically in both `editors/web/package.json` and `editors/vscode/package.json`. Hoisted them into a `catalog:` section in the root `pnpm-workspace.yaml` and switched both manifests to `"catalog:"` references so the two can't drift apart.
- Dropped `@playwright/browser-chromium` and `msw` from `ignoredBuiltDependencies` in `pnpm-workspace.yaml` — neither appears anywhere in the workspace manifests or `pnpm-lock.yaml`. Kept `esbuild` in `ignoredBuiltDependencies` and left `onlyBuiltDependencies` untouched (wasm-pack still needs its native build).
- Regenerated `pnpm-lock.yaml` via `pnpm i` to reflect the catalog references.

## Test plan
- [x] `pnpm i` at the repo root succeeds
- [x] `node_modules/.bin/wasm-pack --version` in `editors/web` reports `0.15.0` (native binary still built under `onlyBuiltDependencies`)
- [x] `cd editors/web && pnpm run build:wasm:dev && pnpm run check` — build and oxlint/oxfmt check pass (only pre-existing warnings)
- [x] `cd editors/vscode && pnpm run check && pnpm run build` — tsc/oxlint/oxfmt check and the esbuild bundle build both pass
- [x] `jj diff --summary` confirms only `pnpm-workspace.yaml`, the two `package.json` files, and `pnpm-lock.yaml` changed

## Dependabot note
Dependabot's `npm` ecosystem has supported pnpm workspace catalogs since [Feb 2025 (GA)](https://github.blog/changelog/2025-02-04-dependabot-now-supports-pnpm-workspace-catalogs-ga/), so the existing `.github/dependabot.yml` (`npm` at `directory: "/"`) will keep bumping the four cataloged tools automatically — no config change is required. Heads-up: there are still open upstream bugs where Dependabot can desync the `specifier`/`version` in the lockfile for catalog entries ([dependabot-core#12244](https://github.com/dependabot/dependabot-core/issues/12244), [#14339](https://github.com/dependabot/dependabot-core/issues/14339)), so give catalog-touching Dependabot PRs a quick `pnpm i --frozen-lockfile` sanity check before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
