### PR TITLE
Set up Storybook and decouple UI components from business logic

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -155,6 +155,30 @@ jobs:
             editors/web/test-results/
           retention-days: 7
 
+  storybook:
+    name: "Storybook tests"
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: editors/web
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node and pnpm
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Install dependencies
+        run: pnpm i
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run Storybook tests
+        run: pnpm run test-storybook
+
   tree-sitter:
     name: Tree-sitter grammar
     runs-on: ubuntu-24.04

--- a/editors/web/.gitignore
+++ b/editors/web/.gitignore
@@ -3,3 +3,4 @@
 /node_modules/
 /test-results/
 /playwright-report/
+/storybook-static/

--- a/editors/web/.storybook/main.ts
+++ b/editors/web/.storybook/main.ts
@@ -1,0 +1,11 @@
+import { defineMain } from "@storybook/react-vite/node";
+
+export default defineMain({
+  stories: ["../app/**/*.stories.@(ts|tsx)"],
+  addons: [
+    "@storybook/addon-a11y",
+    "@storybook/addon-themes",
+    "@storybook/addon-vitest",
+  ],
+  framework: "@storybook/react-vite",
+});

--- a/editors/web/.storybook/preview.tsx
+++ b/editors/web/.storybook/preview.tsx
@@ -2,17 +2,70 @@ import addonA11y from "@storybook/addon-a11y";
 import addonThemes, { withThemeByClassName } from "@storybook/addon-themes";
 import addonVitest from "@storybook/addon-vitest";
 import { definePreview } from "@storybook/react-vite";
+import { useEffect } from "react";
+import { useGlobals } from "storybook/preview-api";
 
 import { TooltipProvider } from "../app/components/ui/tooltip";
+import {
+  type DisplayFormat,
+  useDisplayStore,
+} from "../app/stores/display-store";
 import "../app/globals.css";
 
 export default definePreview({
   addons: [addonA11y(), addonThemes(), addonVitest()],
+  globalTypes: {
+    displayFormat: {
+      description: "Number display format for memory & registers",
+      toolbar: {
+        title: "Format",
+        icon: "hash",
+        items: [
+          { value: "decimal", title: "Decimal" },
+          { value: "hex", title: "Hexadecimal" },
+          { value: "binary", title: "Binary" },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  initialGlobals: {
+    displayFormat: "decimal",
+  },
   decorators: [
     withThemeByClassName({
       themes: { light: "", dark: "dark" },
       defaultTheme: "light",
     }),
+    // Syncs the `displayFormat` toolbar global into the real zustand display
+    // store, which leaf components (memory viewer, register panel, …) subscribe
+    // to directly. Two-way: the toolbar drives the store, and an in-story
+    // FormatSwitcher (which writes the store) mirrors back into the toolbar.
+    // Both directions run in effects and are gated on inequality, so they
+    // converge without a render loop. Mounting each story with the global's
+    // value also resets the shared store, keeping stories deterministic.
+    (Story) => {
+      const [globals, updateGlobals] = useGlobals();
+      const format = (globals["displayFormat"] as DisplayFormat) ?? "decimal";
+
+      // Toolbar global -> store.
+      useEffect(() => {
+        if (useDisplayStore.getState().format !== format) {
+          useDisplayStore.setState({ format });
+        }
+      }, [format]);
+
+      // Store -> toolbar global (e.g. an in-story FormatSwitcher).
+      useEffect(
+        () =>
+          useDisplayStore.subscribe((state) => {
+            updateGlobals({ displayFormat: state.format });
+          }),
+        [updateGlobals],
+      );
+
+      return <Story />;
+    },
     (Story) => (
       <TooltipProvider delay={0}>
         <Story />
@@ -23,7 +76,10 @@ export default definePreview({
     layout: "centered",
     a11y: {
       // "todo" surfaces a11y violations in the UI without failing the test run.
-      // Flip to "error" once the primitives are audited.
+      // Promotion to "error" is blocked on app-wide color-contrast issues in the
+      // design tokens (muted-foreground text ~4.34:1, default badge ~3.76:1),
+      // which also trip the pre-existing UI stories — an app/theme refactor, not
+      // a story-level fix. Flip to "error" once those tokens are audited.
       test: "todo",
     },
   },

--- a/editors/web/.storybook/preview.tsx
+++ b/editors/web/.storybook/preview.tsx
@@ -1,0 +1,31 @@
+import addonA11y from "@storybook/addon-a11y";
+import addonThemes, { withThemeByClassName } from "@storybook/addon-themes";
+import addonVitest from "@storybook/addon-vitest";
+import { definePreview } from "@storybook/react-vite";
+
+import { TooltipProvider } from "../app/components/ui/tooltip";
+import "../app/globals.css";
+
+export default definePreview({
+  addons: [addonA11y(), addonThemes(), addonVitest()],
+  decorators: [
+    withThemeByClassName({
+      themes: { light: "", dark: "dark" },
+      defaultTheme: "light",
+    }),
+    (Story) => (
+      <TooltipProvider delay={0}>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
+  parameters: {
+    layout: "centered",
+    a11y: {
+      // "todo" surfaces a11y violations in the UI without failing the test run.
+      // Flip to "error" once the primitives are audited.
+      test: "todo",
+    },
+  },
+  tags: ["autodocs"],
+});

--- a/editors/web/app/components/error-boundary.stories.tsx
+++ b/editors/web/app/components/error-boundary.stories.tsx
@@ -1,0 +1,56 @@
+import preview from "#.storybook/preview";
+import { expect, within } from "storybook/test";
+
+import { ErrorBoundary } from "./error-boundary";
+
+const meta = preview.meta({
+  title: "Organisms/ErrorBoundary",
+  component: ErrorBoundary,
+});
+
+/** A component that throws on render, to trip the boundary. */
+const Boom: React.FC = () => {
+  throw new Error("kaboom");
+};
+
+export const StaticFallback = meta.story({
+  render: () => (
+    <ErrorBoundary
+      fallback={
+        <div className="rounded border border-destructive px-3 py-2 text-sm text-destructive">
+          Something broke.
+        </div>
+      }
+    >
+      <Boom />
+    </ErrorBoundary>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Something broke.")).toBeInTheDocument();
+  },
+});
+
+export const RenderPropFallback = meta.story({
+  render: () => (
+    <ErrorBoundary
+      fallback={(error, reset) => (
+        <div className="flex flex-col items-start gap-2 rounded border px-3 py-2 text-sm">
+          <span className="text-destructive">Crashed: {error.message}</span>
+          <button type="button" className="underline" onClick={reset}>
+            Try again
+          </button>
+        </div>
+      )}
+    >
+      <Boom />
+    </ErrorBoundary>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Crashed: kaboom")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("button", { name: "Try again" }),
+    ).toBeInTheDocument();
+  },
+});

--- a/editors/web/app/components/error-boundary.tsx
+++ b/editors/web/app/components/error-boundary.tsx
@@ -1,0 +1,46 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+  /** Static node, or a render function given the error and a reset callback. */
+  fallback: ReactNode | ((error: Error, reset: () => void) => ReactNode);
+};
+
+type ErrorBoundaryState = {
+  error: Error | null;
+};
+
+/**
+ * Hand-rolled error boundary: catches render/lifecycle errors in its subtree
+ * and shows `fallback` instead of unmounting the whole app. `reset()` clears
+ * the caught error so the subtree can re-render (e.g. after the user acts).
+ */
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  override state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error("[error-boundary]", error, info.componentStack);
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  override render(): ReactNode {
+    const { error } = this.state;
+    const { children, fallback } = this.props;
+    if (error !== null) {
+      return typeof fallback === "function"
+        ? fallback(error, this.reset)
+        : fallback;
+    }
+    return children;
+  }
+}

--- a/editors/web/app/components/ui/alert-dialog.stories.tsx
+++ b/editors/web/app/components/ui/alert-dialog.stories.tsx
@@ -1,0 +1,67 @@
+import preview from "#.storybook/preview";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "./alert-dialog";
+import { Button } from "./button";
+
+const meta = preview.meta({
+  title: "UI/AlertDialog",
+  component: AlertDialog,
+});
+
+const Example = () => (
+  <AlertDialog>
+    <AlertDialogTrigger
+      render={<Button variant="destructive">Delete project</Button>}
+    />
+    <AlertDialogContent>
+      <AlertDialogHeader>
+        <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+        <AlertDialogDescription>
+          This permanently deletes the project and everything in it. This action
+          cannot be undone.
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel>Cancel</AlertDialogCancel>
+        <AlertDialogAction variant="destructive">Delete</AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+);
+
+export const Default = meta.story({
+  render: () => <Example />,
+});
+
+export const OpenAndCancel = meta.story({
+  render: () => <Example />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Delete project" }),
+    );
+    // base-ui renders the dialog in a portal on document.body.
+    const dialog = await screen.findByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    await expect(
+      within(dialog).getByText("Are you absolutely sure?"),
+    ).toBeVisible();
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Cancel" }),
+    );
+    await waitFor(() =>
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument(),
+    );
+  },
+});

--- a/editors/web/app/components/ui/badge.stories.tsx
+++ b/editors/web/app/components/ui/badge.stories.tsx
@@ -1,0 +1,66 @@
+import preview from "#.storybook/preview";
+import { CheckIcon } from "lucide-react";
+
+import { Badge } from "./badge";
+
+const meta = preview.meta({
+  title: "UI/Badge",
+  component: Badge,
+  argTypes: {
+    variant: {
+      control: "select",
+      options: [
+        "default",
+        "secondary",
+        "destructive",
+        "outline",
+        "ghost",
+        "link",
+      ],
+    },
+  },
+  args: {
+    children: "Badge",
+    variant: "default",
+  },
+});
+
+export const Default = meta.story({});
+
+export const Secondary = meta.story({ args: { variant: "secondary" } });
+
+export const Destructive = meta.story({ args: { variant: "destructive" } });
+
+export const Outline = meta.story({ args: { variant: "outline" } });
+
+export const WithIcon = meta.story({
+  args: {
+    children: (
+      <>
+        <CheckIcon data-icon="inline-start" />
+        Passed
+      </>
+    ),
+  },
+});
+
+const VARIANTS = [
+  "default",
+  "secondary",
+  "destructive",
+  "outline",
+  "ghost",
+  "link",
+] as const;
+
+export const VariantGrid = meta.story({
+  render: () => (
+    <div className="flex flex-wrap items-center gap-2">
+      {VARIANTS.map((variant) => (
+        <Badge key={variant} variant={variant}>
+          {variant}
+        </Badge>
+      ))}
+    </div>
+  ),
+});

--- a/editors/web/app/components/ui/button.stories.tsx
+++ b/editors/web/app/components/ui/button.stories.tsx
@@ -1,0 +1,99 @@
+import preview from "#.storybook/preview";
+import { ArrowRightIcon, PlusIcon } from "lucide-react";
+
+import { Button } from "./button";
+
+const meta = preview.meta({
+  title: "UI/Button",
+  component: Button,
+  argTypes: {
+    variant: {
+      control: "select",
+      options: [
+        "default",
+        "outline",
+        "secondary",
+        "ghost",
+        "destructive",
+        "link",
+      ],
+    },
+    size: {
+      control: "select",
+      options: ["default", "xs", "sm", "lg", "icon"],
+    },
+    disabled: { control: "boolean" },
+  },
+  args: {
+    children: "Button",
+    variant: "default",
+    size: "default",
+    disabled: false,
+  },
+});
+
+export const Default = meta.story({});
+
+export const Secondary = meta.story({
+  args: { variant: "secondary" },
+});
+
+export const Destructive = meta.story({
+  args: { variant: "destructive" },
+});
+
+export const Disabled = meta.story({
+  args: { disabled: true },
+});
+
+export const WithIcon = meta.story({
+  args: {
+    children: (
+      <>
+        <PlusIcon data-icon="inline-start" />
+        Add file
+      </>
+    ),
+  },
+});
+
+const VARIANTS = [
+  "default",
+  "outline",
+  "secondary",
+  "ghost",
+  "destructive",
+  "link",
+] as const;
+
+const SIZES = ["xs", "sm", "default", "lg"] as const;
+
+export const VariantGrid = meta.story({
+  render: () => (
+    <div className="flex flex-col gap-3">
+      {VARIANTS.map((variant) => (
+        <div key={variant} className="flex items-center gap-2">
+          <Button variant={variant}>{variant}</Button>
+          <Button variant={variant} disabled>
+            disabled
+          </Button>
+          <Button variant={variant} size="icon" aria-label={`${variant} icon`}>
+            <ArrowRightIcon />
+          </Button>
+        </div>
+      ))}
+    </div>
+  ),
+});
+
+export const SizeGrid = meta.story({
+  render: () => (
+    <div className="flex items-center gap-2">
+      {SIZES.map((size) => (
+        <Button key={size} size={size}>
+          {size}
+        </Button>
+      ))}
+    </div>
+  ),
+});

--- a/editors/web/app/components/ui/select.stories.tsx
+++ b/editors/web/app/components/ui/select.stories.tsx
@@ -1,0 +1,84 @@
+import preview from "#.storybook/preview";
+import { useState } from "react";
+import { expect, screen, userEvent, within } from "storybook/test";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./select";
+
+const FRUITS = ["Apple", "Banana", "Cherry", "Elderberry"];
+
+const meta = preview.meta({
+  title: "UI/Select",
+  component: Select,
+});
+
+export const Default = meta.story({
+  render: () => (
+    <Select defaultValue="Apple">
+      <SelectTrigger className="w-48">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {FRUITS.map((fruit) => (
+          <SelectItem key={fruit} value={fruit}>
+            {fruit}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  ),
+});
+
+export const Placeholder = meta.story({
+  render: () => (
+    <Select>
+      <SelectTrigger className="w-48">
+        <SelectValue placeholder="Pick a fruit…" />
+      </SelectTrigger>
+      <SelectContent>
+        {FRUITS.map((fruit) => (
+          <SelectItem key={fruit} value={fruit}>
+            {fruit}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  ),
+});
+
+export const SelectsAnItem = meta.story({
+  render: () => {
+    const ControlledSelect = () => {
+      const [value, setValue] = useState<string | null>(null);
+      return (
+        <Select value={value} onValueChange={setValue}>
+          <SelectTrigger className="w-48">
+            <SelectValue placeholder="Pick a fruit…" />
+          </SelectTrigger>
+          <SelectContent>
+            {FRUITS.map((fruit) => (
+              <SelectItem key={fruit} value={fruit}>
+                {fruit}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      );
+    };
+    return <ControlledSelect />;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole("combobox");
+    await userEvent.click(trigger);
+    // base-ui renders the listbox in a portal on document.body.
+    const option = await screen.findByRole("option", { name: "Banana" });
+    await userEvent.click(option);
+    await expect(trigger).toHaveTextContent("Banana");
+  },
+});

--- a/editors/web/app/components/ui/toggle-group.stories.tsx
+++ b/editors/web/app/components/ui/toggle-group.stories.tsx
@@ -1,0 +1,80 @@
+import preview from "#.storybook/preview";
+import { useState } from "react";
+import {
+  AlignCenterIcon,
+  AlignLeftIcon,
+  AlignRightIcon,
+  BoldIcon,
+  ItalicIcon,
+  UnderlineIcon,
+} from "lucide-react";
+
+import { ToggleGroup, ToggleGroupItem } from "./toggle-group";
+
+const meta = preview.meta({
+  title: "UI/ToggleGroup",
+  component: ToggleGroup,
+});
+
+const SingleSelectionDemo = () => {
+  const [value, setValue] = useState<string[]>(["left"]);
+  return (
+    <ToggleGroup value={value} onValueChange={setValue} variant="outline">
+      <ToggleGroupItem value="left" aria-label="Align left">
+        <AlignLeftIcon />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="center" aria-label="Align center">
+        <AlignCenterIcon />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="right" aria-label="Align right">
+        <AlignRightIcon />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  );
+};
+
+const MultipleSelectionDemo = () => {
+  const [value, setValue] = useState<string[]>(["bold"]);
+  return (
+    <ToggleGroup
+      multiple
+      value={value}
+      onValueChange={setValue}
+      variant="outline"
+    >
+      <ToggleGroupItem value="bold" aria-label="Bold">
+        <BoldIcon />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="italic" aria-label="Italic">
+        <ItalicIcon />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="underline" aria-label="Underline">
+        <UnderlineIcon />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  );
+};
+
+export const SingleSelection = meta.story({
+  render: () => <SingleSelectionDemo />,
+});
+
+export const MultipleSelection = meta.story({
+  render: () => <MultipleSelectionDemo />,
+});
+
+export const Spaced = meta.story({
+  render: () => (
+    <ToggleGroup defaultValue={["center"]} spacing={4} variant="outline">
+      <ToggleGroupItem value="left" aria-label="Align left">
+        <AlignLeftIcon />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="center" aria-label="Align center">
+        <AlignCenterIcon />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="right" aria-label="Align right">
+        <AlignRightIcon />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  ),
+});

--- a/editors/web/app/components/ui/toggle.stories.tsx
+++ b/editors/web/app/components/ui/toggle.stories.tsx
@@ -1,0 +1,64 @@
+import preview from "#.storybook/preview";
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle";
+import { type VariantProps } from "class-variance-authority";
+import { BoldIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import { toggleVariants } from "./toggle";
+
+// `toggle.tsx` only ships the `toggleVariants` cva helper (the app styles
+// base-ui's Toggle/ToggleGroupItem with it). This thin wrapper mirrors that
+// usage so the variants can be showcased on their own.
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive
+      className={cn(toggleVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+}
+
+const meta = preview.meta({
+  title: "UI/Toggle",
+  component: Toggle,
+  argTypes: {
+    variant: { control: "select", options: ["default", "outline"] },
+    size: { control: "select", options: ["default", "xs", "sm", "lg"] },
+    disabled: { control: "boolean" },
+  },
+  args: {
+    variant: "default",
+    size: "default",
+    disabled: false,
+    "aria-label": "Bold",
+    children: <BoldIcon />,
+  },
+});
+
+export const Default = meta.story({});
+
+export const Outline = meta.story({ args: { variant: "outline" } });
+
+export const Pressed = meta.story({ args: { defaultPressed: true } });
+
+export const Disabled = meta.story({ args: { disabled: true } });
+
+const SIZES = ["xs", "sm", "default", "lg"] as const;
+
+export const SizeGrid = meta.story({
+  render: () => (
+    <div className="flex items-center gap-2">
+      {SIZES.map((size) => (
+        <Toggle key={size} size={size} variant="outline" aria-label={size}>
+          <BoldIcon />
+        </Toggle>
+      ))}
+    </div>
+  ),
+});

--- a/editors/web/app/components/ui/tooltip.stories.tsx
+++ b/editors/web/app/components/ui/tooltip.stories.tsx
@@ -1,0 +1,37 @@
+import preview from "#.storybook/preview";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
+
+import { Button } from "./button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
+
+const meta = preview.meta({
+  title: "UI/Tooltip",
+  component: Tooltip,
+});
+
+export const Default = meta.story({
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger render={<Button variant="outline">Hover me</Button>} />
+      <TooltipContent>Add to library</TooltipContent>
+    </Tooltip>
+  ),
+});
+
+export const ShowsOnHover = meta.story({
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger render={<Button variant="outline">Hover me</Button>} />
+      <TooltipContent>Add to library</TooltipContent>
+    </Tooltip>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole("button", { name: "Hover me" });
+    await userEvent.hover(trigger);
+    // base-ui renders the tooltip popup in a portal on document.body, and it
+    // stays hidden until the open animation has positioned it.
+    const tooltip = await screen.findByText("Add to library");
+    await waitFor(() => expect(tooltip).toBeVisible());
+  },
+});

--- a/editors/web/app/computer-types.ts
+++ b/editors/web/app/computer-types.ts
@@ -1,8 +1,14 @@
 import type { Cell, Cycles, Registers } from "./lib/wasm";
+import type { RunStatus } from "./lib/emulator-protocol";
 import type { DisplayFormat } from "./stores/display-store";
 import { assertNever } from "./lib/utils";
 
+/** Single import point for the execution state enum used across the UI. */
+export type { RunStatus };
+
 export type Labels = Map<number, string[]>;
+
+type Unsubscribe = () => void;
 
 /** Narrow type for actual CPU registers */
 export type RegisterId = "%pc" | "%sp" | "%a" | "%b";
@@ -26,6 +32,30 @@ export interface ComputerInterface {
   subscribe_memory(address: number, cb: (c: Cell) => void): () => void;
   subscribe_cycles(cb: (c: Cycles) => void): () => void;
   readonly labels: Iterable<[string, number]>;
+}
+
+/**
+ * Execution controls used by the step runner and debug toolbar. Implemented by
+ * the concrete `ComputerProxy`; typed as an interface here so UI props and test
+ * fakes can stand in for it (`ComputerProxy` has `#private` fields, making it a
+ * nominal type that a plain object could never satisfy).
+ */
+export interface ExecutionControls {
+  step(n?: number): void;
+  run(): void;
+  pause(): void;
+  setSpeed(speed: number | null): void;
+  getStatus(): RunStatus;
+  getError(): string | null;
+  subscribeStatus(cb: (s: RunStatus) => void): Unsubscribe;
+}
+
+/** Serial-console I/O surface (ports 110-111), as seen by the terminal UI. */
+export interface SerialPort {
+  /** Subscribe to serial output; fires with each non-empty byte batch. */
+  onOutput(cb: (bytes: number[]) => void): Unsubscribe;
+  /** Send receive bytes to the serial console; one IRQ edge per call. */
+  sendInput(bytes: number[]): void;
 }
 
 export const REGISTER_COLORS: Record<RegisterId, string> = {

--- a/editors/web/app/computer.stories.tsx
+++ b/editors/web/app/computer.stories.tsx
@@ -1,0 +1,80 @@
+import preview from "#.storybook/preview";
+import { expect, within } from "storybook/test";
+
+import { MemoryViewer } from "./computer";
+import type { Pointers } from "./computer-types";
+import { emptyScene, factorialScene, sceneLabels } from "./testing/fixtures";
+import { FakeComputer } from "./testing/fake-computer";
+
+const meta = preview.meta({
+  title: "Organisms/MemoryViewer",
+  component: MemoryViewer,
+  parameters: { layout: "padded" },
+  // The virtualizer only renders rows when its scroll parent has a real height.
+  // Without this fixed-height flex column it would render zero rows.
+  decorators: [
+    (Story) => (
+      <div className="flex h-96 w-80 flex-col overflow-hidden rounded-md border">
+        <Story />
+      </div>
+    ),
+  ],
+});
+
+export const AtProgramStart = meta.story({
+  render: () => {
+    const scene = factorialScene();
+    return (
+      <MemoryViewer
+        computer={new FakeComputer(scene)}
+        highlight={1000}
+        labels={sceneLabels(scene)}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Rows must actually render — assert a known instruction cell is visible.
+    await expect(await canvas.findByText("push 5")).toBeInTheDocument();
+    await expect(await canvas.findByText("main")).toBeInTheDocument();
+  },
+});
+
+export const WithLabelsAndPointers = meta.story({
+  render: () => {
+    const scene = factorialScene();
+    const pointers: Pointers = new Map([
+      [1007, ["%pc"]],
+      [1012, ["%sp"]],
+    ]);
+    return (
+      <MemoryViewer
+        computer={new FakeComputer(scene)}
+        highlight={1000}
+        labels={sceneLabels(scene)}
+        pointers={pointers}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("loop")).toBeInTheDocument();
+    await expect(await canvas.findByText("%pc")).toBeInTheDocument();
+  },
+});
+
+export const EmptyMemory = meta.story({
+  render: () => (
+    <MemoryViewer
+      computer={new FakeComputer(emptyScene())}
+      highlight={null}
+      labels={new Map()}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Empty cells render as a muted zero word.
+    const zeros = await canvas.findAllByText("00000000");
+    await expect(zeros.length).toBeGreaterThan(0);
+  },
+});

--- a/editors/web/app/computer.tsx
+++ b/editors/web/app/computer.tsx
@@ -22,8 +22,8 @@ import {
   formatWord,
 } from "./computer-types";
 import { useMemoryCell } from "./hooks/use-computer";
-import { cn } from "./lib/utils";
 import { useDisplayStore } from "./stores/display-store";
+import { cn } from "./lib/utils";
 
 const MEMORY_SIZE = 10_000;
 const ROW_HEIGHT = 28;

--- a/editors/web/app/debug-layout.tsx
+++ b/editors/web/app/debug-layout.tsx
@@ -1,8 +1,10 @@
 import type * as monaco from "monaco-editor";
 import { useCallback, useState } from "react";
+import { ErrorBoundary } from "./components/error-boundary";
 import type { Following, Labels } from "./computer-types";
 import type { ComputerProxy } from "./lib/computer-proxy";
 import { RegisterPanel } from "./debug-sidebar";
+import { SectionHeader } from "./section-header";
 import { DebugToolbar } from "./debug-toolbar";
 import { useBreakpointSync } from "./hooks/use-breakpoints";
 import { useSourceHighlight } from "./hooks/use-source-highlight";
@@ -18,6 +20,16 @@ import { Group, Panel } from "react-resizable-panels";
 type DebugLayoutProps = {
   onEditorMount: (editor: monaco.editor.IStandaloneCodeEditor) => void;
 };
+
+/** Small inline fallback so one crashing panel doesn't blank the debugger. */
+const PanelError: React.FC<{ label: string }> = ({ label }) => (
+  <div className="flex h-full flex-col border-l">
+    <SectionHeader>Error</SectionHeader>
+    <div className="flex flex-1 items-center justify-center p-4 text-center text-xs text-muted-foreground">
+      The {label} crashed.
+    </div>
+  </div>
+);
 
 /** Outer shell: reads mode from store and passes concrete values to DebugLayoutInner */
 export const DebugLayout: React.FC<DebugLayoutProps> = ({ onEditorMount }) => {
@@ -104,30 +116,34 @@ const DebugLayoutInner: React.FC<DebugLayoutInnerProps> = ({
             </Panel>
             <ResizeHandle />
             <Panel defaultSize="35%" minSize="20%" maxSize="50%" id="z33-right">
-              <div className="flex flex-col h-full border-l">
-                <div className="shrink-0 border-b">
-                  <RegisterPanel
-                    computer={computer}
-                    labels={labels}
-                    following={following}
-                    onFollow={setFollowing}
-                  />
+              <ErrorBoundary fallback={<PanelError label="registers panel" />}>
+                <div className="flex flex-col h-full border-l">
+                  <div className="shrink-0 border-b">
+                    <RegisterPanel
+                      computer={computer}
+                      labels={labels}
+                      following={following}
+                      onFollow={setFollowing}
+                    />
+                  </div>
+                  <div className="flex-1 min-h-0">
+                    <MemoryPanel
+                      computer={computer}
+                      labels={labels}
+                      following={following}
+                      onFollow={setFollowing}
+                    />
+                  </div>
                 </div>
-                <div className="flex-1 min-h-0">
-                  <MemoryPanel
-                    computer={computer}
-                    labels={labels}
-                    following={following}
-                    onFollow={setFollowing}
-                  />
-                </div>
-              </div>
+              </ErrorBoundary>
             </Panel>
           </Group>
         </Panel>
         <ResizeHandle orientation="vertical" />
         <Panel defaultSize="25%" minSize="10%" collapsible id="z33-console">
-          <SerialConsole computer={computer} />
+          <ErrorBoundary fallback={<PanelError label="serial console" />}>
+            <SerialConsole computer={computer} />
+          </ErrorBoundary>
         </Panel>
       </Group>
     </div>

--- a/editors/web/app/debug-sidebar.stories.tsx
+++ b/editors/web/app/debug-sidebar.stories.tsx
@@ -1,0 +1,55 @@
+import preview from "#.storybook/preview";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { RegisterPanel } from "./debug-sidebar";
+import { factorialScene, haltedScene, sceneLabels } from "./testing/fixtures";
+import { FakeComputer } from "./testing/fake-computer";
+
+const running = factorialScene();
+const halted = haltedScene();
+const followingSp = factorialScene();
+
+const meta = preview.meta({
+  title: "Organisms/RegisterPanel",
+  component: RegisterPanel,
+  args: {
+    following: null,
+    onFollow: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-72 rounded-md border">
+        <Story />
+      </div>
+    ),
+  ],
+});
+
+export const Running = meta.story({
+  args: {
+    computer: new FakeComputer(running),
+    labels: sceneLabels(running),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    // %a holds 120 in the factorial scene — assert the value actually renders.
+    await expect(canvas.getByText("120")).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole("button", { name: "Register %a" }));
+    await expect(args.onFollow).toHaveBeenCalledWith("%a");
+  },
+});
+
+export const Halted = meta.story({
+  args: {
+    computer: new FakeComputer(halted),
+    labels: sceneLabels(halted),
+  },
+});
+
+export const FollowingSp = meta.story({
+  args: {
+    computer: new FakeComputer(followingSp),
+    labels: sceneLabels(followingSp),
+    following: "%sp",
+  },
+});

--- a/editors/web/app/debug-toolbar.stories.tsx
+++ b/editors/web/app/debug-toolbar.stories.tsx
@@ -1,0 +1,93 @@
+import preview from "#.storybook/preview";
+import { expect, userEvent, fn, within } from "storybook/test";
+
+import { DebugToolbarInner } from "./debug-toolbar";
+import { factorialScene, haltedScene, panickedScene } from "./testing/fixtures";
+import { FakeComputer } from "./testing/fake-computer";
+
+// A dedicated instance per story keeps the recorded `calls` isolated between
+// vitest test cases (a shared instance would leak state across stories).
+const idleComputer = new FakeComputer(factorialScene());
+
+const meta = preview.meta({
+  title: "Organisms/DebugToolbar",
+  component: DebugToolbarInner,
+  parameters: { layout: "padded" },
+  args: {
+    touchedFiles: ["main.s"],
+    activeFile: "main.s",
+    onFileChange: fn(),
+    onStop: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[48rem] rounded-md border">
+        <Story />
+      </div>
+    ),
+  ],
+});
+
+export const Idle = meta.story({
+  args: { computer: idleComputer },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole("button", { name: /Step/u }));
+    await expect(idleComputer.calls.some((c) => c.method === "step")).toBe(
+      true,
+    );
+
+    await userEvent.click(canvas.getByRole("button", { name: /Run/u }));
+    await expect(idleComputer.getStatus()).toBe("running");
+    // Once running, the Run control flips to Pause.
+    await expect(
+      await canvas.findByRole("button", { name: /Pause/u }),
+    ).toBeInTheDocument();
+  },
+});
+
+export const Running = meta.story({
+  args: {
+    computer: new FakeComputer({ ...factorialScene(), status: "running" }),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("button", { name: /Pause/u }),
+    ).toBeInTheDocument();
+  },
+});
+
+export const Halted = meta.story({
+  args: { computer: new FakeComputer(haltedScene()) },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("alert")).toHaveTextContent("Halted");
+  },
+});
+
+export const Panicked = meta.story({
+  args: {
+    computer: new FakeComputer(panickedScene("division by zero")),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("alert")).toHaveTextContent(
+      "Panicked: division by zero",
+    );
+  },
+});
+
+export const MultiFile = meta.story({
+  args: {
+    computer: new FakeComputer(factorialScene()),
+    touchedFiles: ["main.s", "lib.s"],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The file switcher only appears with more than one touched file: two
+    // comboboxes then exist (clock speed + file), versus one otherwise.
+    await expect(canvas.getAllByRole("combobox")).toHaveLength(2);
+  },
+});

--- a/editors/web/app/debug-toolbar.tsx
+++ b/editors/web/app/debug-toolbar.tsx
@@ -20,7 +20,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "./components/ui/tooltip";
-import type { ComputerProxy } from "./lib/computer-proxy";
+import type { ComputerInterface, ExecutionControls } from "./computer-types";
 import { DocsButton } from "./docs-button";
 import { useCycles } from "./hooks/use-computer";
 import { useStepRunner } from "./hooks/use-step-runner";
@@ -66,7 +66,7 @@ export const DebugToolbar: React.FC<DebugToolbarProps> = memo(
 DebugToolbar.displayName = "DebugToolbar";
 
 const DebugToolbarInner: React.FC<{
-  computer: ComputerProxy;
+  computer: ComputerInterface & ExecutionControls;
   touchedFiles: string[];
   activeFile: string;
   onFileChange: (name: string) => void;

--- a/editors/web/app/debug-toolbar.tsx
+++ b/editors/web/app/debug-toolbar.tsx
@@ -65,7 +65,7 @@ export const DebugToolbar: React.FC<DebugToolbarProps> = memo(
 );
 DebugToolbar.displayName = "DebugToolbar";
 
-const DebugToolbarInner: React.FC<{
+export const DebugToolbarInner: React.FC<{
   computer: ComputerInterface & ExecutionControls;
   touchedFiles: string[];
   activeFile: string;

--- a/editors/web/app/docs-button.stories.tsx
+++ b/editors/web/app/docs-button.stories.tsx
@@ -1,0 +1,10 @@
+import preview from "#.storybook/preview";
+
+import { DocsButton } from "./docs-button";
+
+const meta = preview.meta({
+  title: "UI/DocsButton",
+  component: DocsButton,
+});
+
+export const Default = meta.story({});

--- a/editors/web/app/edit-toolbar.stories.tsx
+++ b/editors/web/app/edit-toolbar.stories.tsx
@@ -1,0 +1,82 @@
+import preview from "#.storybook/preview";
+import { expect, fn, screen, userEvent, within } from "storybook/test";
+
+import { EditToolbar, pickEntrypoint } from "./edit-toolbar";
+
+const meta = preview.meta({
+  title: "Organisms/EditToolbar",
+  component: EditToolbar,
+  parameters: { layout: "padded" },
+  args: {
+    onRun: fn(),
+    compilationError: undefined,
+    defaultEntrypoint: undefined,
+    labels: [],
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[42rem] rounded-md border">
+        <Story />
+      </div>
+    ),
+  ],
+});
+
+export const Idle = meta.story({
+  args: { compilationStatus: "idle" },
+});
+
+export const Pending = meta.story({
+  args: { compilationStatus: "pending" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("status", { name: "Compiling" }),
+    ).toBeInTheDocument();
+  },
+});
+
+export const CompileError = meta.story({
+  args: {
+    compilationStatus: "error",
+    compilationError: "expected a register, found `foo`",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText("expected a register, found `foo`"),
+    ).toBeInTheDocument();
+  },
+});
+
+export const Success = meta.story({
+  args: {
+    compilationStatus: "success",
+    labels: ["main", "loop", "end"],
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    // Open the entrypoint select (portal-rendered on document.body).
+    await userEvent.click(canvas.getByRole("combobox"));
+    await userEvent.click(await screen.findByRole("option", { name: "loop" }));
+    await userEvent.click(canvas.getByRole("button", { name: /Run/u }));
+    await expect(args.onRun).toHaveBeenCalledWith("loop");
+  },
+});
+
+export const DefaultEntrypoint = meta.story({
+  args: {
+    compilationStatus: "success",
+    // No "main" — pickEntrypoint falls to the next well-known name, "start".
+    labels: ["helper", "start"],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The rendered default matches pickEntrypoint's well-known-name fallback.
+    const noPreferred: string | undefined = undefined;
+    await expect(pickEntrypoint(["helper", "start"], noPreferred)).toBe(
+      "start",
+    );
+    await expect(canvas.getByRole("combobox")).toHaveTextContent("start");
+  },
+});

--- a/editors/web/app/edit-toolbar.tsx
+++ b/editors/web/app/edit-toolbar.tsx
@@ -4,7 +4,7 @@ import {
   PlayIcon,
   XCircleIcon,
 } from "lucide-react";
-import { memo, useEffect, useState } from "react";
+import { memo } from "react";
 import { Button } from "./components/ui/button";
 import {
   Select,
@@ -17,6 +17,22 @@ import { DocsButton } from "./docs-button";
 import { ThemeSwitcher } from "./theme-switcher";
 
 const DEFAULT_ENTRYPOINT_NAMES = ["main", "start", "run", "entry"];
+
+/**
+ * Choose the entrypoint to preselect: the preferred label if still present,
+ * else the first well-known entrypoint name that exists, else the first label,
+ * else the empty string.
+ */
+export function pickEntrypoint(
+  labels: string[],
+  preferred: string | undefined,
+): string {
+  if (preferred && labels.includes(preferred)) return preferred;
+  for (const candidate of DEFAULT_ENTRYPOINT_NAMES) {
+    if (labels.includes(candidate)) return candidate;
+  }
+  return labels[0] ?? "";
+}
 
 type EditToolbarProps = {
   onRun: (entrypoint: string) => void;
@@ -34,22 +50,6 @@ export const EditToolbar: React.FC<EditToolbarProps> = memo(
     labels,
     defaultEntrypoint,
   }) => {
-    const [selectedEntrypoint, setSelectedEntrypoint] = useState<string>("");
-
-    useEffect(() => {
-      if (defaultEntrypoint && labels.includes(defaultEntrypoint)) {
-        setSelectedEntrypoint(defaultEntrypoint);
-        return;
-      }
-      for (const candidate of DEFAULT_ENTRYPOINT_NAMES) {
-        if (labels.includes(candidate)) {
-          setSelectedEntrypoint(candidate);
-          return;
-        }
-      }
-      setSelectedEntrypoint(labels[0] ?? "");
-    }, [labels, defaultEntrypoint]);
-
     const canRun = compilationStatus === "success" && labels.length > 0;
 
     return (
@@ -85,13 +85,21 @@ export const EditToolbar: React.FC<EditToolbarProps> = memo(
 
         <div className="ml-auto flex items-center gap-1">
           {canRun && (
-            <>
+            // Remount on a changed label set so the uncontrolled Select picks
+            // up the fresh default entrypoint.
+            <form
+              key={labels.join(" ")}
+              className="flex items-center gap-1"
+              onSubmit={(e: React.SubmitEvent<HTMLFormElement>) => {
+                e.preventDefault();
+                const value = new FormData(e.currentTarget).get("entrypoint");
+                if (typeof value === "string" && value) onRun(value);
+              }}
+            >
               <span className="text-xs text-muted-foreground">Start at</span>
               <Select
-                value={selectedEntrypoint}
-                onValueChange={(v) => {
-                  if (v !== null) setSelectedEntrypoint(v);
-                }}
+                name="entrypoint"
+                defaultValue={pickEntrypoint(labels, defaultEntrypoint)}
               >
                 <SelectTrigger
                   size="xs"
@@ -112,18 +120,11 @@ export const EditToolbar: React.FC<EditToolbarProps> = memo(
                   ))}
                 </SelectContent>
               </Select>
-              <Button
-                type="button"
-                size="xs"
-                disabled={!selectedEntrypoint}
-                onClick={() => {
-                  if (selectedEntrypoint) onRun(selectedEntrypoint);
-                }}
-              >
+              <Button type="submit" size="xs">
                 <PlayIcon data-icon="inline-start" />
                 Run
               </Button>
-            </>
+            </form>
           )}
           <DocsButton />
           <ThemeSwitcher />

--- a/editors/web/app/file-sidebar.stories.tsx
+++ b/editors/web/app/file-sidebar.stories.tsx
@@ -1,0 +1,118 @@
+import preview from "#.storybook/preview";
+import type * as React from "react";
+import { useState } from "react";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { FileSidebarView } from "./file-sidebar";
+
+const noop = (): void => {};
+
+// Stand-ins for the `useFileDrop`-derived props. The pure view only spreads
+// them, so inert handlers and a detached ref are enough for stories.
+const dropZoneRef: React.RefObject<HTMLDivElement | null> = { current: null };
+const dropZoneProps = {
+  onDragOver: noop,
+  onDragEnter: noop,
+  onDragLeave: noop,
+  onDrop: noop,
+};
+
+const meta = preview.meta({
+  title: "Organisms/FileSidebar",
+  component: FileSidebarView,
+  parameters: { layout: "padded" },
+  args: {
+    files: [],
+    activeFile: "",
+    isCreatingFile: false,
+    isWindowDragging: false,
+    isOverDropZone: false,
+    dropZoneRef,
+    dropZoneProps,
+    onSelect: fn(),
+    onStartCreate: fn(),
+    onCreate: fn(),
+    onCancelCreate: fn(),
+    onDelete: fn(),
+    onDownload: fn(),
+    onUpload: fn(),
+    onReset: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex h-96 overflow-hidden rounded-md border">
+        <Story />
+      </div>
+    ),
+  ],
+});
+
+export const Empty = meta.story({});
+
+export const WithFiles = meta.story({
+  args: {
+    files: ["main.s", "lib.s", "util.s"],
+    activeFile: "main.s",
+  },
+  render: (args) => {
+    // Drive the create flow locally: the pure view keeps `isCreatingFile` in
+    // its parent, so a small stateful wrapper reproduces the app's behaviour.
+    const Wrapper: React.FC = () => {
+      const [creating, setCreating] = useState(false);
+      return (
+        <FileSidebarView
+          {...args}
+          isCreatingFile={creating}
+          onStartCreate={() => {
+            args.onStartCreate();
+            setCreating(true);
+          }}
+          onCancelCreate={() => {
+            args.onCancelCreate();
+            setCreating(false);
+          }}
+          onCreate={(name) => {
+            args.onCreate(name);
+            setCreating(false);
+          }}
+        />
+      );
+    };
+    return <Wrapper />;
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("lib.s")).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole("button", { name: "New file" }));
+    const input = await canvas.findByRole("textbox", { name: "File name" });
+    await userEvent.type(input, "hello.s{Enter}");
+    await expect(args.onCreate).toHaveBeenCalledWith("hello.s");
+  },
+});
+
+export const Creating = meta.story({
+  args: {
+    files: ["main.s", "lib.s"],
+    activeFile: "main.s",
+    isCreatingFile: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("textbox", { name: "File name" }),
+    ).toBeInTheDocument();
+  },
+});
+
+export const DragOver = meta.story({
+  args: {
+    files: ["main.s"],
+    activeFile: "main.s",
+    isWindowDragging: true,
+    isOverDropZone: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("Drop files here")).toBeInTheDocument();
+  },
+});

--- a/editors/web/app/file-sidebar.tsx
+++ b/editors/web/app/file-sidebar.tsx
@@ -64,47 +64,48 @@ const InlineFileInput: React.FC<{
   );
 };
 
-export const FileSidebar: React.FC = () => {
-  const files = useFileStore((s) => s.files);
-  const activeFile = useFileStore((s) => s.activeFile);
-  const setActiveFile = useFileStore((s) => s.setActiveFile);
-  const createFile = useFileStore((s) => s.createFile);
-  const deleteFile = useFileStore((s) => s.deleteFile);
-  const resetFiles = useFileStore((s) => s.resetFiles);
-  const setContent = useFileStore((s) => s.setContent);
+type FileSidebarViewProps = Pick<
+  ReturnType<typeof useFileDrop>,
+  "isWindowDragging" | "isOverDropZone" | "dropZoneRef" | "dropZoneProps"
+> & {
+  /** File names to show (already filtered to the current mode). */
+  files: string[];
+  activeFile: string;
+  isCreatingFile: boolean;
+  onSelect: (name: string) => void;
+  onStartCreate: () => void;
+  onCreate: (name: string) => void;
+  onCancelCreate: () => void;
+  onDelete: (name: string) => void;
+  onDownload: (name: string) => void;
+  onUpload: (files: readonly File[]) => void;
+  onReset: () => void;
+};
 
-  const mode = useAppStore((s) => s.mode);
-  const isDebugging = mode.type === "debug";
-
-  const [isCreatingFile, setIsCreatingFile] = useState(false);
+/**
+ * Pure presentational file sidebar: all data and actions arrive as props, so it
+ * has no store coupling and can be rendered standalone (stories/tests). The
+ * reset-confirmation dialog's open state is ephemeral UI, kept local here.
+ */
+export const FileSidebarView: React.FC<FileSidebarViewProps> = ({
+  files,
+  activeFile,
+  isCreatingFile,
+  isWindowDragging,
+  isOverDropZone,
+  dropZoneRef,
+  dropZoneProps,
+  onSelect,
+  onStartCreate,
+  onCreate,
+  onCancelCreate,
+  onDelete,
+  onDownload,
+  onUpload,
+  onReset,
+}) => {
   const uploadInputRef = useRef<HTMLInputElement>(null);
-
-  const processFiles = useCallback(
-    (fileList: readonly File[]) => {
-      for (const file of fileList) {
-        void file.text().then((text) => {
-          setContent(file.name, text);
-          setActiveFile(file.name);
-        });
-      }
-    },
-    [setContent, setActiveFile],
-  );
-
-  const { isWindowDragging, isOverDropZone, dropZoneRef, dropZoneProps } =
-    useFileDrop(processFiles);
-
-  // Filter to touched files during debug, show all during edit
-  const displayedFiles = useMemo(() => {
-    const allFiles = Object.keys(files);
-    if (mode.type !== "debug") return allFiles;
-    const touched = new Set(mode.touchedFiles);
-    return allFiles.filter((name) => touched.has(name));
-  }, [mode, files]);
-
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
-
-  if (isDebugging) return null;
 
   return (
     <div
@@ -138,9 +139,7 @@ export const FileSidebar: React.FC = () => {
                   variant="ghost"
                   size="icon-xs"
                   aria-label="New file"
-                  onClick={() => {
-                    setIsCreatingFile(true);
-                  }}
+                  onClick={onStartCreate}
                 />
               }
             >
@@ -195,7 +194,7 @@ export const FileSidebar: React.FC = () => {
                 <AlertDialogAction
                   variant="destructive"
                   onClick={() => {
-                    resetFiles();
+                    onReset();
                     setResetDialogOpen(false);
                   }}
                 >
@@ -208,7 +207,7 @@ export const FileSidebar: React.FC = () => {
       </div>
 
       <div className="flex-1 flex flex-col gap-1 overflow-auto">
-        {displayedFiles.map((name) => (
+        {files.map((name) => (
           <div
             className="group flex items-center rounded-sm hover:bg-muted/50 data-[state=selected]:bg-muted"
             key={name}
@@ -218,7 +217,7 @@ export const FileSidebar: React.FC = () => {
               type="button"
               className="flex-1 px-3 py-1.5 text-left text-sm font-mono truncate"
               onClick={() => {
-                setActiveFile(name);
+                onSelect(name);
               }}
             >
               {name}
@@ -232,17 +231,7 @@ export const FileSidebar: React.FC = () => {
                     aria-label="Download"
                     className="opacity-0 group-hover:opacity-100"
                     onClick={() => {
-                      const content = files[name];
-                      if (content === undefined) return;
-                      const blob = new Blob([content], {
-                        type: "text/plain",
-                      });
-                      const url = URL.createObjectURL(blob);
-                      const a = document.createElement("a");
-                      a.href = url;
-                      a.download = name;
-                      a.click();
-                      URL.revokeObjectURL(url);
+                      onDownload(name);
                     }}
                   />
                 }
@@ -260,7 +249,7 @@ export const FileSidebar: React.FC = () => {
                     aria-label="Delete"
                     className="opacity-0 group-hover:opacity-100 mr-1"
                     onClick={() => {
-                      deleteFile(name);
+                      onDelete(name);
                     }}
                   />
                 }
@@ -273,15 +262,7 @@ export const FileSidebar: React.FC = () => {
         ))}
 
         {isCreatingFile && (
-          <InlineFileInput
-            onSubmit={(filename) => {
-              createFile(filename, "");
-              setIsCreatingFile(false);
-            }}
-            onCancel={() => {
-              setIsCreatingFile(false);
-            }}
-          />
+          <InlineFileInput onSubmit={onCreate} onCancel={onCancelCreate} />
         )}
       </div>
 
@@ -291,10 +272,92 @@ export const FileSidebar: React.FC = () => {
         multiple
         className="sr-only"
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-          if (e.target.files) processFiles(Array.from(e.target.files));
+          if (e.target.files) onUpload(Array.from(e.target.files));
           e.target.value = "";
         }}
       />
     </div>
+  );
+};
+
+export const FileSidebar: React.FC = () => {
+  const files = useFileStore((s) => s.files);
+  const activeFile = useFileStore((s) => s.activeFile);
+  const setActiveFile = useFileStore((s) => s.setActiveFile);
+  const createFile = useFileStore((s) => s.createFile);
+  const deleteFile = useFileStore((s) => s.deleteFile);
+  const resetFiles = useFileStore((s) => s.resetFiles);
+  const setContent = useFileStore((s) => s.setContent);
+
+  const mode = useAppStore((s) => s.mode);
+  const isDebugging = mode.type === "debug";
+
+  const [isCreatingFile, setIsCreatingFile] = useState(false);
+
+  const processFiles = useCallback(
+    (fileList: readonly File[]) => {
+      for (const file of fileList) {
+        void file.text().then((text) => {
+          setContent(file.name, text);
+          setActiveFile(file.name);
+        });
+      }
+    },
+    [setContent, setActiveFile],
+  );
+
+  const { isWindowDragging, isOverDropZone, dropZoneRef, dropZoneProps } =
+    useFileDrop(processFiles);
+
+  // Filter to touched files during debug, show all during edit
+  const displayedFiles = useMemo(() => {
+    const allFiles = Object.keys(files);
+    if (mode.type !== "debug") return allFiles;
+    const touched = new Set(mode.touchedFiles);
+    return allFiles.filter((name) => touched.has(name));
+  }, [mode, files]);
+
+  const handleDownload = useCallback(
+    (name: string) => {
+      const content = files[name];
+      if (content === undefined) return;
+      const blob = new Blob([content], { type: "text/plain" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = name;
+      a.click();
+      URL.revokeObjectURL(url);
+    },
+    [files],
+  );
+
+  if (isDebugging) return null;
+
+  return (
+    <FileSidebarView
+      files={displayedFiles}
+      activeFile={activeFile}
+      isCreatingFile={isCreatingFile}
+      isWindowDragging={isWindowDragging}
+      isOverDropZone={isOverDropZone}
+      dropZoneRef={dropZoneRef}
+      dropZoneProps={dropZoneProps}
+      onSelect={setActiveFile}
+      onStartCreate={() => {
+        setIsCreatingFile(true);
+      }}
+      onCreate={(filename) => {
+        createFile(filename, "");
+        setIsCreatingFile(false);
+      }}
+      onCancelCreate={() => {
+        setIsCreatingFile(false);
+      }}
+      onDelete={deleteFile}
+      onDownload={handleDownload}
+      onUpload={processFiles}
+      onReset={resetFiles}
+    />
   );
 };

--- a/editors/web/app/format-switcher.stories.tsx
+++ b/editors/web/app/format-switcher.stories.tsx
@@ -1,0 +1,31 @@
+import preview from "#.storybook/preview";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { FormatToggle } from "./format-switcher";
+
+const meta = preview.meta({
+  title: "UI/FormatToggle",
+  component: FormatToggle,
+  args: {
+    value: "decimal" as const,
+    onValueChange: fn(),
+  },
+});
+
+export const Decimal = meta.story({});
+
+export const Hexadecimal = meta.story({
+  args: { value: "hex" },
+});
+
+export const Binary = meta.story({
+  args: { value: "binary" },
+});
+
+export const SwitchesFormat = meta.story({
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "Hexadecimal" }));
+    await expect(args.onValueChange).toHaveBeenCalledWith("hex");
+  },
+});

--- a/editors/web/app/format-switcher.tsx
+++ b/editors/web/app/format-switcher.tsx
@@ -27,33 +27,38 @@ const LABELS: Record<DisplayFormat, string> = {
   binary: "Binary",
 };
 
+/** Pure display-format toggle group; no store or context coupling. */
+export const FormatToggle: React.FC<{
+  value: DisplayFormat;
+  onValueChange: (format: DisplayFormat) => void;
+}> = ({ value, onValueChange }) => (
+  <ToggleGroup
+    value={[value]}
+    onValueChange={(values) => {
+      const next = values[0];
+      if (next && isDisplayFormat(next)) onValueChange(next);
+    }}
+    size="xs"
+    variant="outline"
+  >
+    {FORMATS.map((f) => {
+      const Icon = ICONS[f];
+      return (
+        <Tooltip key={f}>
+          <TooltipTrigger
+            render={<ToggleGroupItem value={f} aria-label={LABELS[f]} />}
+          >
+            <Icon />
+          </TooltipTrigger>
+          <TooltipContent>{LABELS[f]}</TooltipContent>
+        </Tooltip>
+      );
+    })}
+  </ToggleGroup>
+);
+
 export const FormatSwitcher: React.FC = () => {
   const format = useDisplayStore((s) => s.format);
   const setFormat = useDisplayStore((s) => s.setFormat);
-
-  return (
-    <ToggleGroup
-      value={[format]}
-      onValueChange={(values) => {
-        const value = values[0];
-        if (value && isDisplayFormat(value)) setFormat(value);
-      }}
-      size="xs"
-      variant="outline"
-    >
-      {FORMATS.map((f) => {
-        const Icon = ICONS[f];
-        return (
-          <Tooltip key={f}>
-            <TooltipTrigger
-              render={<ToggleGroupItem value={f} aria-label={LABELS[f]} />}
-            >
-              <Icon />
-            </TooltipTrigger>
-            <TooltipContent>{LABELS[f]}</TooltipContent>
-          </Tooltip>
-        );
-      })}
-    </ToggleGroup>
-  );
+  return <FormatToggle value={format} onValueChange={setFormat} />;
 };

--- a/editors/web/app/hooks/use-step-runner.ts
+++ b/editors/web/app/hooks/use-step-runner.ts
@@ -1,12 +1,12 @@
 import { useCallback, useSyncExternalStore } from "react";
-import type { ComputerProxy } from "../lib/computer-proxy";
+import type { ExecutionControls } from "../computer-types";
 
 /**
  * Drives execution through the emulator worker. Status (idle / running /
  * halted / panicked) is reflected from worker-pushed snapshots; there is no
  * main-thread stepping loop.
  */
-export function useStepRunner(computer: ComputerProxy) {
+export function useStepRunner(computer: ExecutionControls) {
   const status = useSyncExternalStore(
     useCallback((cb) => computer.subscribeStatus(cb), [computer]),
     () => computer.getStatus(),

--- a/editors/web/app/index.tsx
+++ b/editors/web/app/index.tsx
@@ -3,6 +3,8 @@ import "./monaco.ts";
 import "./stores/theme-store.ts";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { ErrorBoundary } from "./components/error-boundary";
+import { Button } from "./components/ui/button";
 import { TooltipProvider } from "./components/ui/tooltip.tsx";
 
 const rootElement = document.querySelector("#root");
@@ -11,8 +13,26 @@ if (!rootElement) {
 }
 const root = createRoot(rootElement);
 
+const FullPageError: React.FC<{ error: Error }> = ({ error }) => (
+  <div className="flex h-screen flex-col items-center justify-center gap-4 bg-background p-8 text-center">
+    <h1 className="text-lg font-semibold text-foreground">
+      Something went wrong
+    </h1>
+    <p className="max-w-md text-sm text-muted-foreground">{error.message}</p>
+    <Button
+      onClick={() => {
+        window.location.reload();
+      }}
+    >
+      Reload
+    </Button>
+  </div>
+);
+
 root.render(
-  <TooltipProvider delay={400}>
-    <App />
-  </TooltipProvider>,
+  <ErrorBoundary fallback={(error) => <FullPageError error={error} />}>
+    <TooltipProvider delay={400}>
+      <App />
+    </TooltipProvider>
+  </ErrorBoundary>,
 );

--- a/editors/web/app/lib/computer-proxy.ts
+++ b/editors/web/app/lib/computer-proxy.ts
@@ -14,7 +14,11 @@ import type {
   ResolvedBreakpoint,
   SourcePosition,
 } from "./wasm";
-import type { ComputerInterface } from "../computer-types";
+import type {
+  ComputerInterface,
+  ExecutionControls,
+  SerialPort,
+} from "../computer-types";
 import type {
   RunStatus,
   Snapshot,
@@ -178,7 +182,9 @@ export function startSession(
 
 type Unsubscribe = () => void;
 
-export class ComputerProxy implements ComputerInterface {
+export class ComputerProxy
+  implements ComputerInterface, ExecutionControls, SerialPort
+{
   readonly labels: [string, number][];
 
   #client: EmulatorWorkerClient;

--- a/editors/web/app/memory-panel.stories.tsx
+++ b/editors/web/app/memory-panel.stories.tsx
@@ -1,0 +1,48 @@
+import preview from "#.storybook/preview";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { MemoryPanel } from "./memory-panel";
+import { factorialScene, sceneLabels } from "./testing/fixtures";
+import { FakeComputer } from "./testing/fake-computer";
+
+const withLabels = factorialScene();
+const followingLabel = factorialScene();
+
+const meta = preview.meta({
+  title: "Organisms/MemoryPanel",
+  component: MemoryPanel,
+  parameters: { layout: "padded" },
+  args: {
+    following: null,
+    onFollow: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex h-[32rem] w-80 flex-col overflow-hidden rounded-md border">
+        <Story />
+      </div>
+    ),
+  ],
+});
+
+export const WithLabels = meta.story({
+  args: {
+    computer: new FakeComputer(withLabels),
+    labels: sceneLabels(withLabels),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const labels = canvas.getByRole("region", { name: "Labels" });
+    await expect(within(labels).getByText("loop")).toBeInTheDocument();
+    await userEvent.click(within(labels).getByText("main"));
+    await expect(args.onFollow).toHaveBeenCalledWith("label:main");
+  },
+});
+
+export const FollowingLabel = meta.story({
+  args: {
+    computer: new FakeComputer(followingLabel),
+    labels: sceneLabels(followingLabel),
+    following: "label:loop",
+  },
+});

--- a/editors/web/app/panel-resize-handle.stories.tsx
+++ b/editors/web/app/panel-resize-handle.stories.tsx
@@ -1,0 +1,44 @@
+import preview from "#.storybook/preview";
+import { Group, Panel } from "react-resizable-panels";
+
+import { ResizeHandle } from "./panel-resize-handle";
+
+const meta = preview.meta({
+  title: "UI/ResizeHandle",
+  component: ResizeHandle,
+  parameters: { layout: "fullscreen" },
+});
+
+const PanelBody = ({ label }: { label: string }) => (
+  <div className="flex h-full items-center justify-center bg-muted/30 text-sm text-muted-foreground">
+    {label}
+  </div>
+);
+
+export const Horizontal = meta.story({
+  render: () => (
+    <Group orientation="horizontal" id="sb-h" className="h-64 w-full border">
+      <Panel defaultSize="50%" id="sb-h-left">
+        <PanelBody label="Left" />
+      </Panel>
+      <ResizeHandle />
+      <Panel defaultSize="50%" id="sb-h-right">
+        <PanelBody label="Right" />
+      </Panel>
+    </Group>
+  ),
+});
+
+export const Vertical = meta.story({
+  render: () => (
+    <Group orientation="vertical" id="sb-v" className="h-64 w-full border">
+      <Panel defaultSize="50%" id="sb-v-top">
+        <PanelBody label="Top" />
+      </Panel>
+      <ResizeHandle orientation="vertical" />
+      <Panel defaultSize="50%" id="sb-v-bottom">
+        <PanelBody label="Bottom" />
+      </Panel>
+    </Group>
+  ),
+});

--- a/editors/web/app/section-header.stories.tsx
+++ b/editors/web/app/section-header.stories.tsx
@@ -1,0 +1,24 @@
+import preview from "#.storybook/preview";
+
+import { SectionHeader } from "./section-header";
+
+const meta = preview.meta({
+  title: "UI/SectionHeader",
+  component: SectionHeader,
+  args: {
+    children: "Registers",
+  },
+});
+
+export const Default = meta.story({});
+
+export const InPanel = meta.story({
+  render: () => (
+    <div className="w-64 overflow-hidden rounded-lg border">
+      <SectionHeader>Memory</SectionHeader>
+      <div className="p-3 text-sm text-muted-foreground">
+        Panel body content
+      </div>
+    </div>
+  ),
+});

--- a/editors/web/app/serial-console.stories.tsx
+++ b/editors/web/app/serial-console.stories.tsx
@@ -1,0 +1,45 @@
+import preview from "#.storybook/preview";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { SerialConsoleShell } from "./serial-console";
+
+const meta = preview.meta({
+  title: "Organisms/SerialConsoleShell",
+  component: SerialConsoleShell,
+  parameters: { layout: "padded" },
+  args: {
+    onClear: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex h-64 w-96 flex-col overflow-hidden rounded-md border">
+        <Story />
+      </div>
+    ),
+  ],
+});
+
+export const Default = meta.story({
+  args: {
+    children: (
+      <div className="h-full w-full rounded-sm bg-muted/40 p-2 font-mono text-xs">
+        Hello, world!
+      </div>
+    ),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Clear serial console" }),
+    );
+    await expect(args.onClear).toHaveBeenCalled();
+  },
+});
+
+export const EmptyBody = meta.story({
+  args: {
+    children: (
+      <div className="h-full w-full animate-pulse rounded-sm bg-muted/40" />
+    ),
+  },
+});

--- a/editors/web/app/serial-console.tsx
+++ b/editors/web/app/serial-console.tsx
@@ -1,12 +1,13 @@
 import { TerminalIcon, Trash2Icon } from "lucide-react";
 import { lazy, Suspense, useCallback, useRef } from "react";
+import { ErrorBoundary } from "./components/error-boundary";
 import { Button } from "./components/ui/button";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "./components/ui/tooltip";
-import type { ComputerProxy } from "./lib/computer-proxy";
+import type { SerialPort } from "./computer-types";
 import type { SerialTerminalHandle } from "./serial-terminal";
 
 // Lazy-load the xterm-backed terminal so xterm (~82 KB gzip) lands in its own
@@ -14,8 +15,45 @@ import type { SerialTerminalHandle } from "./serial-terminal";
 // panel renders.
 const SerialTerminal = lazy(() => import("./serial-terminal"));
 
+/**
+ * Pure header + layout chrome for the serial console. The terminal body is
+ * passed in as `children`, so this shell has no coupling to xterm or the
+ * emulator and can be rendered standalone (stories/tests).
+ */
+export const SerialConsoleShell: React.FC<{
+  onClear: () => void;
+  children: React.ReactNode;
+}> = ({ onClear, children }) => (
+  <div className="flex flex-col h-full border-t bg-background">
+    <div className="flex shrink-0 items-center gap-1.5 border-b px-2.5 py-1">
+      <TerminalIcon className="size-3.5 text-muted-foreground" />
+      <span className="text-xs font-medium text-muted-foreground">
+        Serial console
+      </span>
+      <div className="ml-auto">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={onClear}
+                aria-label="Clear serial console"
+              >
+                <Trash2Icon />
+              </Button>
+            }
+          />
+          <TooltipContent>Clear</TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+    <div className="flex-1 min-h-0 p-1.5">{children}</div>
+  </div>
+);
+
 type SerialConsoleProps = {
-  computer: ComputerProxy;
+  computer: SerialPort;
 };
 
 /**
@@ -34,35 +72,22 @@ export const SerialConsole: React.FC<SerialConsoleProps> = ({ computer }) => {
   }, []);
 
   return (
-    <div className="flex flex-col h-full border-t bg-background">
-      <div className="flex shrink-0 items-center gap-1.5 border-b px-2.5 py-1">
-        <TerminalIcon className="size-3.5 text-muted-foreground" />
-        <span className="text-xs font-medium text-muted-foreground">
-          Serial console
-        </span>
-        <div className="ml-auto">
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={clear}
-                  aria-label="Clear serial console"
-                >
-                  <Trash2Icon />
-                </Button>
-              }
-            />
-            <TooltipContent>Clear</TooltipContent>
-          </Tooltip>
-        </div>
-      </div>
-      <div className="flex-1 min-h-0 p-1.5">
-        <Suspense fallback={null}>
+    <SerialConsoleShell onClear={clear}>
+      <ErrorBoundary
+        fallback={
+          <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+            The serial console crashed.
+          </div>
+        }
+      >
+        <Suspense
+          fallback={
+            <div className="h-full w-full animate-pulse rounded-sm bg-muted/40" />
+          }
+        >
           <SerialTerminal computer={computer} ref={terminalRef} />
         </Suspense>
-      </div>
-    </div>
+      </ErrorBoundary>
+    </SerialConsoleShell>
   );
 };

--- a/editors/web/app/serial-terminal.tsx
+++ b/editors/web/app/serial-terminal.tsx
@@ -2,7 +2,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { type ITheme, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { useEffect, useImperativeHandle, useRef } from "react";
-import type { ComputerProxy } from "./lib/computer-proxy";
+import type { SerialPort } from "./computer-types";
 import { useThemeStore } from "./stores/theme-store";
 
 /** Imperative handle exposed to the header (clear button). */
@@ -11,7 +11,7 @@ export type SerialTerminalHandle = {
 };
 
 type SerialTerminalProps = {
-  computer: ComputerProxy;
+  computer: SerialPort;
   ref?: React.Ref<SerialTerminalHandle>;
 };
 

--- a/editors/web/app/testing/fake-computer.ts
+++ b/editors/web/app/testing/fake-computer.ts
@@ -1,0 +1,200 @@
+// In-memory stand-in for `ComputerProxy`, for stories and tests. It mirrors the
+// proxy's reactive contract exactly — per-address memory subscribers and
+// snapshot getters that return **stable references** between changes, which
+// `useSyncExternalStore` relies on to avoid infinite re-render loops. It never
+// touches the wasm: only `import type` from the generated bindings.
+import type { Cell, Registers } from "../lib/wasm";
+import type {
+  ComputerInterface,
+  ExecutionControls,
+  RunStatus,
+  SerialPort,
+} from "../computer-types";
+
+type Unsubscribe = () => void;
+
+/** Shared empty-cell reference, matching `ComputerProxy`'s `EMPTY_CELL`. */
+const EMPTY_CELL: Cell = { type: "empty" };
+
+const DEFAULT_REGISTERS: Registers = {
+  a: { type: "empty" },
+  b: { type: "empty" },
+  pc: 1000,
+  sp: 10_000,
+  sr: 0,
+};
+
+/** Initial machine state for a fake. All fields optional. */
+export type Scene = {
+  registers?: Partial<Registers>;
+  cells?: Iterable<[number, Cell]>;
+  labels?: Iterable<[string, number]>;
+  status?: RunStatus;
+  cycles?: number;
+  error?: string | null;
+};
+
+/** A recorded execution-control invocation, for test assertions. */
+export type ControlCall =
+  | { method: "step"; n: number }
+  | { method: "run" }
+  | { method: "pause" }
+  | { method: "setSpeed"; speed: number | null }
+  | { method: "sendInput"; bytes: number[] };
+
+export class FakeComputer
+  implements ComputerInterface, ExecutionControls, SerialPort
+{
+  readonly labels: [string, number][];
+  /** Every execution-control / input call, in order. */
+  readonly calls: ControlCall[] = [];
+
+  #registers: Registers;
+  #cycles: number;
+  #status: RunStatus;
+  #error: string | null;
+  #cells = new Map<number, Cell>();
+
+  #registerSubs = new Set<(r: Registers) => void>();
+  #cycleSubs = new Set<(c: number) => void>();
+  #statusSubs = new Set<(s: RunStatus) => void>();
+  #cellSubs = new Map<number, Set<(c: Cell) => void>>();
+  #outputSubs = new Set<(bytes: number[]) => void>();
+
+  constructor(scene: Scene = {}) {
+    this.#registers = { ...DEFAULT_REGISTERS, ...scene.registers };
+    this.#cycles = scene.cycles ?? 0;
+    this.#status = scene.status ?? "paused";
+    this.#error = scene.error ?? null;
+    this.labels = [...(scene.labels ?? [])];
+    for (const [address, cell] of scene.cells ?? []) {
+      this.#cells.set(address, cell);
+    }
+  }
+
+  // --- reactive reads (ComputerInterface) --------------------------------
+
+  registers(): Registers {
+    return this.#registers;
+  }
+
+  cycles(): number {
+    return this.#cycles;
+  }
+
+  memory(address: number): Cell {
+    return this.#cells.get(address) ?? EMPTY_CELL;
+  }
+
+  subscribe_registers(cb: (r: Registers) => void): Unsubscribe {
+    this.#registerSubs.add(cb);
+    return () => {
+      this.#registerSubs.delete(cb);
+    };
+  }
+
+  subscribe_cycles(cb: (c: number) => void): Unsubscribe {
+    this.#cycleSubs.add(cb);
+    return () => {
+      this.#cycleSubs.delete(cb);
+    };
+  }
+
+  subscribe_memory(address: number, cb: (c: Cell) => void): Unsubscribe {
+    let set = this.#cellSubs.get(address);
+    if (!set) {
+      set = new Set();
+      this.#cellSubs.set(address, set);
+    }
+    set.add(cb);
+    return () => {
+      const current = this.#cellSubs.get(address);
+      if (!current) return;
+      current.delete(cb);
+      if (current.size === 0) this.#cellSubs.delete(address);
+    };
+  }
+
+  // --- execution controls (ExecutionControls) -----------------------------
+
+  step(n = 1): void {
+    this.calls.push({ method: "step", n });
+    this.setCycles(this.#cycles + n);
+    this.setStatus("paused");
+  }
+
+  run(): void {
+    this.calls.push({ method: "run" });
+    this.setStatus("running");
+  }
+
+  pause(): void {
+    this.calls.push({ method: "pause" });
+    this.setStatus("paused");
+  }
+
+  setSpeed(speed: number | null): void {
+    this.calls.push({ method: "setSpeed", speed });
+  }
+
+  getStatus(): RunStatus {
+    return this.#status;
+  }
+
+  getError(): string | null {
+    return this.#error;
+  }
+
+  subscribeStatus(cb: (s: RunStatus) => void): Unsubscribe {
+    this.#statusSubs.add(cb);
+    return () => {
+      this.#statusSubs.delete(cb);
+    };
+  }
+
+  // --- serial port (SerialPort) -------------------------------------------
+
+  sendInput(bytes: number[]): void {
+    this.calls.push({ method: "sendInput", bytes });
+  }
+
+  onOutput(cb: (bytes: number[]) => void): Unsubscribe {
+    this.#outputSubs.add(cb);
+    return () => {
+      this.#outputSubs.delete(cb);
+    };
+  }
+
+  // --- imperative test API -------------------------------------------------
+
+  /** Replace registers with a new object (fresh ref) and notify subscribers. */
+  setRegisters(partial: Partial<Registers>): void {
+    this.#registers = { ...this.#registers, ...partial };
+    for (const cb of this.#registerSubs) cb(this.#registers);
+  }
+
+  /** Set a single memory cell and notify that address's subscribers. */
+  patchCell(address: number, cell: Cell): void {
+    this.#cells.set(address, cell);
+    const subs = this.#cellSubs.get(address);
+    if (subs) for (const cb of subs) cb(cell);
+  }
+
+  setCycles(cycles: number): void {
+    if (cycles === this.#cycles) return;
+    this.#cycles = cycles;
+    for (const cb of this.#cycleSubs) cb(this.#cycles);
+  }
+
+  setStatus(status: RunStatus, error: string | null = null): void {
+    this.#error = status === "panicked" ? (error ?? "panicked") : error;
+    if (status === this.#status) return;
+    this.#status = status;
+    for (const cb of this.#statusSubs) cb(this.#status);
+  }
+
+  /** Emit a batch of serial output bytes to output subscribers. */
+  emitOutput(bytes: number[]): void {
+    for (const cb of this.#outputSubs) cb(bytes);
+  }
+}

--- a/editors/web/app/testing/fixtures.ts
+++ b/editors/web/app/testing/fixtures.ts
@@ -1,4 +1,5 @@
 // Ready-made scenes for the `FakeComputer`, used by stories and tests.
+import type { Labels } from "../computer-types";
 import type { Cell } from "../lib/wasm";
 import type { Scene } from "./fake-computer";
 
@@ -75,4 +76,19 @@ export function panickedScene(msg: string): Scene {
     status: "panicked",
     error: msg,
   };
+}
+
+/**
+ * Build the address→names `Labels` map (as the UI panels consume it) from a
+ * scene's name→address label list. The panels take this shape separately from
+ * `computer.labels`, so stories derive it here.
+ */
+export function sceneLabels(scene: Scene): Labels {
+  const map: Labels = new Map();
+  for (const [name, address] of scene.labels ?? []) {
+    const names = map.get(address) ?? [];
+    names.push(name);
+    map.set(address, names);
+  }
+  return map;
 }

--- a/editors/web/app/testing/fixtures.ts
+++ b/editors/web/app/testing/fixtures.ts
@@ -1,0 +1,78 @@
+// Ready-made scenes for the `FakeComputer`, used by stories and tests.
+import type { Cell } from "../lib/wasm";
+import type { Scene } from "./fake-computer";
+
+const instruction = (text: string): Cell => ({
+  type: "instruction",
+  instruction: text,
+});
+const word = (value: number): Cell => ({ type: "word", word: value });
+
+/** Fresh machine: nothing loaded, paused at the program start. */
+export function emptyScene(): Scene {
+  return {
+    status: "paused",
+    cycles: 0,
+    registers: { pc: 1000, sp: 10_000 },
+  };
+}
+
+/**
+ * A factorial program part-way through execution: labels laid out from the
+ * program start, a mix of instruction and word cells, and registers mid-run.
+ */
+export function factorialScene(): Scene {
+  return {
+    status: "paused",
+    cycles: 42,
+    labels: [
+      ["main", 1000],
+      ["loop", 1004],
+      ["end", 1012],
+    ],
+    cells: [
+      [1000, instruction("push 5")],
+      [1001, instruction("call loop")],
+      [1002, instruction("reset")],
+      [1004, instruction("ld [%sp+1],%a")],
+      [1005, instruction("cmp 1,%a")],
+      [1006, instruction("jge end")],
+      [1007, instruction("mul %b,%a")],
+      [1012, instruction("rtn")],
+      [9998, word(120)],
+      [9999, word(5)],
+    ],
+    registers: {
+      a: word(120),
+      b: word(5),
+      pc: 1007,
+      sp: 9998,
+      sr: 0x002,
+    },
+  };
+}
+
+/** A program that ran to completion. */
+export function haltedScene(): Scene {
+  return {
+    ...factorialScene(),
+    status: "halted",
+    cycles: 128,
+    registers: {
+      a: word(120),
+      b: word(5),
+      pc: 1002,
+      sp: 10_000,
+      sr: 0x002,
+    },
+  };
+}
+
+/** A program that hit a fatal error. */
+export function panickedScene(msg: string): Scene {
+  return {
+    ...factorialScene(),
+    status: "panicked",
+    error: msg,
+  };
+}

--- a/editors/web/app/theme-switcher.stories.tsx
+++ b/editors/web/app/theme-switcher.stories.tsx
@@ -1,0 +1,23 @@
+import preview from "#.storybook/preview";
+import { fn } from "storybook/test";
+
+import { ThemeToggle } from "./theme-switcher";
+
+const meta = preview.meta({
+  title: "UI/ThemeToggle",
+  component: ThemeToggle,
+  args: {
+    value: "system" as const,
+    onValueChange: fn(),
+  },
+});
+
+export const System = meta.story({});
+
+export const Light = meta.story({
+  args: { value: "light" },
+});
+
+export const Dark = meta.story({
+  args: { value: "dark" },
+});

--- a/editors/web/app/theme-switcher.tsx
+++ b/editors/web/app/theme-switcher.tsx
@@ -22,31 +22,36 @@ const ICONS = {
 
 const LABELS = { light: "Light", system: "System", dark: "Dark" } as const;
 
+/** Pure theme toggle group; no store coupling. */
+export const ThemeToggle: React.FC<{
+  value: ThemeValue;
+  onValueChange: (theme: ThemeValue) => void;
+}> = ({ value, onValueChange }) => (
+  <ToggleGroup
+    value={[value]}
+    onValueChange={(values) => {
+      const next = values[0];
+      if (next && isThemeValue(next)) onValueChange(next);
+    }}
+    size="xs"
+    variant="outline"
+  >
+    {THEMES.map((t) => {
+      const Icon = ICONS[t];
+      return (
+        <Tooltip key={t}>
+          <TooltipTrigger render={<ToggleGroupItem value={t} />}>
+            <Icon />
+          </TooltipTrigger>
+          <TooltipContent>{LABELS[t]}</TooltipContent>
+        </Tooltip>
+      );
+    })}
+  </ToggleGroup>
+);
+
 export const ThemeSwitcher: React.FC = () => {
   const theme = useThemeStore((s) => s.theme);
   const setTheme = useThemeStore((s) => s.setTheme);
-
-  return (
-    <ToggleGroup
-      value={[theme]}
-      onValueChange={(values) => {
-        const value = values[0];
-        if (value && isThemeValue(value)) setTheme(value);
-      }}
-      size="xs"
-      variant="outline"
-    >
-      {THEMES.map((t) => {
-        const Icon = ICONS[t];
-        return (
-          <Tooltip key={t}>
-            <TooltipTrigger render={<ToggleGroupItem value={t} />}>
-              <Icon />
-            </TooltipTrigger>
-            <TooltipContent>{LABELS[t]}</TooltipContent>
-          </Tooltip>
-        );
-      })}
-    </ToggleGroup>
-  );
+  return <ThemeToggle value={theme} onValueChange={setTheme} />;
 };

--- a/editors/web/app/workers/emulator.worker.ts
+++ b/editors/web/app/workers/emulator.worker.ts
@@ -184,7 +184,7 @@ let slowTickHandle: number | null = null;
 function scheduleSlowTick(): void {
   slowTickHandle = useRaf
     ? self.requestAnimationFrame(slowTick)
-    : setTimeout(slowTick, 16);
+    : self.setTimeout(slowTick, 16);
 }
 
 function cancelSlowTick(): void {

--- a/editors/web/knip.json
+++ b/editors/web/knip.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://unpkg.com/knip@6/schema.json"
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "ignore": ["storybook-static/**"]
 }

--- a/editors/web/package.json
+++ b/editors/web/package.json
@@ -2,6 +2,9 @@
   "name": "z33-web",
   "private": true,
   "type": "module",
+  "imports": {
+    "#*": ["./*", "./*.ts", "./*.tsx"]
+  },
   "scripts": {
     "build:wasm": "wasm-pack build ../../crates/wasm --target web --out-dir ../../editors/web/pkg --out-name z33_web",
     "build:wasm:dev": "wasm-pack build ../../crates/wasm --dev --target web --out-dir ../../editors/web/pkg --out-name z33_web",
@@ -15,10 +18,18 @@
     "knip": "knip",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
-    "e2e:headed": "playwright test --headed"
+    "e2e:headed": "playwright test --headed",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build",
+    "test-storybook": "vitest run --project=storybook",
+    "test-storybook:watch": "vitest --project=storybook"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "@storybook/addon-a11y": "^10.5.0",
+    "@storybook/addon-themes": "^10.5.0",
+    "@storybook/addon-vitest": "^10.5.0",
+    "@storybook/react-vite": "^10.5.0",
     "@tailwindcss/vite": "^4.3.2",
     "@tsconfig/node20": "^20.1.9",
     "@tsconfig/strictest": "^2.0.8",
@@ -27,13 +38,17 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
+    "@vitest/browser-playwright": "^4.1.10",
     "knip": "^6.3.0",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "oxlint-tsgolint": "^0.24.0",
+    "playwright": "^1.61.1",
+    "storybook": "^10.5.0",
     "tailwindcss": "^4.3.2",
     "typescript": "catalog:",
     "vite": "^8.1.3",
+    "vitest": "^4.1.10",
     "wasm-pack": "catalog:"
   },
   "dependencies": {

--- a/editors/web/vitest.config.ts
+++ b/editors/web/vitest.config.ts
@@ -1,0 +1,33 @@
+import { fileURLToPath } from "node:url";
+import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
+import { playwright } from "@vitest/browser-playwright";
+import { defineConfig } from "vitest/config";
+
+// Storybook stories are run as a dedicated Vitest project in a real browser
+// (Playwright/chromium). The project extends the app's ./vite.config.ts so the
+// Tailwind plugin and the `@` alias apply, just like the running app. The
+// storybookTest plugin auto-injects the preview's project annotations
+// (decorators/parameters), so no explicit setup file is needed.
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        extends: "./vite.config.ts",
+        plugins: [
+          await storybookTest({
+            configDir: fileURLToPath(new URL(".storybook", import.meta.url)),
+          }),
+        ],
+        test: {
+          name: "storybook",
+          browser: {
+            enabled: true,
+            provider: playwright(),
+            headless: true,
+            instances: [{ browser: "chromium" }],
+          },
+        },
+      },
+    ],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,18 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.61.1
+      '@storybook/addon-a11y':
+        specifier: ^10.5.0
+        version: 10.5.0(storybook@10.5.0(@types/react@19.2.17)(react@19.2.7))
+      '@storybook/addon-themes':
+        specifier: ^10.5.0
+        version: 10.5.0(storybook@10.5.0(@types/react@19.2.17)(react@19.2.7))
+      '@storybook/addon-vitest':
+        specifier: ^10.5.0
+        version: 10.5.0(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/runner@4.1.10)(react@19.2.7)(storybook@10.5.0(@types/react@19.2.17)(react@19.2.7))(vitest@4.1.10)
+      '@storybook/react-vite':
+        specifier: ^10.5.0
+        version: 10.5.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.0(@types/react@19.2.17)(react@19.2.7))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: ^4.3.2
         version: 4.3.2(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -147,6 +159,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/browser-playwright':
+        specifier: ^4.1.10
+        version: 4.1.10(playwright@1.61.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
       knip:
         specifier: ^6.3.0
         version: 6.24.0
@@ -159,6 +174,12 @@ importers:
       oxlint-tsgolint:
         specifier: ^0.24.0
         version: 0.24.0
+      playwright:
+        specifier: ^1.61.1
+        version: 1.61.1
+      storybook:
+        specifier: ^10.5.0
+        version: 10.5.0(@types/react@19.2.17)(react@19.2.7)
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -168,6 +189,9 @@ importers:
       vite:
         specifier: ^8.1.3
         version: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       wasm-pack:
         specifier: 'catalog:'
         version: 0.15.0
@@ -179,6 +203,9 @@ importers:
         version: 0.26.10
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
   '@azu/format-text@1.0.2':
     resolution: {integrity: sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==}
@@ -390,6 +417,9 @@ packages:
       '@types/react':
         optional: true
 
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
+
   '@dotenvx/dotenvx@1.57.0':
     resolution: {integrity: sha512-WsTEcqfHzKmLFZh3jLGd7o4iCkrIupp+qFH2FJUJtQXUh2GcOnLXD00DcrhlO4H8QSmaKnW9lugOEbrdpu25kA==}
     hasBin: true
@@ -406,11 +436,20 @@ packages:
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
   '@emnapi/runtime@1.11.0':
     resolution: {integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==}
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
@@ -599,6 +638,15 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
+    resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -759,10 +807,22 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    resolution: {integrity: sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@oxc-parser/binding-android-arm-eabi@0.137.0':
     resolution: {integrity: sha512-KDs+0VPdEmasOkpuJHW9V5WCF+cvYdMQv2Jd+aJXt+cxIx12NToRQRbXaRwUEDsZw+/jMk81Ve8ZFbjUkJTOwA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
+    resolution: {integrity: sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
     os: [android]
 
   '@oxc-parser/binding-android-arm64@0.137.0':
@@ -771,10 +831,22 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    resolution: {integrity: sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxc-parser/binding-darwin-arm64@0.137.0':
     resolution: {integrity: sha512-bFPr5hgmNMOMoyPTGtdsK4Ug21RovIPojRMgDDhSp1LtCnc/DkLwGONKjgRjszg677RlGnkYSviQ8hHaUPOVYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
+    resolution: {integrity: sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [darwin]
 
   '@oxc-parser/binding-darwin-x64@0.137.0':
@@ -783,14 +855,32 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    resolution: {integrity: sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxc-parser/binding-freebsd-x64@0.137.0':
     resolution: {integrity: sha512-79h8rYGnSlKPGWo7mHr2ixO6ea7aW8B0CT965SZ8SLbNnCOH5aOYBTeVXUY6eMvEaiLyWr8Skuiugr5pDYgLGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    resolution: {integrity: sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.137.0':
     resolution: {integrity: sha512-ASgmlSimhGyr0lksgVIo6hibz1obnDq4qJbiMX/AzltfgPnanRrzG1Q+23g8ljOHOjv6dsznkUuCYL3gg0sY1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    resolution: {integrity: sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -801,12 +891,26 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    resolution: {integrity: sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-arm64-gnu@0.137.0':
     resolution: {integrity: sha512-GdEtiG89yMr7XkUGxifgodXEEm2f+xW2f9CpDjlgAnBOwhTmrpQMvhOGobLVKUyzf/qHBXW16smk5zbF3nZU6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-arm64-musl@0.137.0':
     resolution: {integrity: sha512-EGJ+Bs8iXx8KBH8DQ5BLoEm5lnHaYjlh4/8j8vFhrr/6z4tqONy5BZDzLpKmmNWlN6Hlc5r8YOuBVHqZ9vRFEQ==}
@@ -815,10 +919,24 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-ppc64-gnu@0.137.0':
     resolution: {integrity: sha512-vzFUQENy/fnbSe5DZWovq6tIBc1uhuMztanSW6rz1e9WdQE4gHwYuD7ZII6JnrJifd1R3RSoqiZbgRFlVL2tYQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
@@ -829,6 +947,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
   '@oxc-parser/binding-linux-riscv64-musl@0.137.0':
     resolution: {integrity: sha512-e7Ppy4FCIFNQxT/ikSeIWFoQ0l+N9vgtRBtLcyZXeolTzApyVoPqEXsYPrcdM/9i0Bwk8knvYd37vaEMxHyi6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -836,10 +961,24 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-s390x-gnu@0.137.0':
     resolution: {integrity: sha512-Bho5qFwdhqsIFR7gipYEUlqvi3SRrY8sugxXig380MIaakBB1PyU9+7dBiBVScfImTNWhijUxdBwqrprGdq5WA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -850,6 +989,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@oxc-parser/binding-linux-x64-musl@0.137.0':
     resolution: {integrity: sha512-/Jqx6+N7A44n2BdvUr7pXhVr2vFjs6WGH3unZRczwrfiH0H1zY0QwKQMG/dtRiTlKGDKGukznPT8lx84/oEsZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -857,21 +1003,44 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@oxc-parser/binding-openharmony-arm64@0.137.0':
     resolution: {integrity: sha512-9Uj0qHNNl+OgT1UTGwF7ixIXU6T1u2SbMidmgPy/h1h/fl2gRS6YpAxxY1gwHofcWjoTwkoMFd8xs5Vuj6GOFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    resolution: {integrity: sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@oxc-parser/binding-wasm32-wasi@0.137.0':
     resolution: {integrity: sha512-gW2vfkytNGgMVADiuzdvOfw0mWG9za20F/1fCJsif5aBMAvWJTSbpIXbIe0XkOe0VENk+PadpQ7cZgUy2sUJcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    resolution: {integrity: sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@oxc-parser/binding-win32-arm64-msvc@0.137.0':
     resolution: {integrity: sha512-x+pFANF0yL5uK/6T7lu6SlR5qid6sp//eZXKLq5iNsIE+EQg6EaS8/wsW7E91nXXjpnPhSoMOHXShSVhGRdn8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    resolution: {integrity: sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
     os: [win32]
 
   '@oxc-parser/binding-win32-ia32-msvc@0.137.0':
@@ -880,11 +1049,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    resolution: {integrity: sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@oxc-parser/binding-win32-x64-msvc@0.137.0':
     resolution: {integrity: sha512-2AsevxlvNN4WKxpEn3RtqD5zbqMaXF+T7JXblsP4gVuY+vC9dXS4ED/PwfRCliFqoeisYS3Iro4DHzxr0TEvVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
   '@oxc-project/types@0.137.0':
     resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
@@ -1274,6 +1452,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
   '@rolldown/binding-android-arm64@1.1.4':
     resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1372,6 +1553,15 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -1427,6 +1617,112 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@storybook/addon-a11y@10.5.0':
+    resolution: {integrity: sha512-AguqTsYS2NX20AF1vWt6IonbkpMXur30/dAOOYltbEW7uKmPxBNtjuiBmYB2WI4aFN4r8jje4bbDGk/Yfq58hQ==}
+    peerDependencies:
+      storybook: ^10.5.0
+
+  '@storybook/addon-themes@10.5.0':
+    resolution: {integrity: sha512-9dvrN1JcpWt+f+RueMGvdeGTNQJ5y4w931X2HHzE+ItrN2Ogp0vSppb/baUNezeBLqhuUJjPbvyAeAb9v4rong==}
+    peerDependencies:
+      storybook: ^10.5.0
+
+  '@storybook/addon-vitest@10.5.0':
+    resolution: {integrity: sha512-o/H+ii8o7bu4r1M4pgyFt+DjVaIIccSeaAikpspNHKkKdiJ2GXfkgNwtib8Jru28HaBRfcP5u+m0QE3KBYIQkw==}
+    peerDependencies:
+      '@vitest/browser': ^3.0.0 || ^4.0.0
+      '@vitest/browser-playwright': ^4.0.0
+      '@vitest/runner': ^3.0.0 || ^4.0.0
+      storybook: ^10.5.0
+      vitest: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/runner':
+        optional: true
+      vitest:
+        optional: true
+
+  '@storybook/builder-vite@10.5.0':
+    resolution: {integrity: sha512-KXlifNIThDgS84KqVAJXyilool8OLTWp6DGoO9h5bHM2IPLe7UcdKfOzMUBkQ807mWBk4aW1yGEekj7kC2dvmg==}
+    peerDependencies:
+      storybook: ^10.5.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/csf-plugin@10.5.0':
+    resolution: {integrity: sha512-R7VFw6FnDZTWct0ekOcFnTfDgdHnnAuQW+AbGG9A9IZPvyH9uLJivK7L86+r9MITRrO2+v81HaFDsT/OFk6ZkQ==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: '*'
+      storybook: ^10.5.0
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/icons@2.1.0':
+    resolution: {integrity: sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@storybook/react-dom-shim@10.5.0':
+    resolution: {integrity: sha512-GwGA6zDj4Cfw6vGsdfPKfF39L0W6solNbbnjdjGa57m2ooASkidLhrXo2wgC9wh3o/jcfonmYPDRGY6sEhGDtg==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.5.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@storybook/react-vite@10.5.0':
+    resolution: {integrity: sha512-d9n/I3pViscXpJYT9JHxcpxVSam14HsHOr2wBqTQTiRtaiH4xSsT00HTEGm6CEZTyq/npTJyV0Qday9XhrtiDQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.5.0
+      typescript: '>= 4.9.x'
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@storybook/react@10.5.0':
+    resolution: {integrity: sha512-2IhddiREy7NqAqnFsEOfW6HBG7azIcLxhRQYploSsaemOncR29xhzvAZsG+xlWgrtvxv4h3fYQTTR4TNn8CgPQ==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.5.0
+      typescript: '>= 4.9.x'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+      typescript:
+        optional: true
 
   '@tailwindcss/node@4.3.2':
     resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
@@ -1556,6 +1852,20 @@ packages:
   '@tanstack/virtual-core@3.17.3':
     resolution: {integrity: sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@textlint/ast-node-types@15.5.2':
     resolution: {integrity: sha512-fCaOxoup5LIyBEo7R1oYWE7V4bSX0KQeHh66twon9e9usaLE3ijgF8QjYsR6joCssdeCHVd0wHm7ppsEyTr6vg==}
 
@@ -1586,6 +1896,33 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/doctrine@0.0.9':
+    resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/node@26.1.0':
     resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
 
@@ -1599,6 +1936,9 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/resolve@1.20.6':
+    resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
@@ -1628,6 +1968,58 @@ packages:
         optional: true
       babel-plugin-react-compiler:
         optional: true
+
+  '@vitest/browser-playwright@4.1.10':
+    resolution: {integrity: sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.1.10
+
+  '@vitest/browser@4.1.10':
+    resolution: {integrity: sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==}
+    peerDependencies:
+      vitest: 4.1.10
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@vscode/vsce-sign-alpine-arm64@2.0.6':
     resolution: {integrity: sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==}
@@ -1682,6 +2074,9 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
+  '@webcontainer/env@1.1.1':
+    resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
+
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
 
@@ -1691,6 +2086,11 @@ packages:
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -1723,8 +2123,23 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
@@ -1736,6 +2151,10 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
 
   azure-devops-node-api@12.5.0:
     resolution: {integrity: sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==}
@@ -1814,6 +2233,14 @@ packages:
   caniuse-lite@1.0.30001780:
     resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1821,6 +2248,10 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -1935,6 +2366,9 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -1963,6 +2397,10 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -2000,6 +2438,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -2007,6 +2449,16 @@ packages:
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
+
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -2055,6 +2507,10 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  empathic@2.0.1:
+    resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
+    engines: {node: '>=14'}
+
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
@@ -2100,6 +2556,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -2125,6 +2584,16 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -2148,6 +2617,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.3.1:
     resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
@@ -2321,6 +2794,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
   hono@4.12.8:
     resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
     engines: {node: '>=16.9.0'}
@@ -2379,6 +2856,10 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
@@ -2403,6 +2884,10 @@ packages:
   is-ci@2.0.0:
     resolution: {integrity: sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==}
     hasBin: true
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -2668,6 +3153,9 @@ packages:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -2686,6 +3174,10 @@ packages:
     resolution: {integrity: sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2758,6 +3250,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -2784,6 +3280,10 @@ packages:
 
   monaco-types@0.1.2:
     resolution: {integrity: sha512-8LwfrlWXsedHwAL41xhXyqzPibS8IqPuIXr9NdORhonS495c2/wky+sI1PRLvMCuiI0nqC2NH1six9hdiRY4Xg==}
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2848,6 +3348,10 @@ packages:
     resolution: {integrity: sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==}
     engines: {node: '>= 10'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -2879,6 +3383,10 @@ packages:
     resolution: {integrity: sha512-N0gWlINGgoOA2Sn0AhrF9L3ap40a/QbsFUpMDKR+CKYyZGJeTFEoNGngplLHjAYtcjrrZv2jX2K7ktPzxWjPNg==}
     engines: {node: '>= 20'}
     hasBin: true
+
+  oxc-parser@0.127.0:
+    resolution: {integrity: sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-parser@0.137.0:
     resolution: {integrity: sha512-yFImD+WLElJpLKy8llG1qe4DCmMsL18peRp8XP1JKfig/gISbJkglnpDtX2aTmAn10kZF7164HbN2H8QPsXxGg==}
@@ -2964,6 +3472,9 @@ packages:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
 
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
@@ -2974,6 +3485,13 @@ packages:
   path-type@6.0.0:
     resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
     engines: {node: '>=18'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -3010,6 +3528,10 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
+
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
@@ -3027,6 +3549,10 @@ packages:
     engines: {node: '>=10'}
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
@@ -3069,10 +3595,22 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-docgen-typescript@2.4.0:
+    resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+
+  react-docgen@8.0.3:
+    resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
+    engines: {node: ^20.9.0 || >=22}
+
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
       react: ^19.2.7
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-resizable-panels@4.12.0:
     resolution: {integrity: sha512-t/Gp57qSCxGQ52ckhz+8lM7dnuymeU95TEzl2U203qEbGkSLHrtm7US2/ANzq/zOlja3CwPTAfCDuh1unv9mfw==}
@@ -3100,6 +3638,10 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -3113,6 +3655,11 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -3209,6 +3756,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3225,6 +3775,10 @@ packages:
   simple-invariant@2.0.1:
     resolution: {integrity: sha512-1sbhsxqI+I2tqlmjbz99GXNmZtr6tKIyEgGGnJw/MKGblalqk/XoOYYFJlBzTKZCxx8kLaD3FD5s9BEEjx5Pyg==}
     engines: {node: '>=10'}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -3261,6 +3815,9 @@ packages:
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
@@ -3268,9 +3825,27 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
+
+  storybook@10.5.0:
+    resolution: {integrity: sha512-dRhM/kSSvHQR8DmZO41v5sJuz9U6zDjjR2gRBTgZN2RBSXbmF0Brvgszrvvxyx2VfxuYKzhB+xumKwWkwlBtig==}
+    hasBin: true
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      prettier: ^2 || ^3
+      vite-plus: ^0.1.15 || ^0.2.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      prettier:
+        optional: true
+      vite-plus:
+        optional: true
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -3307,6 +3882,14 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  strip-indent@4.1.1:
+    resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
+    engines: {node: '>=12'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -3325,6 +3908,10 @@ packages:
   supports-hyperlinks@3.2.0:
     resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
     engines: {node: '>=14.18'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
@@ -3365,6 +3952,13 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -3372,6 +3966,18 @@ packages:
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   tmp@0.2.5:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
@@ -3385,10 +3991,18 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
   tree-sitter-cli@0.26.10:
     resolution: {integrity: sha512-RTse32x5YWOrEtH7wos8ODt3yyB7SKgmGN70jC7R+WcnDA64vrpYU98+LnwrwdXMlxgr0LGQdezZz85DN8Wv0w==}
     engines: {node: '>=12.0.0'}
     hasBin: true
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
 
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
@@ -3458,6 +4072,10 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -3539,6 +4157,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@9.0.1:
     resolution: {integrity: sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==}
     engines: {node: '>=14.0.0'}
@@ -3568,6 +4227,9 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
@@ -3587,8 +4249,25 @@ packages:
     engines: {node: ^16.13.0 || >=18.0.0}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
@@ -3666,6 +4345,8 @@ packages:
         optional: true
 
 snapshots:
+
+  '@adobe/css-tools@4.5.0': {}
 
   '@azu/format-text@1.0.2': {}
 
@@ -3967,6 +4648,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@blazediff/core@1.9.1': {}
+
   '@dotenvx/dotenvx@1.57.0':
     dependencies:
       commander: 11.1.0
@@ -3995,12 +4678,28 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.11.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4115,6 +4814,14 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      glob: 13.0.6
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
+      vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+    optionalDependencies:
+      typescript: 6.0.3
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4185,6 +4892,13 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -4269,52 +4983,107 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-android-arm-eabi@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
     optional: true
 
   '@oxc-parser/binding-android-arm64@0.137.0':
     optional: true
 
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-darwin-arm64@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
     optional: true
 
   '@oxc-parser/binding-darwin-x64@0.137.0':
     optional: true
 
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-freebsd-x64@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-gnueabihf@0.137.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm-musleabihf@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-gnu@0.137.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm64-musl@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     optional: true
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.137.0':
     optional: true
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-linux-riscv64-gnu@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-musl@0.137.0':
     optional: true
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-linux-s390x-gnu@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-gnu@0.137.0':
     optional: true
 
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-linux-x64-musl@0.137.0':
     optional: true
 
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-openharmony-arm64@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.137.0':
@@ -4324,14 +5093,25 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-win32-arm64-msvc@0.137.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
     optional: true
 
   '@oxc-parser/binding-win32-ia32-msvc@0.137.0':
     optional: true
 
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    optional: true
+
   '@oxc-parser/binding-win32-x64-msvc@0.137.0':
     optional: true
+
+  '@oxc-project/types@0.127.0': {}
 
   '@oxc-project/types@0.137.0': {}
 
@@ -4534,6 +5314,8 @@ snapshots:
     dependencies:
       playwright: 1.61.1
 
+  '@polka/url@1.0.0-next.29': {}
+
   '@rolldown/binding-android-arm64@1.1.4':
     optional: true
 
@@ -4584,6 +5366,12 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
+
+  '@rollup/pluginutils@5.4.0':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.5
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -4664,6 +5452,107 @@ snapshots:
   '@sindresorhus/merge-streams@2.3.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@storybook/addon-a11y@10.5.0(storybook@10.5.0(@types/react@19.2.17)(react@19.2.7))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      axe-core: 4.12.1
+      storybook: 10.5.0(@types/react@19.2.17)(react@19.2.7)
+
+  '@storybook/addon-themes@10.5.0(storybook@10.5.0(@types/react@19.2.17)(react@19.2.7))':
+    dependencies:
+      storybook: 10.5.0(@types/react@19.2.17)(react@19.2.7)
+      ts-dedent: 2.3.0
+
+  '@storybook/addon-vitest@10.5.0(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/runner@4.1.10)(react@19.2.7)(storybook@10.5.0(@types/react@19.2.17)(react@19.2.7))(vitest@4.1.10)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.1.0(react@19.2.7)
+      storybook: 10.5.0(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(playwright@1.61.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/runner': 4.1.10
+      vitest: 4.1.10(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - react
+
+  '@storybook/builder-vite@10.5.0(esbuild@0.28.1)(storybook@10.5.0(@types/react@19.2.17)(react@19.2.7))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@storybook/csf-plugin': 10.5.0(esbuild@0.28.1)(storybook@10.5.0(@types/react@19.2.17)(react@19.2.7))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      storybook: 10.5.0(@types/react@19.2.17)(react@19.2.7)
+      ts-dedent: 2.3.0
+      vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+
+  '@storybook/csf-plugin@10.5.0(esbuild@0.28.1)(storybook@10.5.0(@types/react@19.2.17)(react@19.2.7))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      storybook: 10.5.0(@types/react@19.2.17)(react@19.2.7)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.28.1
+      vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/icons@2.1.0(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+
+  '@storybook/react-dom-shim@10.5.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.0(@types/react@19.2.17)(react@19.2.7))':
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      storybook: 10.5.0(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@storybook/react-vite@10.5.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.0(@types/react@19.2.17)(react@19.2.7))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@rollup/pluginutils': 5.4.0
+      '@storybook/builder-vite': 10.5.0(esbuild@0.28.1)(storybook@10.5.0(@types/react@19.2.17)(react@19.2.7))(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@storybook/react': 10.5.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.0(@types/react@19.2.17)(react@19.2.7))(typescript@6.0.3)
+      empathic: 2.0.1
+      magic-string: 0.30.21
+      react: 19.2.7
+      react-docgen: 8.0.3
+      react-dom: 19.2.7(react@19.2.7)
+      resolve: 1.22.12
+      storybook: 10.5.0(@types/react@19.2.17)(react@19.2.7)
+      tsconfig-paths: 4.2.0
+      vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - supports-color
+      - webpack
+
+  '@storybook/react@10.5.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.0(@types/react@19.2.17)(react@19.2.7))(typescript@6.0.3)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/react-dom-shim': 10.5.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.0(@types/react@19.2.17)(react@19.2.7))
+      react: 19.2.7
+      react-docgen: 8.0.3
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
+      react-dom: 19.2.7(react@19.2.7)
+      storybook: 10.5.0(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@tailwindcss/node@4.3.2':
     dependencies:
@@ -4764,6 +5653,30 @@ snapshots:
 
   '@tanstack/virtual-core@3.17.3': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@textlint/ast-node-types@15.5.2': {}
 
   '@textlint/linter-formatter@15.5.2':
@@ -4810,6 +5723,40 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/doctrine@0.0.9': {}
+
+  '@types/estree@1.0.9': {}
+
   '@types/node@26.1.0':
     dependencies:
       undici-types: 8.3.0
@@ -4823,6 +5770,8 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/resolve@1.20.6': {}
 
   '@types/sarif@2.1.7': {}
 
@@ -4845,6 +5794,99 @@ snapshots:
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+
+  '@vitest/browser-playwright@4.1.10(playwright@1.61.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@vitest/browser': 4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      playwright: 1.61.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@vscode/vsce-sign-alpine-arm64@2.0.6':
     optional: true
@@ -4921,6 +5963,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@webcontainer/env@1.1.1': {}
+
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/xterm@6.0.0': {}
@@ -4929,6 +5973,8 @@ snapshots:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
+
+  acorn@8.17.0: {}
 
   agent-base@7.1.4: {}
 
@@ -4955,7 +6001,17 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
 
   ast-types@0.16.1:
     dependencies:
@@ -4964,6 +6020,8 @@ snapshots:
   astral-regex@2.0.0: {}
 
   asynckit@0.4.0: {}
+
+  axe-core@4.12.1: {}
 
   azure-devops-node-api@12.5.0:
     dependencies:
@@ -5052,12 +6110,24 @@ snapshots:
 
   caniuse-lite@1.0.30001780: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
+
+  check-error@2.1.3: {}
 
   cheerio-select@2.1.0:
     dependencies:
@@ -5165,6 +6235,8 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
@@ -5179,6 +6251,8 @@ snapshots:
     optional: true
 
   dedent@1.7.2: {}
+
+  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0:
     optional: true
@@ -5210,9 +6284,19 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   diff@8.0.3: {}
+
+  doctrine@3.0.0:
+    dependencies:
+      esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -5267,6 +6351,8 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
+  empathic@2.0.1: {}
+
   encodeurl@2.0.0: {}
 
   encoding-sniffer@0.2.1:
@@ -5301,6 +6387,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -5348,6 +6436,14 @@ snapshots:
 
   esprima@4.0.1: {}
 
+  estree-walker@2.0.2: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  esutils@2.0.3: {}
+
   etag@1.8.1: {}
 
   eventsource-parser@3.0.6: {}
@@ -5385,6 +6481,8 @@ snapshots:
 
   expand-template@2.0.3:
     optional: true
+
+  expect-type@1.4.0: {}
 
   express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
@@ -5586,6 +6684,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   hono@4.12.8: {}
 
   hosted-git-info@4.1.0:
@@ -5649,6 +6751,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  indent-string@4.0.0: {}
+
   index-to-position@1.2.0: {}
 
   inherits@2.0.4: {}
@@ -5665,6 +6769,10 @@ snapshots:
   is-ci@2.0.0:
     dependencies:
       ci-info: 2.0.0
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
 
   is-docker@3.0.0: {}
 
@@ -5878,6 +6986,8 @@ snapshots:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
 
+  loupe@3.2.1: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@11.2.7: {}
@@ -5893,6 +7003,8 @@ snapshots:
   lucide-react@1.23.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -5947,6 +7059,8 @@ snapshots:
   mimic-response@3.1.0:
     optional: true
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.7
@@ -5974,6 +7088,8 @@ snapshots:
       vscode-uri: 3.1.0
 
   monaco-types@0.1.2: {}
+
+  mrmime@2.0.1: {}
 
   ms@2.1.3: {}
 
@@ -6027,6 +7143,8 @@ snapshots:
   object-keys@1.1.1: {}
 
   object-treeify@1.1.33: {}
+
+  obug@2.1.3: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -6085,6 +7203,31 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
+
+  oxc-parser@0.127.0:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.127.0
+      '@oxc-parser/binding-android-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-x64': 0.127.0
+      '@oxc-parser/binding-freebsd-x64': 0.127.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.127.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.127.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-musl': 0.127.0
+      '@oxc-parser/binding-openharmony-arm64': 0.127.0
+      '@oxc-parser/binding-wasm32-wasi': 0.127.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.127.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.127.0
 
   oxc-parser@0.137.0:
     dependencies:
@@ -6235,6 +7378,8 @@ snapshots:
 
   path-key@4.0.0: {}
 
+  path-parse@1.0.7: {}
+
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.2.7
@@ -6243,6 +7388,10 @@ snapshots:
   path-to-regexp@8.4.2: {}
 
   path-type@6.0.0: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   pend@1.2.0: {}
 
@@ -6265,6 +7414,8 @@ snapshots:
   pluralize@2.0.0: {}
 
   pluralize@8.0.0: {}
+
+  pngjs@7.0.0: {}
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -6294,6 +7445,12 @@ snapshots:
       tar-fs: 2.1.5
       tunnel-agent: 0.6.0
     optional: true
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   pretty-ms@9.3.0:
     dependencies:
@@ -6349,10 +7506,31 @@ snapshots:
       strip-json-comments: 2.0.1
     optional: true
 
+  react-docgen-typescript@2.4.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
+  react-docgen@8.0.3:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.28.0
+      '@types/doctrine': 0.0.9
+      '@types/resolve': 1.20.6
+      doctrine: 3.0.0
+      resolve: 1.22.12
+      strip-indent: 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   react-dom@19.2.7(react@19.2.7):
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-resizable-panels@4.12.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -6388,6 +7566,11 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   require-from-string@2.0.2: {}
 
   reselect@5.2.0: {}
@@ -6395,6 +7578,13 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   restore-cursor@5.1.0:
     dependencies:
@@ -6567,6 +7757,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -6582,6 +7774,12 @@ snapshots:
     optional: true
 
   simple-invariant@2.0.1: {}
+
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
 
   sisteransi@1.0.5: {}
 
@@ -6613,11 +7811,41 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
+  stackback@0.0.2: {}
+
   state-local@1.0.7: {}
 
   statuses@2.0.2: {}
 
+  std-env@4.2.0: {}
+
   stdin-discarder@0.2.2: {}
+
+  storybook@10.5.0(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.1.0(react@19.2.7)
+      '@testing-library/dom': 10.4.1
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
+      esbuild: 0.28.1
+      jsonc-parser: 3.3.1
+      open: 10.2.0
+      oxc-parser: 0.127.0
+      oxc-resolver: 11.21.3
+      recast: 0.23.11
+      semver: 7.8.5
+      use-sync-external-store: 1.6.0(react@19.2.7)
+      ws: 8.21.0
+    optionalDependencies:
+      '@types/react': 19.2.17
+    transitivePeerDependencies:
+      - bufferutil
+      - react
+      - utf-8-validate
 
   string-width@4.2.3:
     dependencies:
@@ -6656,6 +7884,12 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  strip-indent@4.1.1: {}
+
   strip-json-comments@2.0.1:
     optional: true
 
@@ -6673,6 +7907,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
       supports-color: 7.2.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   table@6.9.0:
     dependencies:
@@ -6726,12 +7962,22 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
 
   tinypool@2.1.0: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyrainbow@3.1.0: {}
+
+  tinyspy@4.0.4: {}
 
   tmp@0.2.5: {}
 
@@ -6741,7 +7987,11 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  totalist@3.0.1: {}
+
   tree-sitter-cli@0.26.10: {}
+
+  ts-dedent@2.3.0: {}
 
   ts-morph@26.0.0:
     dependencies:
@@ -6799,6 +8049,13 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.17.0
+      picomatch: 4.0.5
+      webpack-virtual-modules: 0.6.2
+
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -6840,6 +8097,34 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
+  vitest@4.1.10(@types/node@26.1.0)(@vitest/browser-playwright@4.1.10)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.1.0
+      '@vitest/browser-playwright': 4.1.10(playwright@1.61.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
+    transitivePeerDependencies:
+      - msw
+
   vscode-jsonrpc@9.0.1: {}
 
   vscode-languageclient@10.1.0:
@@ -6866,6 +8151,8 @@ snapshots:
     dependencies:
       tar: 7.5.19
 
+  webpack-virtual-modules@0.6.2: {}
+
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
@@ -6880,7 +8167,14 @@ snapshots:
     dependencies:
       isexe: 3.1.5
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   wrappy@1.0.2: {}
+
+  ws@8.21.0: {}
 
   wsl-utils@0.1.0:
     dependencies:


### PR DESCRIPTION
Sets up **Storybook 10** as an organized UI library for the web IDE and decouples the presentational components from business logic, in five commits (bottom → top):

1. **Add the Storybook 10 toolchain** — devDeps (`storybook`/`@storybook/react-vite`/addon-vitest/addon-themes/addon-a11y @ 10.5, vitest 4 browser mode via the Playwright provider), the `#*` subpath-imports entry, and scripts (`storybook`, `build-storybook`, `test-storybook`).
2. **Scaffold + UI primitive stories** — `.storybook/` config using the **CSF Factories** format (`defineMain`/`definePreview`/`preview.meta()`); light/dark switching via `withThemeByClassName` against the existing `.dark` tokens; stories with play functions for the base-ui primitives (Button, Badge, Select, Toggle(Group), Tooltip, AlertDialog, …). No `vitest.setup.ts` on purpose: the SB10 vitest plugin auto-injects preview annotations.
3. **Decouple UI from business logic** — behavior-preserving:
   - `ExecutionControls`/`SerialPort` interfaces next to `ComputerInterface`; `ComputerProxy` now `implements` them (its `#private` fields made props typed as the class un-fakeable).
   - Pure `FormatToggle`/`ThemeToggle` split from their connected switchers.
   - `EditToolbar`: the props→state `useEffect` sync is gone — pure `pickEntrypoint()` + an uncontrolled Select in a `<form onSubmit>` (FormData), keyed remount on label-set changes.
   - Pure `SerialConsoleShell` and `FileSidebarView` split from their store-wired wrappers.
   - New `ErrorBoundary` (hand-rolled) at the root, around the debug panels, and around the lazy xterm terminal, which also gets a real Suspense skeleton instead of `fallback={null}`.
   - `FakeComputer` test double + scene fixtures in `app/testing/` (stable-ref subscribe semantics matching the proxy, imperative test API, recorded control calls).
4. **Organism stories** — RegisterPanel, MemoryViewer/MemoryPanel, DebugToolbar, EditToolbar, SerialConsoleShell, FileSidebarView driven by `FakeComputer`, with interaction tests (spies, portal-aware queries) and a `displayFormat` toolbar global two-way synced with the display store by a preview decorator.
5. **Storybook tests in CI** — new non-required `storybook` job in check.yaml mirroring the e2e job, minus the Rust cache and wasm build: the story graph only `import type`s from `lib/wasm`, and the suite is verified to pass without `pkg/` present.

Monaco editor internals and the xterm terminal stay out of Storybook by design.

**Verification**: 66 Storybook tests green in headless Chromium (including without `pkg/`), full Playwright e2e suite still 29/29, `pnpm run check`, `knip`, `build`, and `build-storybook` all clean. a11y checks run at "todo" severity for now: promoting to "error" surfaces 29 pre-existing `color-contrast` violations in the app's design tokens (muted-foreground 4.34:1, badge-on-blue 3.76:1) — worth a separate theme audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
