### PR TITLE
Accessibility pass: contrast, landmarks, accessible names

### DIFF
--- a/editors/web/.storybook/preview.tsx
+++ b/editors/web/.storybook/preview.tsx
@@ -75,12 +75,15 @@ export default definePreview({
   parameters: {
     layout: "centered",
     a11y: {
-      // "todo" surfaces a11y violations in the UI without failing the test run.
-      // Promotion to "error" is blocked on app-wide color-contrast issues in the
-      // design tokens (muted-foreground text ~4.34:1, default badge ~3.76:1),
-      // which also trip the pre-existing UI stories — an app/theme refactor, not
-      // a story-level fix. Flip to "error" once those tokens are audited.
-      test: "todo",
+      // a11y violations FAIL the test run (every story is checked by axe via
+      // @storybook/addon-vitest). The design-token contrast audit is done
+      // (globals.css light-theme muted-foreground/destructive were darkened)
+      // and app landmarks/accessible-names were added. The escape hatch for
+      // genuine upstream issues we don't control (e.g. base-ui focus guards
+      // tripping `aria-hidden-focus` on open popups) is a per-story
+      // `parameters.a11y.config.rules` disable with a comment — never a global
+      // one.
+      test: "error",
     },
   },
   tags: ["autodocs"],

--- a/editors/web/.storybook/preview.tsx
+++ b/editors/web/.storybook/preview.tsx
@@ -75,12 +75,11 @@ export default definePreview({
   parameters: {
     layout: "centered",
     a11y: {
-      // "todo" surfaces a11y violations in the UI without failing the test run.
-      // Promotion to "error" is blocked on app-wide color-contrast issues in the
-      // design tokens (muted-foreground text ~4.34:1, default badge ~3.76:1),
-      // which also trip the pre-existing UI stories — an app/theme refactor, not
-      // a story-level fix. Flip to "error" once those tokens are audited.
-      test: "todo",
+      // axe runs on every story through @storybook/addon-vitest and a violation
+      // fails the test run. Disable a rule an upstream library owns in that
+      // story's `parameters.a11y.config.rules`, with a comment naming the
+      // cause, rather than here.
+      test: "error",
     },
   },
   tags: ["autodocs"],

--- a/editors/web/app/App.tsx
+++ b/editors/web/app/App.tsx
@@ -78,25 +78,30 @@ const App = () => {
   const isDebugging = mode.type === "debug";
 
   return (
-    <main className="flex flex-col h-screen bg-background">
+    <div className="flex flex-col h-screen bg-background">
       {!isDebugging && (
-        <EditToolbar
-          onRun={handleRun}
-          compilationStatus={compilationStatus}
-          compilationError={
-            compilationResult.type === "error"
-              ? compilationResult.message
-              : undefined
-          }
-          labels={
-            compilationResult.type === "idle" ? [] : compilationResult.labels
-          }
-          defaultEntrypoint={entrypoints[activeFile]}
-        />
+        <header>
+          <EditToolbar
+            onRun={handleRun}
+            compilationStatus={compilationStatus}
+            compilationError={
+              compilationResult.type === "error"
+                ? compilationResult.message
+                : undefined
+            }
+            labels={
+              compilationResult.type === "idle" ? [] : compilationResult.labels
+            }
+            defaultEntrypoint={entrypoints[activeFile]}
+          />
+        </header>
       )}
       <div className="flex flex-1 min-h-0">
         <FileSidebar />
-        <div className="flex-1 min-w-0 flex flex-col min-h-0">
+        <main
+          className="flex-1 min-w-0 flex flex-col min-h-0"
+          aria-label="Program editor"
+        >
           {isDebugging ? (
             <DebugLayout onEditorMount={handleEditorMount} />
           ) : (
@@ -107,9 +112,9 @@ const App = () => {
               />
             </div>
           )}
-        </div>
+        </main>
       </div>
-    </main>
+    </div>
   );
 };
 

--- a/editors/web/app/App.tsx
+++ b/editors/web/app/App.tsx
@@ -78,25 +78,27 @@ const App = () => {
   const isDebugging = mode.type === "debug";
 
   return (
-    <main className="flex flex-col h-screen bg-background">
+    <div className="flex flex-col h-screen bg-background">
       {!isDebugging && (
-        <EditToolbar
-          onRun={handleRun}
-          compilationStatus={compilationStatus}
-          compilationError={
-            compilationResult.type === "error"
-              ? compilationResult.message
-              : undefined
-          }
-          labels={
-            compilationResult.type === "idle" ? [] : compilationResult.labels
-          }
-          defaultEntrypoint={entrypoints[activeFile]}
-        />
+        <header>
+          <EditToolbar
+            onRun={handleRun}
+            compilationStatus={compilationStatus}
+            compilationError={
+              compilationResult.type === "error"
+                ? compilationResult.message
+                : undefined
+            }
+            labels={
+              compilationResult.type === "idle" ? [] : compilationResult.labels
+            }
+            defaultEntrypoint={entrypoints[activeFile]}
+          />
+        </header>
       )}
       <div className="flex flex-1 min-h-0">
         <FileSidebar />
-        <div className="flex-1 min-w-0 flex flex-col min-h-0">
+        <main className="flex-1 min-w-0 flex flex-col min-h-0">
           {isDebugging ? (
             <DebugLayout onEditorMount={handleEditorMount} />
           ) : (
@@ -107,9 +109,9 @@ const App = () => {
               />
             </div>
           )}
-        </div>
+        </main>
       </div>
-    </main>
+    </div>
   );
 };
 

--- a/editors/web/app/components/ui/select.stories.tsx
+++ b/editors/web/app/components/ui/select.stories.tsx
@@ -20,7 +20,7 @@ const meta = preview.meta({
 export const Default = meta.story({
   render: () => (
     <Select defaultValue="Apple">
-      <SelectTrigger className="w-48">
+      <SelectTrigger className="w-48" aria-label="Fruit">
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
@@ -37,7 +37,7 @@ export const Default = meta.story({
 export const Placeholder = meta.story({
   render: () => (
     <Select>
-      <SelectTrigger className="w-48">
+      <SelectTrigger className="w-48" aria-label="Fruit">
         <SelectValue placeholder="Pick a fruit…" />
       </SelectTrigger>
       <SelectContent>
@@ -52,12 +52,29 @@ export const Placeholder = meta.story({
 });
 
 export const SelectsAnItem = meta.story({
+  // The play function opens the base-ui select. Two axe rules fire on base-ui's
+  // own popup internals, both upstream behaviour we don't control:
+  //  - `aria-input-field-name`: base-ui doesn't propagate the trigger's
+  //    accessible name to its `role="listbox"` element.
+  //  - `aria-hidden-focus`: base-ui's aria-hidden focus-guard spans are
+  //    focusable while the popup is open.
+  // Disable just those two rules for this open-popup story.
+  parameters: {
+    a11y: {
+      config: {
+        rules: [
+          { id: "aria-input-field-name", enabled: false },
+          { id: "aria-hidden-focus", enabled: false },
+        ],
+      },
+    },
+  },
   render: () => {
     const ControlledSelect = () => {
       const [value, setValue] = useState<string | null>(null);
       return (
         <Select value={value} onValueChange={setValue}>
-          <SelectTrigger className="w-48">
+          <SelectTrigger className="w-48" aria-label="Fruit">
             <SelectValue placeholder="Pick a fruit…" />
           </SelectTrigger>
           <SelectContent>

--- a/editors/web/app/components/ui/select.stories.tsx
+++ b/editors/web/app/components/ui/select.stories.tsx
@@ -20,7 +20,7 @@ const meta = preview.meta({
 export const Default = meta.story({
   render: () => (
     <Select defaultValue="Apple">
-      <SelectTrigger className="w-48">
+      <SelectTrigger className="w-48" aria-label="Fruit">
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
@@ -37,7 +37,7 @@ export const Default = meta.story({
 export const Placeholder = meta.story({
   render: () => (
     <Select>
-      <SelectTrigger className="w-48">
+      <SelectTrigger className="w-48" aria-label="Fruit">
         <SelectValue placeholder="Pick a fruit…" />
       </SelectTrigger>
       <SelectContent>
@@ -52,12 +52,28 @@ export const Placeholder = meta.story({
 });
 
 export const SelectsAnItem = meta.story({
+  // The play function ends on the click that closes the select, and
+  // SelectContent's exit transition (`data-closed:animate-out … duration-100`)
+  // keeps the popup and base-ui's focus guards in the DOM while axe runs. On
+  // @base-ui/react 1.7.0 `SelectList` carries `role="listbox"` without an
+  // accessible name (it drops the trigger's) and `FocusGuard` renders
+  // `tabIndex=0` `aria-hidden` spans.
+  parameters: {
+    a11y: {
+      config: {
+        rules: [
+          { id: "aria-input-field-name", enabled: false },
+          { id: "aria-hidden-focus", enabled: false },
+        ],
+      },
+    },
+  },
   render: () => {
     const ControlledSelect = () => {
       const [value, setValue] = useState<string | null>(null);
       return (
         <Select value={value} onValueChange={setValue}>
-          <SelectTrigger className="w-48">
+          <SelectTrigger className="w-48" aria-label="Fruit">
             <SelectValue placeholder="Pick a fruit…" />
           </SelectTrigger>
           <SelectContent>

--- a/editors/web/app/computer.tsx
+++ b/editors/web/app/computer.tsx
@@ -109,7 +109,7 @@ const Label: React.FC<{ label: string }> = ({ label }) => (
 );
 
 const RegisterBadge: React.FC<{ register: RegisterId }> = ({ register }) => (
-  <Badge className={`font-semibold ${REGISTER_COLORS[register]} text-white`}>
+  <Badge className={`font-semibold ${REGISTER_COLORS[register]} text-black`}>
     {register}
   </Badge>
 );
@@ -236,7 +236,11 @@ export const MemoryViewer = memo(
       );
 
       return (
-        <div className="overflow-auto flex-1 min-h-0" ref={parentRef}>
+        <div
+          className="overflow-auto flex-1 min-h-0"
+          ref={parentRef}
+          tabIndex={0}
+        >
           <div
             className="font-mono text-xs w-full relative"
             style={{ height: `${rowVirtualizer.getTotalSize()}px` }}

--- a/editors/web/app/computer.tsx
+++ b/editors/web/app/computer.tsx
@@ -109,7 +109,7 @@ const Label: React.FC<{ label: string }> = ({ label }) => (
 );
 
 const RegisterBadge: React.FC<{ register: RegisterId }> = ({ register }) => (
-  <Badge className={`font-semibold ${REGISTER_COLORS[register]} text-white`}>
+  <Badge className={`font-semibold ${REGISTER_COLORS[register]} text-black`}>
     {register}
   </Badge>
 );
@@ -135,11 +135,20 @@ type MemoryViewerProps = {
   pointers?: Pointers;
   /** Called when user scrolls highlight address out of the visible range */
   onUserScroll?: () => void;
+  /**
+   * Names the scroll container. axe's `scrollable-region-focusable` requires
+   * the container to be keyboard focusable, which puts it in the tab order,
+   * where it needs a name.
+   */
+  labelledBy?: string;
 };
 
 export const MemoryViewer = memo(
   forwardRef<MemoryViewerRef, MemoryViewerProps>(
-    ({ computer, highlight, labels, pointers, onUserScroll }, ref) => {
+    (
+      { computer, highlight, labels, pointers, onUserScroll, labelledBy },
+      ref,
+    ) => {
       // TanStack Virtual relies on re-renders; a memoized virtualizer serves stale rows.
       "use no memo";
       const displayFormat = useDisplayStore((s) => s.format);
@@ -238,7 +247,13 @@ export const MemoryViewer = memo(
       );
 
       return (
-        <div className="overflow-auto flex-1 min-h-0" ref={parentRef}>
+        <div
+          className="overflow-auto flex-1 min-h-0"
+          ref={parentRef}
+          role="group"
+          aria-labelledby={labelledBy}
+          tabIndex={0}
+        >
           <div
             className="font-mono text-xs w-full relative"
             style={{ height: `${rowVirtualizer.getTotalSize()}px` }}

--- a/editors/web/app/debug-sidebar.tsx
+++ b/editors/web/app/debug-sidebar.tsx
@@ -102,7 +102,12 @@ export const RegisterPanel: React.FC<{
   };
 
   return (
-    <div role="region" aria-label="Registers" className="font-mono text-xs">
+    <div
+      role="region"
+      aria-label="Registers"
+      tabIndex={-1}
+      className="font-mono text-xs"
+    >
       <SectionHeader className="font-sans flex items-center justify-between">
         Registers
         <FormatSwitcher />

--- a/editors/web/app/debug-toolbar.tsx
+++ b/editors/web/app/debug-toolbar.tsx
@@ -125,7 +125,13 @@ export const DebugToolbarInner: React.FC<{
       >
         <Tooltip>
           <TooltipTrigger
-            render={<SelectTrigger size="xs" className="w-24 font-mono" />}
+            render={
+              <SelectTrigger
+                size="xs"
+                className="w-24 font-mono"
+                aria-label="Clock speed"
+              />
+            }
           >
             <GaugeIcon data-icon="inline-start" />
             <SelectValue />
@@ -197,7 +203,11 @@ export const DebugToolbarInner: React.FC<{
               if (v !== null) onFileChange(v);
             }}
           >
-            <SelectTrigger size="xs" className="font-mono w-36">
+            <SelectTrigger
+              size="xs"
+              className="font-mono w-36"
+              aria-label="Active file"
+            >
               <SelectValue />
             </SelectTrigger>
             <SelectContent align="end">

--- a/editors/web/app/edit-toolbar.stories.tsx
+++ b/editors/web/app/edit-toolbar.stories.tsx
@@ -54,6 +54,15 @@ export const Success = meta.story({
     compilationStatus: "success",
     labels: ["main", "loop", "end"],
   },
+  // The play function leaves the base-ui entrypoint listbox popup open. base-ui
+  // does not propagate the trigger's accessible name to its `role="listbox"`
+  // element, so axe's `aria-input-field-name` rule fires on the popup — upstream
+  // base-ui behaviour we don't control. Disable just that rule for this story.
+  parameters: {
+    a11y: {
+      config: { rules: [{ id: "aria-input-field-name", enabled: false }] },
+    },
+  },
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
     // Open the entrypoint select (portal-rendered on document.body).

--- a/editors/web/app/edit-toolbar.stories.tsx
+++ b/editors/web/app/edit-toolbar.stories.tsx
@@ -54,6 +54,15 @@ export const Success = meta.story({
     compilationStatus: "success",
     labels: ["main", "loop", "end"],
   },
+  // SelectContent's exit transition keeps the popup in the DOM while axe runs,
+  // and on @base-ui/react 1.7.0 its `role="listbox"` element carries no
+  // accessible name, so `aria-input-field-name` fires. The focus guards have
+  // unmounted by this point; see select.stories.tsx, where they have not.
+  parameters: {
+    a11y: {
+      config: { rules: [{ id: "aria-input-field-name", enabled: false }] },
+    },
+  },
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
     // Open the entrypoint select (portal-rendered on document.body).

--- a/editors/web/app/file-sidebar.tsx
+++ b/editors/web/app/file-sidebar.tsx
@@ -270,6 +270,7 @@ export const FileSidebarView: React.FC<FileSidebarViewProps> = ({
         ref={uploadInputRef}
         type="file"
         multiple
+        aria-label="Upload files"
         className="sr-only"
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           if (e.target.files) onUpload(Array.from(e.target.files));

--- a/editors/web/app/file-sidebar.tsx
+++ b/editors/web/app/file-sidebar.tsx
@@ -112,6 +112,7 @@ export const FileSidebarView: React.FC<FileSidebarViewProps> = ({
       ref={dropZoneRef}
       role="navigation"
       aria-label="Files"
+      tabIndex={-1}
       className="relative flex flex-col w-48 border-r border-border p-2"
       {...dropZoneProps}
     >

--- a/editors/web/app/file-sidebar.tsx
+++ b/editors/web/app/file-sidebar.tsx
@@ -271,6 +271,7 @@ export const FileSidebarView: React.FC<FileSidebarViewProps> = ({
         ref={uploadInputRef}
         type="file"
         multiple
+        aria-label="Upload files"
         className="sr-only"
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           if (e.target.files) onUpload(Array.from(e.target.files));

--- a/editors/web/app/globals.css
+++ b/editors/web/app/globals.css
@@ -17,10 +17,10 @@
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
+  --muted-foreground: oklch(0.52 0 0);
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.58 0.22 27);
+  --destructive: oklch(0.52 0.22 27);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);

--- a/editors/web/app/globals.css
+++ b/editors/web/app/globals.css
@@ -17,10 +17,10 @@
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
+  --muted-foreground: oklch(0.52 0 0);
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.58 0.22 27);
+  --destructive: oklch(0.52 0.21 27);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);

--- a/editors/web/app/memory-panel.tsx
+++ b/editors/web/app/memory-panel.tsx
@@ -158,6 +158,7 @@ export const MemoryPanel: React.FC<MemoryPanelProps> = memo(
         <div
           role="region"
           aria-label="Memory"
+          tabIndex={-1}
           className="flex-1 overflow-hidden flex flex-col"
         >
           <SectionHeader className="border-b shrink-0">Memory</SectionHeader>

--- a/editors/web/app/memory-panel.tsx
+++ b/editors/web/app/memory-panel.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useRef } from "react";
+import { memo, useCallback, useId, useMemo, useRef } from "react";
 import {
   ADDRESS_WIDTH,
   type ComputerInterface,
@@ -95,6 +95,7 @@ const LabelList: React.FC<{
 export const MemoryPanel: React.FC<MemoryPanelProps> = memo(
   ({ computer, labels, following, onFollow }) => {
     const viewerRef = useRef<MemoryViewerRef>(null);
+    const headingId = useId();
     const registers = useRegisters(computer);
 
     // Derive the address to follow in the viewer (null = not following, no highlight)
@@ -161,9 +162,12 @@ export const MemoryPanel: React.FC<MemoryPanelProps> = memo(
           tabIndex={-1}
           className="flex-1 overflow-hidden flex flex-col"
         >
-          <SectionHeader className="border-b shrink-0">Memory</SectionHeader>
+          <SectionHeader id={headingId} className="border-b shrink-0">
+            Memory
+          </SectionHeader>
           <MemoryViewer
             ref={viewerRef}
+            labelledBy={headingId}
             computer={computer}
             highlight={highlight}
             labels={labels}

--- a/editors/web/app/panel-resize-handle.stories.tsx
+++ b/editors/web/app/panel-resize-handle.stories.tsx
@@ -9,8 +9,15 @@ const meta = preview.meta({
   parameters: { layout: "fullscreen" },
 });
 
+// react-resizable-panels marks a panel's content as a scrollable region; in the
+// vertical demo axe then wants keyboard access to it (`scrollable-region-
+// focusable`). tabIndex makes this story fixture focusable; it is harmless in
+// the horizontal demo where the region isn't flagged.
 const PanelBody = ({ label }: { label: string }) => (
-  <div className="flex h-full items-center justify-center bg-muted/30 text-sm text-muted-foreground">
+  <div
+    tabIndex={0}
+    className="flex h-full items-center justify-center bg-muted/30 text-sm text-muted-foreground"
+  >
     {label}
   </div>
 );

--- a/editors/web/app/panel-resize-handle.stories.tsx
+++ b/editors/web/app/panel-resize-handle.stories.tsx
@@ -9,8 +9,13 @@ const meta = preview.meta({
   parameters: { layout: "fullscreen" },
 });
 
+// react-resizable-panels makes a panel's content a scroll container, so axe's
+// `scrollable-region-focusable` requires it to be keyboard reachable.
 const PanelBody = ({ label }: { label: string }) => (
-  <div className="flex h-full items-center justify-center bg-muted/30 text-sm text-muted-foreground">
+  <div
+    tabIndex={0}
+    className="flex h-full items-center justify-center bg-muted/30 text-sm text-muted-foreground"
+  >
     {label}
   </div>
 );

--- a/editors/web/app/serial-console.tsx
+++ b/editors/web/app/serial-console.tsx
@@ -24,7 +24,11 @@ export const SerialConsoleShell: React.FC<{
   onClear: () => void;
   children: React.ReactNode;
 }> = ({ onClear, children }) => (
-  <div className="flex flex-col h-full border-t bg-background">
+  <div
+    role="region"
+    aria-label="Serial console"
+    className="flex flex-col h-full border-t bg-background"
+  >
     <div className="flex shrink-0 items-center gap-1.5 border-b px-2.5 py-1">
       <TerminalIcon className="size-3.5 text-muted-foreground" />
       <span className="text-xs font-medium text-muted-foreground">

--- a/editors/web/app/serial-console.tsx
+++ b/editors/web/app/serial-console.tsx
@@ -24,7 +24,12 @@ export const SerialConsoleShell: React.FC<{
   onClear: () => void;
   children: React.ReactNode;
 }> = ({ onClear, children }) => (
-  <div className="flex flex-col h-full border-t bg-background">
+  <div
+    role="region"
+    aria-label="Serial console"
+    tabIndex={-1}
+    className="flex flex-col h-full border-t bg-background"
+  >
     <div className="flex shrink-0 items-center gap-1.5 border-b px-2.5 py-1">
       <TerminalIcon className="size-3.5 text-muted-foreground" />
       <span className="text-xs font-medium text-muted-foreground">

--- a/editors/web/app/theme-switcher.tsx
+++ b/editors/web/app/theme-switcher.tsx
@@ -22,6 +22,12 @@ const ICONS = {
 
 const LABELS = { light: "Light", system: "System", dark: "Dark" } as const;
 
+const ARIA_LABELS = {
+  light: "Light theme",
+  system: "System theme",
+  dark: "Dark theme",
+} as const;
+
 /** Pure theme toggle group; no store coupling. */
 export const ThemeToggle: React.FC<{
   value: ThemeValue;
@@ -40,7 +46,9 @@ export const ThemeToggle: React.FC<{
       const Icon = ICONS[t];
       return (
         <Tooltip key={t}>
-          <TooltipTrigger render={<ToggleGroupItem value={t} />}>
+          <TooltipTrigger
+            render={<ToggleGroupItem value={t} aria-label={ARIA_LABELS[t]} />}
+          >
             <Icon />
           </TooltipTrigger>
           <TooltipContent>{LABELS[t]}</TooltipContent>

--- a/editors/web/app/theme-switcher.tsx
+++ b/editors/web/app/theme-switcher.tsx
@@ -40,7 +40,11 @@ export const ThemeToggle: React.FC<{
       const Icon = ICONS[t];
       return (
         <Tooltip key={t}>
-          <TooltipTrigger render={<ToggleGroupItem value={t} />}>
+          <TooltipTrigger
+            render={
+              <ToggleGroupItem value={t} aria-label={`${LABELS[t]} theme`} />
+            }
+          >
             <Icon />
           </TooltipTrigger>
           <TooltipContent>{LABELS[t]}</TooltipContent>


### PR DESCRIPTION
Follow-up to #1007, in three commits.

**1. Contrast tokens (light theme).** `--muted-foreground` goes from `oklch(0.556 0 0)` to `oklch(0.52 0 0)`: 4.99:1 on `--muted` and 5.51:1 on `--background`, up from 4.35:1. `--destructive` goes from `oklch(0.58 0.22 27)` to `oklch(0.52 0.21 27)`: 5.13:1 as text on the `destructive/10` chip tint, up from 4.09:1. Chroma drops one step along with lightness because `oklch(0.52 0.22 27)` sits outside the sRGB gamut and each display would map it differently. The dark theme passes on every surface that uses these tokens. No component paints a solid `bg-destructive` fill, so the darker red changes text, rings and tints only.

**2. Landmarks.** The app used to wrap toolbars, sidebar and content in one `<main>`. The edit toolbar now sits in a `<header>`, `<main>` wraps the editor and debug layouts, and the serial console becomes a named region. The Registers, Memory and Labels regions and the Files nav existed before. The four named landmarks carry `tabIndex={-1}` so #1009 can move focus to them. Screen-reader outline in debug mode: main, then the regions "Registers", "Labels", "Memory" and "Serial console", each with a unique name.

**3. Accessible names and axe enforcement.** Register badges switch to black text: white measured 3.76:1 on blue-500 and worse on emerald and amber, black measures at least 4.77:1 on all four. The icon-only theme toggles get `aria-label`s derived from their tooltip text, and the clock-speed select, active-file select and hidden upload input get names. The memory scroll container becomes a focusable `role="group"` labelled by the "Memory" header, which satisfies `scrollable-region-focusable`. Storybook's a11y level moves from `todo` to `error`, so an axe failure fails `test-storybook` and CI. Three per-story rule disables remain, all for base-ui 1.7.0 internals: the popup's unnamed `role="listbox"` element, and the focus-guard `aria-hidden` spans that the exit transition keeps mounted. I re-checked each disable on its own and documented it in the story. None are global.

**Verification**: 66/66 Storybook tests with a11y at error level, 29/29 Playwright e2e, `check`, `knip` and `build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
