### PR TITLE
Fix %sr highlighting in Monaco and add a keyword sync test

### DIFF
--- a/crates/emulator/src/lsp/instructions.rs
+++ b/crates/emulator/src/lsp/instructions.rs
@@ -349,6 +349,7 @@ pub(super) fn directive_meta(kind: DirectiveKind) -> DirectiveMeta {
 mod tests {
     use super::{directive_meta, meta, DIRECTIVE_KINDS, INSTRUCTION_KINDS};
     use crate::parser::value::{DirectiveKind, InstructionKind};
+    use crate::runtime::Reg;
 
     #[test]
     fn every_instruction_kind_is_populated_and_roundtrips() {
@@ -391,5 +392,104 @@ mod tests {
             );
         }
         assert_eq!(DIRECTIVE_KINDS.len(), 4);
+    }
+
+    // --- Keyword-sync guards ------------------------------------------------
+    //
+    // The Z33 keyword set (33 instructions, 4 directives, 5 registers) is
+    // hand-duplicated across every editor-highlighting file. These tests read
+    // those committed files (repo-relative to the workspace, which is where
+    // `cargo test --workspace` runs) and assert that each keyword derived from
+    // the Rust enums still appears, so future drift — like Monaco once dropping
+    // `%sr` — fails CI instead of silently mis-highlighting.
+
+    /// Whole-word (ASCII `\b…\b`) containment. Case-sensitive: every keyword is
+    /// lowercase in every file. Word boundaries stop short mnemonics such as
+    /// `in`/`or`/`ld` from false-passing as substrings (e.g. `in` in
+    /// `invalid`).
+    fn contains_word(haystack: &str, needle: &str) -> bool {
+        let bytes = haystack.as_bytes();
+        let is_word = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+        haystack.match_indices(needle).any(|(i, _)| {
+            let end = i + needle.len();
+            let before = i == 0 || !is_word(bytes[i - 1]);
+            let after = end >= bytes.len() || !is_word(bytes[end]);
+            before && after
+        })
+    }
+
+    fn read_repo_file(rel: &str) -> String {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join(rel);
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+    }
+
+    /// Assert every `keyword` occurs as a whole word in the file at `rel`.
+    fn assert_all_present(rel: &str, keywords: &[String]) {
+        let content = read_repo_file(rel);
+        for kw in keywords {
+            assert!(
+                contains_word(&content, kw),
+                "{rel} is missing keyword `{kw}` — it drifted from the Rust enums; \
+                 update the highlighting file to match crates/emulator",
+            );
+        }
+    }
+
+    fn instruction_keywords() -> Vec<String> {
+        INSTRUCTION_KINDS.iter().map(ToString::to_string).collect()
+    }
+
+    fn directive_keywords() -> Vec<String> {
+        DIRECTIVE_KINDS.iter().map(ToString::to_string).collect()
+    }
+
+    /// Register names without the leading `%` (the highlighting files list the
+    /// bare names in alternations, e.g. Monaco's `%(a|b|sp|pc|sr)`).
+    fn register_keywords() -> Vec<String> {
+        Reg::ALL
+            .iter()
+            .map(|r| r.to_string().trim_start_matches('%').to_string())
+            .collect()
+    }
+
+    #[test]
+    fn monaco_has_all_instructions_and_registers() {
+        // Directives are not enumerated in Monaco (it colours any `.\w+`), so
+        // only instructions and registers are checked. This is the check that
+        // would have caught the `%sr` bug.
+        let file = "editors/web/app/monaco.ts";
+        assert_all_present(file, &instruction_keywords());
+        assert_all_present(file, &register_keywords());
+    }
+
+    #[test]
+    fn vim_syntax_has_all_keywords() {
+        let file = "editors/vim/syntax/z33.vim";
+        assert_all_present(file, &instruction_keywords());
+        assert_all_present(file, &directive_keywords());
+        assert_all_present(file, &register_keywords());
+    }
+
+    #[test]
+    fn zed_highlights_has_all_instructions() {
+        // Directives and registers reach Zed through grammar nodes
+        // (`directive_name`, `register`), so only the hand-copied 33-mnemonic
+        // list lives in the query file and is checked here.
+        assert_all_present(
+            "editors/zed/languages/zorglub33/highlights.scm",
+            &instruction_keywords(),
+        );
+    }
+
+    #[test]
+    fn tree_sitter_grammar_has_all_directives_and_registers() {
+        // Instruction mnemonics lex as identifiers in the grammar (deliberately
+        // not enumerated); only the DIRECTIVES/REGISTERS arrays are checked.
+        let file = "tree-sitter-z33/grammar.js";
+        assert_all_present(file, &directive_keywords());
+        assert_all_present(file, &register_keywords());
     }
 }

--- a/crates/emulator/src/runtime/registers.rs
+++ b/crates/emulator/src/runtime/registers.rs
@@ -129,6 +129,10 @@ pub enum Reg {
 
 // r[impl addr.register]
 impl Reg {
+    /// Every register variant, in canonical order. Single source of truth for
+    /// iterating over the register set (e.g. the keyword-sync tests).
+    pub const ALL: [Self; 5] = [Self::A, Self::B, Self::PC, Self::SP, Self::SR];
+
     /// CPU cycles count to use this value
     pub(crate) const fn cost() -> usize {
         // Accessing a register does not take any CPU cycle

--- a/crates/emulator/src/runtime/registers.rs
+++ b/crates/emulator/src/runtime/registers.rs
@@ -131,7 +131,19 @@ pub enum Reg {
 impl Reg {
     /// Every register variant, in canonical order. Single source of truth for
     /// iterating over the register set (e.g. the keyword-sync tests).
-    pub const ALL: [Self; 5] = [Self::A, Self::B, Self::PC, Self::SP, Self::SR];
+    ///
+    /// Exhaustiveness tripwire: the match below stops compiling if a variant is
+    /// added, and its `[Self; N]` length must then be bumped too — so `ALL`
+    /// can't silently miss a register (which would blind the keyword-sync
+    /// tests).
+    pub const ALL: [Self; 5] = {
+        // Exhaustiveness tripwire (compile-time only): a new variant makes this
+        // match non-exhaustive.
+        match Self::A {
+            Reg::A | Reg::B | Reg::PC | Reg::SP | Reg::SR => {}
+        }
+        [Self::A, Self::B, Self::PC, Self::SP, Self::SR]
+    };
 
     /// CPU cycles count to use this value
     pub(crate) const fn cost() -> usize {

--- a/editors/web/app/monaco.ts
+++ b/editors/web/app/monaco.ts
@@ -145,9 +145,9 @@ monaco.languages.setMonarchTokensProvider("z33", {
     constants: [[/[0-9]+/u, "constant"]],
     comments: [[/\/\/.*/u, "comment"]],
     registers: [
-      [/%(a|b|sp|pc)\b/u, "tag"],
+      [/%(a|b|sp|pc|sr)\b/u, "tag"],
       [/%[^ab]\b/u, "invalid"],
-      [/%s[^p]/u, "invalid"],
+      [/%s[^pr]/u, "invalid"],
       [/%p[^c]/u, "invalid"],
       [/%[^absp]/u, "invalid"],
     ],


### PR DESCRIPTION
## Summary

- **Fix a real highlighting bug**: the Monaco Monarch register rule (`editors/web/app/monaco.ts`) listed only `%a %b %sp %pc`, so the valid `%sr` status register fell through to the `%s[^p]` *invalid* rule and rendered as an error. Added `sr` to the valid alternation.
- Now that both `%sp` and `%sr` are valid, tightened the s-branch invalid rule from `%s[^p]` to `%s[^pr]` so it still flags genuinely invalid tokens (`%sq`, `%sa`, …) but its intent no longer relies on rule ordering to spare the now-valid `%sr`. The `%p[^c]` and catch-all rules are unchanged.
- **Add a keyword-sync guard test** (`crates/emulator/src/lsp/instructions.rs`) so future drift like this bug fails `cargo test --workspace` in the "Test Suite" CI job instead of silently mis-highlighting.

## Background

The Z33 keyword set (33 instructions, 4 directives, 5 registers) is hand-duplicated across every editor-highlighting file. An audit found the only drift was Monaco's register rule omitting `%sr`.

## The test

Keywords are derived from the Rust enums — the existing `INSTRUCTION_KINDS` / `DIRECTIVE_KINDS` lists plus a new canonical `Reg::ALL` const — not hardcoded string lists. Each is asserted to appear as a whole word (a dependency-free `\b…\b` matcher, so short mnemonics like `in`/`or`/`ld` can't false-pass as substrings) in every committed highlighting file. Coverage mirrors what each file actually enumerates:

| File | Checked |
|------|---------|
| `editors/web/app/monaco.ts` | instructions + registers (directives are matched generically as `.\w+`) |
| `editors/vim/syntax/z33.vim` | instructions + directives + registers |
| `editors/zed/languages/zorglub33/highlights.scm` | the hand-copied 33-mnemonic list (directives/registers reach Zed via grammar nodes) |
| `tree-sitter-z33/grammar.js` | the `DIRECTIVES` / `REGISTERS` arrays (mnemonics lex as identifiers there) |

Files are located via `env!("CARGO_MANIFEST_DIR")` + `../..`. `z33-emulator` is `publish = false`, so a workspace-run test reading sibling repo files is fine.

## Proof the guard bites

Reverting the Monaco fix (`%sr` removed) makes the new test fail:

```
editors/web/app/monaco.ts is missing keyword `sr` — it drifted from the
Rust enums; update the highlighting file to match crates/emulator
```

## Verification

- `cargo test -p z33-emulator` — 190+ tests pass, including the 4 new sync tests; confirmed the monaco test FAILS when the fix is reverted, then re-applied.
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets` — clean.
- `cd editors/web && pnpm run check` — passes (only pre-existing warnings unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)