### PR TITLE
Add app-wide keyboard shortcuts (TanStack Hotkeys pilot)

### DIFF
--- a/editors/web/app/App.tsx
+++ b/editors/web/app/App.tsx
@@ -1,16 +1,31 @@
 import { useMonaco } from "@monaco-editor/react";
 import type * as monaco from "monaco-editor";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AppShortcuts } from "./app-shortcuts";
 import { DebugLayout } from "./debug-layout";
-import { EditToolbar } from "./edit-toolbar";
+import { EditToolbar, pickEntrypoint } from "./edit-toolbar";
 import { FileSidebar } from "./file-sidebar";
 import { useCompilation } from "./hooks/use-compilation";
+import type { ShortcutActions } from "./hooks/use-app-shortcuts";
+import { ShortcutsHelpDialog } from "./keyboard-shortcuts";
 import { stripLeadingSlash } from "./lib/file-paths";
 import { setRunCommandHandler } from "./lib/lsp-monaco";
 import { getMonacoFiles } from "./lib/monaco-sync";
 import { MultiFileEditor } from "./multi-file-editor";
 import { useAppStore } from "./stores/app-store";
 import { useFileStore } from "./stores/file-store";
+
+/**
+ * Move focus to a landmark region by its accessible name (from the a11y pass).
+ * Regions aren't tabbable by default, so give them a programmatic-only
+ * tabindex the first time they're focused.
+ */
+function focusLandmark(label: string): void {
+  const el = document.querySelector<HTMLElement>(`[aria-label="${label}"]`);
+  if (!el) return;
+  if (!el.hasAttribute("tabindex")) el.setAttribute("tabindex", "-1");
+  el.focus();
+}
 
 const App = () => {
   const monacoInstance = useMonaco();
@@ -21,6 +36,8 @@ const App = () => {
   const mode = useAppStore((s) => s.mode);
   const setEntrypoint = useFileStore((s) => s.setEntrypoint);
   const entrypoints = useFileStore((s) => s.entrypoints);
+
+  const [helpOpen, setHelpOpen] = useState(false);
 
   const { compilationResult, compilationStatus } = useCompilation(
     activeFile,
@@ -61,24 +78,129 @@ const App = () => {
   // the file store.
   useEffect(() => {
     setRunCommandHandler(({ path, label }) => {
-      const { mode, stopDebug } = useAppStore.getState();
-      if (mode.type === "debug") stopDebug();
+      const { mode: session, stopDebug } = useAppStore.getState();
+      if (session.type === "debug") stopDebug();
       runFile(path, label);
     });
     return () => setRunCommandHandler(null);
   }, [runFile]);
 
+  // --- shortcut handlers -----------------------------------------------------
+
+  // Run at the default entrypoint (the same choice the Run button preselects).
+  const runDefault = useCallback(() => {
+    if (compilationResult.type !== "success") return;
+    const entrypoint = pickEntrypoint(
+      compilationResult.labels,
+      entrypoints[activeFile],
+    );
+    if (entrypoint) handleRun(entrypoint);
+  }, [compilationResult, entrypoints, activeFile, handleRun]);
+  // Monaco commands are registered once at editor mount, so read the latest
+  // run handler through a ref to avoid a stale closure across recompiles.
+  const runDefaultRef = useRef(runDefault);
+  runDefaultRef.current = runDefault;
+
+  // Execution controls read the live session from the store, so they stay
+  // stable across renders and mirror the debug toolbar's guards.
+  const step = useCallback(() => {
+    const { mode: session } = useAppStore.getState();
+    if (session.type !== "debug") return;
+    if (session.computer.getStatus() !== "paused") return;
+    session.computer.step(1);
+  }, []);
+
+  const runPause = useCallback(() => {
+    const { mode: session } = useAppStore.getState();
+    if (session.type !== "debug") return;
+    const status = session.computer.getStatus();
+    if (status === "running") session.computer.pause();
+    else if (status === "paused") session.computer.run();
+  }, []);
+
+  const stop = useCallback(() => {
+    const { mode: session, stopDebug } = useAppStore.getState();
+    if (session.type === "debug") stopDebug();
+  }, []);
+
+  const focusSecondary = useCallback(() => {
+    const { mode: session } = useAppStore.getState();
+    focusLandmark(session.type === "debug" ? "Registers" : "Files");
+  }, []);
+
+  const focusEditor = useCallback(() => {
+    editorRef.current?.focus();
+  }, []);
+  const focusMemory = useCallback(() => {
+    focusLandmark("Memory");
+  }, []);
+  const focusSerial = useCallback(() => {
+    focusLandmark("Serial console");
+  }, []);
+  const openHelp = useCallback(() => {
+    setHelpOpen(true);
+  }, []);
+
+  // Stable handler bundle: only `runDefault` changes (per recompile), so the
+  // memoized <AppShortcuts> leaf stays put while the help dialog is open.
+  const actions = useMemo<ShortcutActions>(
+    () => ({
+      run: runDefault,
+      stop,
+      step,
+      runPause,
+      focusEditor,
+      focusSecondary,
+      focusMemory,
+      focusSerial,
+      help: openHelp,
+    }),
+    [
+      runDefault,
+      stop,
+      step,
+      runPause,
+      focusEditor,
+      focusSecondary,
+      focusMemory,
+      focusSerial,
+      openHelp,
+    ],
+  );
+
   const handleEditorMount = useCallback(
     (editor: monaco.editor.IStandaloneCodeEditor) => {
       editorRef.current = editor;
+      if (!monacoInstance) return;
+      const { KeyMod, KeyCode } = monacoInstance;
+      // Mirror the shortcuts Monaco would otherwise swallow while it owns
+      // keydown. Bind execution keys only in the (read-only) debug editor so
+      // they don't shadow Monaco's own F8 while editing; bind Run only while
+      // editing (debug Mod+Enter is a no-op by design).
+      if (useAppStore.getState().mode.type === "debug") {
+        editor.addCommand(KeyCode.F8, () => {
+          step();
+        });
+        editor.addCommand(KeyCode.F9, () => {
+          runPause();
+        });
+        editor.addCommand(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Enter, () => {
+          stop();
+        });
+      } else {
+        editor.addCommand(KeyMod.CtrlCmd | KeyCode.Enter, () => {
+          runDefaultRef.current();
+        });
+      }
     },
-    [],
+    [monacoInstance, step, runPause, stop],
   );
 
   const isDebugging = mode.type === "debug";
 
   return (
     <div className="flex flex-col h-screen bg-background">
+      <AppShortcuts mode={mode.type} actions={actions} />
       {!isDebugging && (
         <header>
           <EditToolbar
@@ -114,6 +236,7 @@ const App = () => {
           )}
         </main>
       </div>
+      <ShortcutsHelpDialog open={helpOpen} onOpenChange={setHelpOpen} />
     </div>
   );
 };

--- a/editors/web/app/App.tsx
+++ b/editors/web/app/App.tsx
@@ -1,16 +1,32 @@
 import { useMonaco } from "@monaco-editor/react";
 import type * as monaco from "monaco-editor";
-import { useCallback, useEffect, useRef } from "react";
+import { KeyCode, KeyMod } from "monaco-editor/editor/editor.api.js";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AppShortcuts } from "./app-shortcuts";
 import { DebugLayout } from "./debug-layout";
-import { EditToolbar } from "./edit-toolbar";
+import { EditToolbar, pickEntrypoint } from "./edit-toolbar";
 import { FileSidebar } from "./file-sidebar";
 import { useCompilation } from "./hooks/use-compilation";
+import type { ShortcutActions } from "./hooks/use-app-shortcuts";
+import { ShortcutsHelpDialog } from "./keyboard-shortcuts";
 import { stripLeadingSlash } from "./lib/file-paths";
 import { setRunCommandHandler } from "./lib/lsp-monaco";
 import { getMonacoFiles } from "./lib/monaco-sync";
 import { MultiFileEditor } from "./multi-file-editor";
 import { useAppStore } from "./stores/app-store";
 import { useFileStore } from "./stores/file-store";
+
+/**
+ * Move focus to a landmark region by its accessible name. Targets carry
+ * `tabIndex={-1}` to take programmatic focus, and the selector matches only the
+ * landmark roles, keeping a same-named control out of the match.
+ */
+function focusLandmark(label: string): void {
+  const el = document.querySelector<HTMLElement>(
+    `[role="region"][aria-label="${label}"], [role="navigation"][aria-label="${label}"]`,
+  );
+  el?.focus();
+}
 
 const App = () => {
   const monacoInstance = useMonaco();
@@ -21,6 +37,8 @@ const App = () => {
   const mode = useAppStore((s) => s.mode);
   const setEntrypoint = useFileStore((s) => s.setEntrypoint);
   const entrypoints = useFileStore((s) => s.entrypoints);
+
+  const [helpOpen, setHelpOpen] = useState(false);
 
   const { compilationResult, compilationStatus } = useCompilation(
     activeFile,
@@ -61,24 +79,134 @@ const App = () => {
   // the file store.
   useEffect(() => {
     setRunCommandHandler(({ path, label }) => {
-      const { mode, stopDebug } = useAppStore.getState();
-      if (mode.type === "debug") stopDebug();
+      const { mode: session, stopDebug } = useAppStore.getState();
+      if (session.type === "debug") stopDebug();
       runFile(path, label);
     });
     return () => setRunCommandHandler(null);
   }, [runFile]);
 
+  // --- shortcut handlers -----------------------------------------------------
+
+  // Run at the default entrypoint (the same choice the Run button preselects).
+  const runDefault = useCallback(() => {
+    if (compilationResult.type !== "success") return;
+    const entrypoint = pickEntrypoint(
+      compilationResult.labels,
+      entrypoints[activeFile],
+    );
+    if (entrypoint) handleRun(entrypoint);
+  }, [compilationResult, entrypoints, activeFile, handleRun]);
+  // `runDefault` changes on every recompile, but its callers register once:
+  // Monaco commands at editor mount, and the hotkey registrations keyed off
+  // `actions`. They call the stable `run` below, which reads the ref.
+  const runDefaultRef = useRef(runDefault);
+  useEffect(() => {
+    runDefaultRef.current = runDefault;
+  }, [runDefault]);
+
+  const run = useCallback(() => {
+    runDefaultRef.current();
+  }, []);
+
+  // Execution controls read the live session from the store, so they stay
+  // stable across renders and mirror the debug toolbar's guards.
+  const step = useCallback(() => {
+    const { mode: session } = useAppStore.getState();
+    if (session.type !== "debug") return;
+    if (session.computer.getStatus() !== "paused") return;
+    session.computer.step(1);
+  }, []);
+
+  const runPause = useCallback(() => {
+    const { mode: session } = useAppStore.getState();
+    if (session.type !== "debug") return;
+    const status = session.computer.getStatus();
+    if (status === "running") session.computer.pause();
+    else if (status === "paused") session.computer.run();
+  }, []);
+
+  const stop = useCallback(() => {
+    const { mode: session, stopDebug } = useAppStore.getState();
+    if (session.type === "debug") stopDebug();
+  }, []);
+
+  const focusSecondary = useCallback(() => {
+    const { mode: session } = useAppStore.getState();
+    focusLandmark(session.type === "debug" ? "Registers" : "Files");
+  }, []);
+
+  const focusEditor = useCallback(() => {
+    editorRef.current?.focus();
+  }, []);
+  const focusMemory = useCallback(() => {
+    focusLandmark("Memory");
+  }, []);
+  const focusSerial = useCallback(() => {
+    focusLandmark("Serial console");
+  }, []);
+  const openHelp = useCallback(() => {
+    setHelpOpen(true);
+  }, []);
+
+  // The handlers are stable, so `actions` keeps its identity and the memoized
+  // <AppShortcuts> leaf re-renders only when the mode changes.
+  const actions = useMemo<ShortcutActions>(
+    () => ({
+      run,
+      stop,
+      step,
+      runPause,
+      focusEditor,
+      focusSecondary,
+      focusMemory,
+      focusSerial,
+      help: openHelp,
+    }),
+    [
+      run,
+      stop,
+      step,
+      runPause,
+      focusEditor,
+      focusSecondary,
+      focusMemory,
+      focusSerial,
+      openHelp,
+    ],
+  );
+
   const handleEditorMount = useCallback(
     (editor: monaco.editor.IStandaloneCodeEditor) => {
       editorRef.current = editor;
+      // Mirror the shortcuts Monaco swallows while it owns keydown. Execution
+      // keys bind only in the read-only debug editor, where they can't shadow
+      // Monaco's own F8; Run binds only while editing, since Mod+Enter does
+      // nothing during a debug session.
+      if (useAppStore.getState().mode.type === "debug") {
+        editor.addCommand(KeyCode.F8, () => {
+          step();
+        });
+        editor.addCommand(KeyCode.F9, () => {
+          runPause();
+        });
+        editor.addCommand(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Enter, () => {
+          stop();
+        });
+      } else {
+        editor.addCommand(KeyMod.CtrlCmd | KeyCode.Enter, () => {
+          run();
+        });
+      }
     },
-    [],
+    [run, step, runPause, stop],
   );
 
   const isDebugging = mode.type === "debug";
 
   return (
     <div className="flex flex-col h-screen bg-background">
+      <AppShortcuts mode={mode.type} actions={actions} />
       {!isDebugging && (
         <header>
           <EditToolbar
@@ -111,6 +239,7 @@ const App = () => {
           )}
         </main>
       </div>
+      <ShortcutsHelpDialog open={helpOpen} onOpenChange={setHelpOpen} />
     </div>
   );
 };

--- a/editors/web/app/app-shortcuts.tsx
+++ b/editors/web/app/app-shortcuts.tsx
@@ -1,0 +1,22 @@
+import { memo } from "react";
+import {
+  type ShortcutActions,
+  useAppShortcuts,
+} from "./hooks/use-app-shortcuts";
+
+/**
+ * Registers the app's global keyboard shortcuts. Isolated into a memoized leaf
+ * that renders nothing: the hotkey library re-syncs options during render (it
+ * calls the registry store's `setState`), so keeping registration out of any
+ * component that re-renders while the help dialog is open prevents a
+ * "setState during render" warning against the dialog's live subscription.
+ * With stable `actions`, this only re-renders on a genuine mode/handler change.
+ */
+export const AppShortcuts = memo<{
+  mode: "edit" | "debug";
+  actions: ShortcutActions;
+}>(({ mode, actions }) => {
+  useAppShortcuts(mode, actions);
+  return null;
+});
+AppShortcuts.displayName = "AppShortcuts";

--- a/editors/web/app/app-shortcuts.tsx
+++ b/editors/web/app/app-shortcuts.tsx
@@ -1,0 +1,22 @@
+import { memo } from "react";
+import {
+  type ShortcutActions,
+  useAppShortcuts,
+} from "./hooks/use-app-shortcuts";
+
+/**
+ * Registers the app's global keyboard shortcuts from a memoized leaf that
+ * renders nothing and re-renders only when the mode changes (`actions` is
+ * stable). The hotkey library calls the registry store's `setState` during
+ * render, which warns "setState during render" against the help dialog's live
+ * subscription when registration sits in a component that re-renders while the
+ * dialog is open.
+ */
+export const AppShortcuts = memo<{
+  mode: "edit" | "debug";
+  actions: ShortcutActions;
+}>(({ mode, actions }) => {
+  useAppShortcuts(mode, actions);
+  return null;
+});
+AppShortcuts.displayName = "AppShortcuts";

--- a/editors/web/app/hooks/use-app-hotkey.ts
+++ b/editors/web/app/hooks/use-app-hotkey.ts
@@ -1,0 +1,47 @@
+// Thin wrapper around @tanstack/react-hotkeys (alpha). ALL app code imports
+// keyboard-shortcut functionality from here and never from the library
+// directly, so if the alpha API shifts under us the blast radius is this one
+// file. Keep the surface small: only re-export/wrap what the app uses.
+import {
+  formatForDisplay,
+  type FormatDisplayOptions,
+  type HotkeyRegistrationView,
+  type RegisterableHotkey,
+  type UseHotkeyDefinition,
+  type UseHotkeyOptions,
+  useHotkeyRegistrations,
+  useHotkeys,
+} from "@tanstack/react-hotkeys";
+
+/** A single hotkey registration: `{ hotkey, callback, options }`. */
+export type AppHotkeyDefinition = UseHotkeyDefinition;
+export type { HotkeyRegistrationView, RegisterableHotkey };
+
+/**
+ * Register a dynamic list of hotkeys. Callbacks/options are synced on every
+ * render by the underlying manager, so closures never go stale and toggling
+ * `enabled` updates the existing registration in place.
+ */
+export function useAppHotkeys(
+  hotkeys: AppHotkeyDefinition[],
+  commonOptions?: UseHotkeyOptions,
+): void {
+  useHotkeys(hotkeys, commonOptions);
+}
+
+/**
+ * Live view of every registered hotkey (including soft-disabled ones), used to
+ * drive the shortcuts help dialog. Returns only the `hotkeys` array; sequences
+ * are unused in this app.
+ */
+export function useAppHotkeyRegistrations(): HotkeyRegistrationView[] {
+  return useHotkeyRegistrations().hotkeys;
+}
+
+/** Format a hotkey for display (⌘-symbols on macOS, `Ctrl+…` elsewhere). */
+export function formatHotkey(
+  hotkey: RegisterableHotkey,
+  options?: FormatDisplayOptions,
+): string {
+  return formatForDisplay(hotkey, options);
+}

--- a/editors/web/app/hooks/use-app-hotkey.ts
+++ b/editors/web/app/hooks/use-app-hotkey.ts
@@ -1,0 +1,47 @@
+// Thin wrapper around @tanstack/react-hotkeys (alpha). App code imports
+// keyboard shortcuts from here and never from the library, so an alpha API
+// change lands in this one file. Keep the surface small: wrap only what the
+// app uses.
+import {
+  formatForDisplay,
+  type FormatDisplayOptions,
+  type HotkeyRegistrationView,
+  type RegisterableHotkey,
+  type UseHotkeyDefinition,
+  type UseHotkeyOptions,
+  useHotkeyRegistrations,
+  useHotkeys,
+} from "@tanstack/react-hotkeys";
+
+/** A single hotkey registration: `{ hotkey, callback, options }`. */
+export type AppHotkeyDefinition = UseHotkeyDefinition;
+export type { HotkeyRegistrationView, RegisterableHotkey };
+
+/**
+ * Register a dynamic list of hotkeys. The manager re-syncs callbacks and
+ * options on every render, so closures stay current and toggling `enabled`
+ * updates the existing registration in place.
+ */
+export function useAppHotkeys(
+  hotkeys: AppHotkeyDefinition[],
+  commonOptions?: UseHotkeyOptions,
+): void {
+  useHotkeys(hotkeys, commonOptions);
+}
+
+/**
+ * Live view of every registered hotkey, soft-disabled ones included, for the
+ * shortcuts help dialog. Returns the `hotkeys` array; this app registers no
+ * sequences.
+ */
+export function useAppHotkeyRegistrations(): HotkeyRegistrationView[] {
+  return useHotkeyRegistrations().hotkeys;
+}
+
+/** Format a hotkey for display (⌘-symbols on macOS, `Ctrl+…` elsewhere). */
+export function formatHotkey(
+  hotkey: RegisterableHotkey,
+  options?: FormatDisplayOptions,
+): string {
+  return formatForDisplay(hotkey, options);
+}

--- a/editors/web/app/hooks/use-app-shortcuts.ts
+++ b/editors/web/app/hooks/use-app-shortcuts.ts
@@ -1,0 +1,33 @@
+import { SHORTCUTS, type ShortcutActionId } from "../shortcuts";
+import { type AppHotkeyDefinition, useAppHotkeys } from "./use-app-hotkey";
+
+/** One handler per action id; the same handler backs its toolbar button. */
+export type ShortcutActions = Record<ShortcutActionId, () => void>;
+
+/**
+ * Registers every app shortcut at the document level. Each is always
+ * registered (so the help dialog can list the full set) but soft-disabled via
+ * `enabled` when its scope doesn't match the current mode. Focus shortcuts opt
+ * out of `ignoreInputs` so panel navigation works even from a focused field.
+ *
+ * Execution shortcuts (F8/F9) are ALSO mirrored into Monaco by the caller —
+ * the library can't see keydown while the editor's textarea is focused.
+ */
+export function useAppShortcuts(
+  mode: "edit" | "debug",
+  actions: ShortcutActions,
+): void {
+  const definitions: AppHotkeyDefinition[] = SHORTCUTS.map((spec) => ({
+    hotkey: spec.hotkey,
+    callback: () => {
+      actions[spec.action]();
+    },
+    options: {
+      enabled: spec.scope === "any" || spec.scope === mode,
+      meta: { name: spec.name, description: spec.description },
+      ...(spec.group === "Panels" ? { ignoreInputs: false } : {}),
+    },
+  }));
+
+  useAppHotkeys(definitions);
+}

--- a/editors/web/app/hooks/use-app-shortcuts.ts
+++ b/editors/web/app/hooks/use-app-shortcuts.ts
@@ -1,0 +1,33 @@
+import { SHORTCUTS, type ShortcutActionId } from "../shortcuts";
+import { type AppHotkeyDefinition, useAppHotkeys } from "./use-app-hotkey";
+
+/** One handler per action id; the same handler backs its toolbar button. */
+export type ShortcutActions = Record<ShortcutActionId, () => void>;
+
+/**
+ * Registers every app shortcut at the document level. A shortcut outside the
+ * current mode's scope stays registered, so the help dialog lists the full set,
+ * and `enabled` soft-disables it. Focus shortcuts opt out of `ignoreInputs` to
+ * reach panels from a focused field.
+ *
+ * The caller mirrors the execution shortcuts (F8/F9) into Monaco, which owns
+ * keydown while the editor's textarea has focus.
+ */
+export function useAppShortcuts(
+  mode: "edit" | "debug",
+  actions: ShortcutActions,
+): void {
+  const definitions: AppHotkeyDefinition[] = SHORTCUTS.map((spec) => ({
+    hotkey: spec.hotkey,
+    callback: () => {
+      actions[spec.action]();
+    },
+    options: {
+      enabled: spec.scope === "any" || spec.scope === mode,
+      meta: { name: spec.name, description: spec.description },
+      ...(spec.group === "Panels" ? { ignoreInputs: false } : {}),
+    },
+  }));
+
+  useAppHotkeys(definitions);
+}

--- a/editors/web/app/keyboard-shortcuts.stories.tsx
+++ b/editors/web/app/keyboard-shortcuts.stories.tsx
@@ -1,0 +1,135 @@
+import preview from "#.storybook/preview";
+import { useState } from "react";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
+
+import { Button } from "./components/ui/button";
+import {
+  type ShortcutGroup,
+  ShortcutsDialogView,
+  ShortcutsSheet,
+} from "./keyboard-shortcuts";
+
+// Fixed, hand-written groups so the presentational components render
+// deterministically without touching the live hotkey registry.
+const GROUPS: ShortcutGroup[] = [
+  {
+    title: "Session",
+    rows: [
+      {
+        name: "Run",
+        description: "Start debugging at the default entrypoint",
+        keys: ["⌘ ⏎"],
+      },
+      {
+        name: "Stop",
+        description: "Stop debugging and return to the editor",
+        keys: ["⌘ ⇧ ⏎"],
+      },
+    ],
+  },
+  {
+    title: "Execution",
+    rows: [
+      {
+        name: "Step",
+        description: "Execute a single instruction",
+        keys: ["F8"],
+      },
+      {
+        name: "Run / Pause",
+        description: "Toggle continuous execution",
+        keys: ["F9"],
+      },
+    ],
+  },
+  {
+    title: "Panels",
+    rows: [
+      {
+        name: "Focus editor",
+        description: "Move focus to the program editor",
+        keys: ["⌥ 1"],
+      },
+      {
+        name: "Focus registers / files",
+        description: "Focus the registers panel or the file list",
+        keys: ["⌥ 2"],
+      },
+    ],
+  },
+  {
+    title: "Help",
+    rows: [
+      {
+        name: "Keyboard shortcuts",
+        description: "Open this help dialog",
+        keys: ["⌘ /", "?"],
+      },
+    ],
+  },
+];
+
+const meta = preview.meta({
+  title: "Organisms/ShortcutsHelp",
+  component: ShortcutsSheet,
+  parameters: { layout: "padded" },
+});
+
+export const Sheet = meta.story({
+  args: { groups: GROUPS },
+  decorators: [
+    (Story) => (
+      <div className="w-[28rem] rounded-md border p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("heading", { name: "Session" }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Step")).toBeInTheDocument();
+    // The Help action lists both of its keys.
+    await expect(canvas.getByText("⌘ /")).toBeInTheDocument();
+    await expect(canvas.getByText("?")).toBeInTheDocument();
+  },
+});
+
+const DialogHarness = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button
+        onClick={() => {
+          setOpen(true);
+        }}
+      >
+        Show shortcuts
+      </Button>
+      <ShortcutsDialogView open={open} onOpenChange={setOpen} groups={GROUPS} />
+    </>
+  );
+};
+
+export const InDialog = meta.story({
+  render: () => <DialogHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Show shortcuts" }),
+    );
+    // base-ui portals the dialog onto document.body.
+    const dialog = await screen.findByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(
+      within(dialog).getByRole("heading", { name: "Keyboard shortcuts" }),
+    ).toBeVisible();
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Close" }),
+    );
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+  },
+});

--- a/editors/web/app/keyboard-shortcuts.stories.tsx
+++ b/editors/web/app/keyboard-shortcuts.stories.tsx
@@ -1,0 +1,139 @@
+import preview from "#.storybook/preview";
+import { useState } from "react";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
+
+import { Button } from "./components/ui/button";
+import {
+  type ShortcutGroup,
+  ShortcutsDialogView,
+  ShortcutsSheet,
+} from "./keyboard-shortcuts";
+
+// Hand-written groups, so the presentational components render a fixed set of
+// rows without the live hotkey registry.
+const GROUPS: ShortcutGroup[] = [
+  {
+    title: "Session",
+    rows: [
+      {
+        name: "Run",
+        description: "Start debugging at the default entrypoint",
+        keys: ["⌘ ⏎"],
+      },
+      {
+        name: "Stop",
+        description: "Stop debugging and return to the editor",
+        keys: ["⌘ ⇧ ⏎"],
+      },
+    ],
+  },
+  {
+    title: "Execution",
+    rows: [
+      {
+        name: "Step",
+        description: "Execute a single instruction",
+        keys: ["F8"],
+        unavailable: "debug only",
+      },
+      {
+        name: "Run / Pause",
+        description: "Toggle continuous execution",
+        keys: ["F9"],
+      },
+    ],
+  },
+  {
+    title: "Panels",
+    rows: [
+      {
+        name: "Focus editor",
+        description: "Move focus to the program editor",
+        keys: ["⌥ 1"],
+      },
+      {
+        name: "Focus registers / files",
+        description: "Focus the registers panel or the file list",
+        keys: ["⌥ 2"],
+      },
+    ],
+  },
+  {
+    title: "Help",
+    rows: [
+      {
+        name: "Keyboard shortcuts",
+        description: "Open this help dialog",
+        keys: ["⌘ /", "?"],
+      },
+    ],
+  },
+];
+
+const meta = preview.meta({
+  title: "Organisms/ShortcutsHelp",
+  component: ShortcutsSheet,
+  parameters: { layout: "padded" },
+});
+
+export const Sheet = meta.story({
+  args: { groups: GROUPS },
+  decorators: [
+    (Story) => (
+      <div className="w-[28rem] rounded-md border p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole("heading", { name: "Session" }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Step")).toBeInTheDocument();
+    // The Help action lists both of its keys.
+    await expect(canvas.getByText("⌘ /")).toBeInTheDocument();
+    await expect(canvas.getByText("?")).toBeInTheDocument();
+    // A shortcut that doesn't apply in the current mode says so.
+    await expect(canvas.getByText("debug only")).toBeInTheDocument();
+  },
+});
+
+const DialogHarness = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button
+        onClick={() => {
+          setOpen(true);
+        }}
+      >
+        Show shortcuts
+      </Button>
+      <ShortcutsDialogView open={open} onOpenChange={setOpen} groups={GROUPS} />
+    </>
+  );
+};
+
+export const InDialog = meta.story({
+  render: () => <DialogHarness />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Show shortcuts" }),
+    );
+    // base-ui renders the dialog in a portal on document.body, mounting it at
+    // opacity 0 and fading it in, so poll for visibility.
+    const dialog = await screen.findByRole("dialog");
+    await waitFor(() => expect(dialog).toBeVisible());
+    await expect(
+      within(dialog).getByRole("heading", { name: "Keyboard shortcuts" }),
+    ).toBeVisible();
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Close" }),
+    );
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+  },
+});

--- a/editors/web/app/keyboard-shortcuts.tsx
+++ b/editors/web/app/keyboard-shortcuts.tsx
@@ -1,0 +1,197 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { XIcon } from "lucide-react";
+import { useMemo } from "react";
+import { Button } from "./components/ui/button";
+import {
+  formatHotkey,
+  type HotkeyRegistrationView,
+  useAppHotkeyRegistrations,
+} from "./hooks/use-app-hotkey";
+import { cn } from "./lib/utils";
+import { SHORTCUT_GROUP_ORDER, SHORTCUTS } from "./shortcuts";
+
+interface ShortcutRow {
+  name: string;
+  description?: string;
+  /** Display strings for the key(s) that trigger this action. */
+  keys: string[];
+}
+
+export interface ShortcutGroup {
+  title: string;
+  rows: ShortcutRow[];
+}
+
+const Kbd: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <kbd className="inline-flex h-5 min-w-5 items-center justify-center rounded border border-border bg-muted px-1.5 font-mono text-[11px] font-medium text-muted-foreground">
+    {children}
+  </kbd>
+);
+
+/**
+ * Pure, presentational shortcuts list: grouped rows of name + description and
+ * their key chip(s). No coupling to the hotkey registry, so it renders
+ * standalone in stories and tests.
+ */
+export const ShortcutsSheet: React.FC<{ groups: ShortcutGroup[] }> = ({
+  groups,
+}) => (
+  <div className="flex flex-col gap-4">
+    {groups.map((group) => (
+      <section
+        key={group.title}
+        aria-label={group.title}
+        className="flex flex-col gap-1.5"
+      >
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {group.title}
+        </h3>
+        <ul className="flex flex-col">
+          {group.rows.map((row) => (
+            <li
+              key={row.name}
+              className="flex items-center justify-between gap-6 py-1"
+            >
+              <span className="min-w-0">
+                <span className="block text-sm text-foreground">
+                  {row.name}
+                </span>
+                {row.description && (
+                  <span className="block text-xs text-muted-foreground">
+                    {row.description}
+                  </span>
+                )}
+              </span>
+              <span className="flex shrink-0 items-center gap-1.5">
+                {row.keys.map((key, index) => (
+                  <span key={key} className="flex items-center gap-1.5">
+                    {index > 0 && (
+                      <span className="text-[11px] text-muted-foreground">
+                        or
+                      </span>
+                    )}
+                    <Kbd>{key}</Kbd>
+                  </span>
+                ))}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    ))}
+  </div>
+);
+
+/** Pure dialog chrome (title, description, close); the body is `children`. */
+const ShortcutsDialogChrome: React.FC<{
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}> = ({ open, onOpenChange, children }) => (
+  <Dialog.Root open={open} onOpenChange={onOpenChange}>
+    <Dialog.Portal>
+      <Dialog.Backdrop
+        className={cn(
+          "fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        )}
+      />
+      <Dialog.Popup
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 flex max-h-[85vh] w-full max-w-md -translate-x-1/2 -translate-y-1/2 flex-col gap-4 overflow-y-auto rounded-xl bg-background p-4 ring-1 ring-foreground/10 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+        )}
+      >
+        <div className="flex items-center justify-between gap-4">
+          <Dialog.Title className="text-base font-medium">
+            Keyboard shortcuts
+          </Dialog.Title>
+          <Dialog.Close
+            render={
+              <Button variant="ghost" size="icon-xs" aria-label="Close">
+                <XIcon />
+              </Button>
+            }
+          />
+        </div>
+        <Dialog.Description className="sr-only">
+          A list of every available keyboard shortcut, grouped by area.
+        </Dialog.Description>
+        {children}
+      </Dialog.Popup>
+    </Dialog.Portal>
+  </Dialog.Root>
+);
+
+/**
+ * Pure dialog fed groups via props (no registry). Kept separate from the
+ * connected component so it can be storied and axe-checked deterministically.
+ */
+export const ShortcutsDialogView: React.FC<{
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  groups: ShortcutGroup[];
+}> = ({ open, onOpenChange, groups }) => (
+  <ShortcutsDialogChrome open={open} onOpenChange={onOpenChange}>
+    <ShortcutsSheet groups={groups} />
+  </ShortcutsDialogChrome>
+);
+
+/**
+ * Builds the display groups from the live registry: dedupes by action name
+ * (merging the keys of, e.g., `⌘/` and `?`), keeps only currently registered
+ * shortcuts, and orders groups/rows per `SHORTCUTS`.
+ */
+function buildShortcutGroups(
+  registrations: HotkeyRegistrationView[],
+): ShortcutGroup[] {
+  const specNames = new Set(SHORTCUTS.map((spec) => spec.name));
+  const keysByName = new Map<string, string[]>();
+
+  for (const registration of registrations) {
+    const name = registration.options.meta?.name;
+    if (!name || !specNames.has(name)) continue;
+    const display = formatHotkey(registration.hotkey);
+    const keys = keysByName.get(name) ?? [];
+    if (!keys.includes(display)) keys.push(display);
+    keysByName.set(name, keys);
+  }
+
+  const groups: ShortcutGroup[] = [];
+  for (const title of SHORTCUT_GROUP_ORDER) {
+    const rows: ShortcutRow[] = [];
+    const seen = new Set<string>();
+    for (const spec of SHORTCUTS) {
+      if (spec.group !== title || seen.has(spec.name)) continue;
+      const keys = keysByName.get(spec.name);
+      if (!keys || keys.length === 0) continue;
+      seen.add(spec.name);
+      rows.push({ name: spec.name, description: spec.description, keys });
+    }
+    if (rows.length > 0) groups.push({ title, rows });
+  }
+  return groups;
+}
+
+/**
+ * Reads the live registry and renders the sheet. Mounted ONLY while the dialog
+ * is open: the registration hook re-`setOptions` during render, so a
+ * permanently-mounted subscriber would be updated mid-render on every app
+ * re-render. It is safe while open because registrations don't change then.
+ */
+const ConnectedShortcutsSheet: React.FC = () => {
+  const registrations = useAppHotkeyRegistrations();
+  const groups = useMemo(
+    () => buildShortcutGroups(registrations),
+    [registrations],
+  );
+  return <ShortcutsSheet groups={groups} />;
+};
+
+/** Connected help dialog: reads the live hotkey registry while open. */
+export const ShortcutsHelpDialog: React.FC<{
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}> = ({ open, onOpenChange }) => (
+  <ShortcutsDialogChrome open={open} onOpenChange={onOpenChange}>
+    {open && <ConnectedShortcutsSheet />}
+  </ShortcutsDialogChrome>
+);

--- a/editors/web/app/keyboard-shortcuts.tsx
+++ b/editors/web/app/keyboard-shortcuts.tsx
@@ -1,0 +1,227 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { XIcon } from "lucide-react";
+import { useMemo } from "react";
+import { Button } from "./components/ui/button";
+import {
+  formatHotkey,
+  type HotkeyRegistrationView,
+  useAppHotkeyRegistrations,
+} from "./hooks/use-app-hotkey";
+import { cn } from "./lib/utils";
+import {
+  SHORTCUT_GROUP_ORDER,
+  SHORTCUTS,
+  type ShortcutScope,
+} from "./shortcuts";
+
+interface ShortcutRow {
+  name: string;
+  description?: string;
+  /** Display strings for the key(s) that trigger this action. */
+  keys: string[];
+  /** Set when the shortcut is soft-disabled; says when it does work. */
+  unavailable?: string;
+}
+
+export interface ShortcutGroup {
+  title: string;
+  rows: ShortcutRow[];
+}
+
+const Kbd: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <kbd className="inline-flex h-5 min-w-5 items-center justify-center rounded border border-border bg-muted px-1.5 font-mono text-[11px] font-medium text-muted-foreground">
+    {children}
+  </kbd>
+);
+
+/**
+ * Pure, presentational shortcuts list: grouped rows of name + description and
+ * their key chip(s). No coupling to the hotkey registry, so it renders
+ * standalone in stories and tests.
+ */
+export const ShortcutsSheet: React.FC<{ groups: ShortcutGroup[] }> = ({
+  groups,
+}) => (
+  <div className="flex flex-col gap-4">
+    {groups.map((group) => (
+      <section
+        key={group.title}
+        aria-label={group.title}
+        className="flex flex-col gap-1.5"
+      >
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {group.title}
+        </h3>
+        <ul className="flex flex-col">
+          {group.rows.map((row) => (
+            <li
+              key={row.name}
+              className="flex items-center justify-between gap-6 py-1"
+            >
+              <span className="min-w-0">
+                <span
+                  className={cn(
+                    "block text-sm",
+                    row.unavailable
+                      ? "text-muted-foreground"
+                      : "text-foreground",
+                  )}
+                >
+                  {row.name}
+                </span>
+                {row.description && (
+                  <span className="block text-xs text-muted-foreground">
+                    {row.description}
+                  </span>
+                )}
+              </span>
+              <span className="flex shrink-0 items-center gap-1.5">
+                {row.unavailable && (
+                  <span className="text-[11px] text-muted-foreground">
+                    {row.unavailable}
+                  </span>
+                )}
+                {row.keys.map((key, index) => (
+                  <span key={key} className="flex items-center gap-1.5">
+                    {index > 0 && (
+                      <span className="text-[11px] text-muted-foreground">
+                        or
+                      </span>
+                    )}
+                    <Kbd>{key}</Kbd>
+                  </span>
+                ))}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    ))}
+  </div>
+);
+
+/** Pure dialog chrome (title, description, close); the body is `children`. */
+const ShortcutsDialogChrome: React.FC<{
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}> = ({ open, onOpenChange, children }) => (
+  <Dialog.Root open={open} onOpenChange={onOpenChange}>
+    <Dialog.Portal>
+      <Dialog.Backdrop
+        className={cn(
+          "fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        )}
+      />
+      <Dialog.Popup
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 flex max-h-[85vh] w-full max-w-md -translate-x-1/2 -translate-y-1/2 flex-col gap-4 overflow-y-auto rounded-xl bg-background p-4 ring-1 ring-foreground/10 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+        )}
+      >
+        <div className="flex items-center justify-between gap-4">
+          <Dialog.Title className="text-base font-medium">
+            Keyboard shortcuts
+          </Dialog.Title>
+          <Dialog.Close
+            render={
+              <Button variant="ghost" size="icon-xs" aria-label="Close">
+                <XIcon />
+              </Button>
+            }
+          />
+        </div>
+        <Dialog.Description className="sr-only">
+          A list of every available keyboard shortcut, grouped by area.
+        </Dialog.Description>
+        {children}
+      </Dialog.Popup>
+    </Dialog.Portal>
+  </Dialog.Root>
+);
+
+/**
+ * Dialog fed groups through props, with no registry behind it, so stories and
+ * axe checks get a fixed set of rows.
+ */
+export const ShortcutsDialogView: React.FC<{
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  groups: ShortcutGroup[];
+}> = ({ open, onOpenChange, groups }) => (
+  <ShortcutsDialogChrome open={open} onOpenChange={onOpenChange}>
+    <ShortcutsSheet groups={groups} />
+  </ShortcutsDialogChrome>
+);
+
+/** Shown next to a shortcut that is soft-disabled in the current mode. */
+const UNAVAILABLE_LABEL: Record<ShortcutScope, string> = {
+  debug: "debug only",
+  edit: "edit only",
+  any: "unavailable",
+};
+
+/**
+ * Builds the display groups from `SHORTCUTS`, deduped by action name, which
+ * merges the keys of `⌘/` and `?`. The registry supplies each shortcut's
+ * `enabled` state and its registrations carry no back-reference to a spec, so
+ * this joins them on the canonical combo string, the same whether the spec
+ * wrote the hotkey as a string or an object.
+ */
+function buildShortcutGroups(
+  registrations: HotkeyRegistrationView[],
+): ShortcutGroup[] {
+  const enabledByHotkey = new Map<string, boolean>();
+  for (const registration of registrations) {
+    enabledByHotkey.set(
+      formatHotkey(registration.hotkey),
+      registration.options.enabled !== false,
+    );
+  }
+
+  const groups: ShortcutGroup[] = [];
+  for (const title of SHORTCUT_GROUP_ORDER) {
+    const rows: ShortcutRow[] = [];
+    const seen = new Set<string>();
+    for (const spec of SHORTCUTS) {
+      if (spec.group !== title || seen.has(spec.name)) continue;
+      seen.add(spec.name);
+      const specs = SHORTCUTS.filter((other) => other.name === spec.name);
+      const enabled = specs.some(
+        (other) => enabledByHotkey.get(formatHotkey(other.hotkey)) ?? false,
+      );
+      rows.push({
+        name: spec.name,
+        description: spec.description,
+        keys: specs.map((other) => other.display ?? formatHotkey(other.hotkey)),
+        ...(enabled ? {} : { unavailable: UNAVAILABLE_LABEL[spec.scope] }),
+      });
+    }
+    if (rows.length > 0) groups.push({ title, rows });
+  }
+  return groups;
+}
+
+/**
+ * Reads the live registry and renders the sheet. It mounts only while the
+ * dialog is open, because the registration hook writes to the registry store
+ * during render (see app-shortcuts.tsx) and a lifetime subscriber would take
+ * that write mid-render on every <AppShortcuts> re-render.
+ */
+const ConnectedShortcutsSheet: React.FC = () => {
+  const registrations = useAppHotkeyRegistrations();
+  const groups = useMemo(
+    () => buildShortcutGroups(registrations),
+    [registrations],
+  );
+  return <ShortcutsSheet groups={groups} />;
+};
+
+/** Connected help dialog: reads the live hotkey registry while open. */
+export const ShortcutsHelpDialog: React.FC<{
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}> = ({ open, onOpenChange }) => (
+  <ShortcutsDialogChrome open={open} onOpenChange={onOpenChange}>
+    {open && <ConnectedShortcutsSheet />}
+  </ShortcutsDialogChrome>
+);

--- a/editors/web/app/shortcuts.ts
+++ b/editors/web/app/shortcuts.ts
@@ -1,0 +1,137 @@
+// The single source of truth for the app's keyboard shortcuts. Both the
+// registration hook (`useAppShortcuts`) and the help dialog read from here.
+//
+// Key choices (see the report / README of the a11y branch for the rationale):
+//   - Mode/help/focus shortcuts fire at the document level via the library.
+//   - Execution shortcuts (F8/F9) are ALSO mirrored into Monaco (App wires
+//     `editor.addCommand`) because Monaco owns keydown while the editor is
+//     focused and the library's `ignoreInputs` default suppresses bare keys
+//     inside the editor's textarea.
+//   - Focus shortcuts use `Alt+1..4` rather than `Mod+1..4`: on macOS the
+//     browser binds `Cmd+<digit>` to tab switching, so `Mod` (=Cmd there)
+//     would never reach us. `Alt+<digit>` is free on every platform and the
+//     library matches it via `event.code` even though Option mangles the glyph.
+import type { RegisterableHotkey } from "./hooks/use-app-hotkey";
+
+/** Stable id linking a spec to its handler in `ShortcutActions`. */
+export type ShortcutActionId =
+  | "run"
+  | "stop"
+  | "step"
+  | "runPause"
+  | "focusEditor"
+  | "focusSecondary"
+  | "focusMemory"
+  | "focusSerial"
+  | "help";
+
+/** Heading buckets in the help dialog, in display order. */
+export type ShortcutGroupTitle = "Session" | "Execution" | "Panels" | "Help";
+
+export const SHORTCUT_GROUP_ORDER: ShortcutGroupTitle[] = [
+  "Session",
+  "Execution",
+  "Panels",
+  "Help",
+];
+
+/** Which app mode a shortcut is active in (`"any"` = both). */
+type ShortcutScope = "edit" | "debug" | "any";
+
+export interface ShortcutSpec {
+  action: ShortcutActionId;
+  hotkey: RegisterableHotkey;
+  /** Human-readable name; also the merge key when one action has two keys. */
+  name: string;
+  description: string;
+  group: ShortcutGroupTitle;
+  scope: ShortcutScope;
+}
+
+export const SHORTCUTS: ShortcutSpec[] = [
+  {
+    action: "run",
+    hotkey: "Mod+Enter",
+    name: "Run",
+    description: "Start debugging at the default entrypoint",
+    group: "Session",
+    scope: "edit",
+  },
+  {
+    action: "stop",
+    hotkey: "Mod+Shift+Enter",
+    name: "Stop",
+    description: "Stop debugging and return to the editor",
+    group: "Session",
+    scope: "debug",
+  },
+  {
+    action: "step",
+    hotkey: "F8",
+    name: "Step",
+    description: "Execute a single instruction",
+    group: "Execution",
+    scope: "debug",
+  },
+  {
+    action: "runPause",
+    hotkey: "F9",
+    name: "Run / Pause",
+    description: "Toggle continuous execution",
+    group: "Execution",
+    scope: "debug",
+  },
+  {
+    action: "focusEditor",
+    hotkey: "Alt+1",
+    name: "Focus editor",
+    description: "Move focus to the program editor",
+    group: "Panels",
+    scope: "any",
+  },
+  {
+    action: "focusSecondary",
+    hotkey: "Alt+2",
+    name: "Focus registers / files",
+    description:
+      "Focus the registers panel (debugging) or the file list (editing)",
+    group: "Panels",
+    scope: "any",
+  },
+  {
+    action: "focusMemory",
+    hotkey: "Alt+3",
+    name: "Focus memory",
+    description: "Move focus to the memory panel",
+    group: "Panels",
+    scope: "debug",
+  },
+  {
+    action: "focusSerial",
+    hotkey: "Alt+4",
+    name: "Focus serial console",
+    description: "Move focus to the serial console",
+    group: "Panels",
+    scope: "debug",
+  },
+  {
+    action: "help",
+    hotkey: "Mod+/",
+    name: "Keyboard shortcuts",
+    description: "Open this help dialog",
+    group: "Help",
+    scope: "any",
+  },
+  {
+    // `?` is Shift+/, so the KeyboardEvent's key is "?" with shiftKey true;
+    // the library matches on `key` and requires shift to agree, hence the
+    // explicit `shift: true`. It is deliberately a bare-ish combo so
+    // `ignoreInputs` keeps it from firing while typing.
+    action: "help",
+    hotkey: { key: "?", shift: true },
+    name: "Keyboard shortcuts",
+    description: "Open this help dialog",
+    group: "Help",
+    scope: "any",
+  },
+];

--- a/editors/web/app/shortcuts.ts
+++ b/editors/web/app/shortcuts.ts
@@ -1,0 +1,140 @@
+// The single source of truth for the app's keyboard shortcuts. The
+// registration hook (`useAppShortcuts`) and the help dialog both read from
+// here; that hook covers document-level registration and the F8/F9 mirroring
+// into Monaco.
+//
+// Focus shortcuts use `Alt+1..4`: macOS browsers bind `Cmd+<digit>` to tab
+// switching, so `Mod+<digit>` would never reach the page. `Alt+<digit>` is free
+// on every platform, and the library matches it via `event.code`, which the
+// glyph Option produces doesn't affect.
+import type { RegisterableHotkey } from "./hooks/use-app-hotkey";
+
+/** Stable id linking a spec to its handler in `ShortcutActions`. */
+export type ShortcutActionId =
+  | "run"
+  | "stop"
+  | "step"
+  | "runPause"
+  | "focusEditor"
+  | "focusSecondary"
+  | "focusMemory"
+  | "focusSerial"
+  | "help";
+
+/** Heading buckets in the help dialog, in display order. */
+export type ShortcutGroupTitle = "Session" | "Execution" | "Panels" | "Help";
+
+export const SHORTCUT_GROUP_ORDER: ShortcutGroupTitle[] = [
+  "Session",
+  "Execution",
+  "Panels",
+  "Help",
+];
+
+/** Which app mode a shortcut is active in (`"any"` = both). */
+export type ShortcutScope = "edit" | "debug" | "any";
+
+export interface ShortcutSpec {
+  action: ShortcutActionId;
+  hotkey: RegisterableHotkey;
+  /** Human-readable name; also the merge key when one action has two keys. */
+  name: string;
+  description: string;
+  group: ShortcutGroupTitle;
+  scope: ShortcutScope;
+  /**
+   * Overrides the formatted key chip in the help dialog, for combos whose
+   * canonical form doesn't match how the key is typed or named.
+   */
+  display?: string;
+}
+
+export const SHORTCUTS: ShortcutSpec[] = [
+  {
+    action: "run",
+    hotkey: "Mod+Enter",
+    name: "Run",
+    description: "Start debugging at the default entrypoint",
+    group: "Session",
+    scope: "edit",
+  },
+  {
+    action: "stop",
+    hotkey: "Mod+Shift+Enter",
+    name: "Stop",
+    description: "Stop debugging and return to the editor",
+    group: "Session",
+    scope: "debug",
+  },
+  {
+    action: "step",
+    hotkey: "F8",
+    name: "Step",
+    description: "Execute a single instruction",
+    group: "Execution",
+    scope: "debug",
+  },
+  {
+    action: "runPause",
+    hotkey: "F9",
+    name: "Run / Pause",
+    description: "Toggle continuous execution",
+    group: "Execution",
+    scope: "debug",
+  },
+  {
+    action: "focusEditor",
+    hotkey: "Alt+1",
+    name: "Focus editor",
+    description: "Move focus to the program editor",
+    group: "Panels",
+    scope: "any",
+  },
+  {
+    action: "focusSecondary",
+    hotkey: "Alt+2",
+    name: "Focus registers / files",
+    description:
+      "Focus the registers panel (debugging) or the file list (editing)",
+    group: "Panels",
+    scope: "any",
+  },
+  {
+    action: "focusMemory",
+    hotkey: "Alt+3",
+    name: "Focus memory",
+    description: "Move focus to the memory panel",
+    group: "Panels",
+    scope: "debug",
+  },
+  {
+    action: "focusSerial",
+    hotkey: "Alt+4",
+    name: "Focus serial console",
+    description: "Move focus to the serial console",
+    group: "Panels",
+    scope: "debug",
+  },
+  {
+    action: "help",
+    hotkey: "Mod+/",
+    name: "Keyboard shortcuts",
+    description: "Open this help dialog",
+    group: "Help",
+    scope: "any",
+  },
+  {
+    // Typing `?` means Shift+/, so the event carries key "?" with shiftKey true
+    // and `matchesKeyboardEvent` needs the explicit `shift: true` to agree.
+    // With no Ctrl or Meta on it, the library's `ignoreInputs` default keeps it
+    // from firing in text inputs and Monaco's textarea, and `display` replaces
+    // the formatter's "⇧ ?", since the glyph implies the Shift.
+    action: "help",
+    hotkey: { key: "?", shift: true },
+    name: "Keyboard shortcuts",
+    description: "Open this help dialog",
+    group: "Help",
+    scope: "any",
+    display: "?",
+  },
+];

--- a/editors/web/e2e/keyboard.spec.ts
+++ b/editors/web/e2e/keyboard.spec.ts
@@ -1,0 +1,72 @@
+import {
+  enterDebugMode,
+  expect,
+  getCycleCount,
+  test,
+  waitForCompileSuccess,
+} from "./fixtures";
+
+// `Mod` resolves to the platform primary modifier; Playwright's
+// `ControlOrMeta` matches it (Meta on macOS, Control elsewhere), same as the
+// library's platform detection inside the page.
+const MOD = "ControlOrMeta";
+
+test.describe("Keyboard shortcuts", () => {
+  test("Mod+Enter starts a debug session from edit mode", async ({
+    cleanPage: page,
+  }) => {
+    await waitForCompileSuccess(page);
+    await page.keyboard.press(`${MOD}+Enter`);
+    await expect(page.getByRole("toolbar", { name: "Debug" })).toBeVisible();
+  });
+
+  test("Step shortcut (F8) advances the cycle counter", async ({
+    cleanPage: page,
+  }) => {
+    await enterDebugMode(page);
+    await expect.poll(() => getCycleCount(page)).toBe(0);
+    await page.keyboard.press("F8");
+    await expect.poll(() => getCycleCount(page)).toBeGreaterThan(0);
+  });
+
+  test("Mod+Shift+Enter returns to the editor", async ({
+    cleanPage: page,
+  }) => {
+    await enterDebugMode(page);
+    await page.keyboard.press(`${MOD}+Shift+Enter`);
+    await expect(page.getByRole("toolbar", { name: "Edit" })).toBeVisible();
+  });
+
+  test("help dialog opens with '?' and Mod+/ and closes", async ({
+    cleanPage: page,
+  }) => {
+    await waitForCompileSuccess(page);
+    // Move focus out of the Monaco editor (which owns Mod+/) so the document
+    // level shortcuts fire.
+    await page.getByRole("toolbar", { name: "Edit" }).click();
+
+    // Open with "?" (Shift+/).
+    await page.keyboard.press("Shift+Slash");
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByRole("heading", { name: "Keyboard shortcuts" }),
+    ).toBeVisible();
+    // Every group is present.
+    await expect(dialog.getByRole("heading", { name: "Session" })).toBeVisible();
+    await expect(
+      dialog.getByRole("heading", { name: "Panels" }),
+    ).toBeVisible();
+
+    // Escape closes it.
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+
+    // Re-open with Mod+/.
+    await page.getByRole("toolbar", { name: "Edit" }).click();
+    await page.keyboard.press(`${MOD}+Slash`);
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByRole("button", { name: "Close" }).click();
+    await expect(page.getByRole("dialog")).toBeHidden();
+  });
+});

--- a/editors/web/e2e/keyboard.spec.ts
+++ b/editors/web/e2e/keyboard.spec.ts
@@ -1,0 +1,85 @@
+import type { Page } from "@playwright/test";
+
+import {
+  enterDebugMode,
+  expect,
+  getCycleCount,
+  test,
+  waitForCompileSuccess,
+} from "./fixtures";
+
+// `Mod` resolves to the platform primary modifier; Playwright's
+// `ControlOrMeta` matches it (Meta on macOS, Control elsewhere), same as the
+// library's platform detection inside the page.
+const MOD = "ControlOrMeta";
+
+const blurActiveElement = async (page: Page): Promise<void> => {
+  await page.evaluate(() => {
+    (document.activeElement as HTMLElement | null)?.blur();
+  });
+};
+
+test.describe("Keyboard shortcuts", () => {
+  test("Mod+Enter starts a debug session from edit mode", async ({
+    cleanPage: page,
+  }) => {
+    await waitForCompileSuccess(page);
+    await page.keyboard.press(`${MOD}+Enter`);
+    await expect(page.getByRole("toolbar", { name: "Debug" })).toBeVisible();
+  });
+
+  test("Step shortcut (F8) advances the cycle counter", async ({
+    cleanPage: page,
+  }) => {
+    await enterDebugMode(page);
+    await expect.poll(() => getCycleCount(page)).toBe(0);
+    await page.keyboard.press("F8");
+    await expect.poll(() => getCycleCount(page)).toBeGreaterThan(0);
+  });
+
+  test("Mod+Shift+Enter returns to the editor", async ({
+    cleanPage: page,
+  }) => {
+    await enterDebugMode(page);
+    await page.keyboard.press(`${MOD}+Shift+Enter`);
+    await expect(page.getByRole("toolbar", { name: "Edit" })).toBeVisible();
+  });
+
+  test("help dialog opens with '?' and Mod+/ and closes", async ({
+    cleanPage: page,
+  }) => {
+    await waitForCompileSuccess(page);
+    // Move focus out of the Monaco editor so the document-level shortcuts
+    // fire: while its textarea has focus Monaco handles Mod+/ itself, and the
+    // library's `ignoreInputs` default suppresses `?` there.
+    await blurActiveElement(page);
+
+    // Open with "?" (Shift+/).
+    await page.keyboard.press("Shift+Slash");
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByRole("heading", { name: "Keyboard shortcuts" }),
+    ).toBeVisible();
+    // Every group is present.
+    await expect(dialog.getByRole("heading", { name: "Session" })).toBeVisible();
+    await expect(
+      dialog.getByRole("heading", { name: "Panels" }),
+    ).toBeVisible();
+    // The `?` combo is registered as Shift+? but shown as the bare glyph.
+    await expect(dialog.getByText("?", { exact: true })).toBeVisible();
+    // Execution shortcuts are soft-disabled while editing.
+    await expect(dialog.getByText("debug only").first()).toBeVisible();
+
+    // Escape closes it.
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+
+    // Re-open with Mod+/.
+    await blurActiveElement(page);
+    await page.keyboard.press(`${MOD}+Slash`);
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByRole("button", { name: "Close" }).click();
+    await expect(page.getByRole("dialog")).toBeHidden();
+  });
+});

--- a/editors/web/package.json
+++ b/editors/web/package.json
@@ -3,7 +3,11 @@
   "private": true,
   "type": "module",
   "imports": {
-    "#*": ["./*", "./*.ts", "./*.tsx"]
+    "#*": [
+      "./*",
+      "./*.ts",
+      "./*.tsx"
+    ]
   },
   "scripts": {
     "build:wasm": "wasm-pack build ../../crates/wasm --target web --out-dir ../../editors/web/pkg --out-name z33_web",
@@ -55,6 +59,7 @@
     "@base-ui/react": "^1.6.0",
     "@fontsource-variable/inter": "^5.2.8",
     "@monaco-editor/react": "^4.7.0",
+    "@tanstack/react-hotkeys": "0.10.0",
     "@tanstack/react-pacer": "^0.22.1",
     "@tanstack/react-virtual": "^3.14.5",
     "@xterm/addon-fit": "^0.11.0",

--- a/editors/web/package.json
+++ b/editors/web/package.json
@@ -56,6 +56,7 @@
     "@base-ui/react": "^1.7.0",
     "@fontsource-variable/inter": "^5.3.0",
     "@monaco-editor/react": "^4.7.0",
+    "@tanstack/react-hotkeys": "0.10.0",
     "@tanstack/react-pacer": "^0.23.0",
     "@tanstack/react-virtual": "^3.14.10",
     "@xterm/addon-fit": "^0.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-hotkeys':
+        specifier: 0.10.0
+        version: 0.10.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-pacer':
         specifier: ^0.22.1
         version: 0.22.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1823,9 +1826,20 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@tanstack/hotkeys@0.8.0':
+    resolution: {integrity: sha512-vqH7X9nb0MTJ/O08++dB5bP9jgj4+BIPOUu/U+6myG86lDsirZSVSobpq5UQpE7nBuk62i8eIYeOhd+OMl/UrA==}
+    engines: {node: '>=18'}
+
   '@tanstack/pacer@0.21.1':
     resolution: {integrity: sha512-hB01dd4rlsYcTCNP7wK186jgAe6K5qimgM1Y5Jtvz+9PUaILvpmeLLjmQNUNSO1l23lIt+CeQR6mO1mjlPvRtQ==}
     engines: {node: '>=18'}
+
+  '@tanstack/react-hotkeys@0.10.0':
+    resolution: {integrity: sha512-GwOSndI5j3qBVYTmgP1mYyRTnlxb2MS17cwGlsavSxMQPSnmDf+m3LzMIpRMs+3zzQMjg3cYhHsFYizYlFI2tw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
 
   '@tanstack/react-pacer@0.22.1':
     resolution: {integrity: sha512-CenQqK0GluSPIrnsG1yuD7w5uMSQ/4lI9AcGEFxBrRd66r260boWcYRIsS5+eHtXb238FoZYhKmJPGlhRzmHRw==}
@@ -5624,10 +5638,21 @@ snapshots:
 
   '@tanstack/devtools-event-client@0.4.3': {}
 
+  '@tanstack/hotkeys@0.8.0':
+    dependencies:
+      '@tanstack/store': 0.11.0
+
   '@tanstack/pacer@0.21.1':
     dependencies:
       '@tanstack/devtools-event-client': 0.4.3
       '@tanstack/store': 0.11.0
+
+  '@tanstack/react-hotkeys@0.10.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/hotkeys': 0.8.0
+      '@tanstack/react-store': 0.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@tanstack/react-pacer@0.22.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.56.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/react-hotkeys':
+        specifier: 0.10.0
+        version: 0.10.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-pacer':
         specifier: ^0.23.0
         version: 0.23.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -2239,9 +2242,20 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@tanstack/hotkeys@0.8.0':
+    resolution: {integrity: sha512-vqH7X9nb0MTJ/O08++dB5bP9jgj4+BIPOUu/U+6myG86lDsirZSVSobpq5UQpE7nBuk62i8eIYeOhd+OMl/UrA==}
+    engines: {node: '>=18'}
+
   '@tanstack/pacer@0.22.0':
     resolution: {integrity: sha512-Zq23KOn30tFiA6ZYWihs5x++ttHkOIcnIIjRrJq05tGrYx9+iHsmVaj8jb7UJVemEI+JRWGzJ9C+50YV4nRz0w==}
     engines: {node: '>=18'}
+
+  '@tanstack/react-hotkeys@0.10.0':
+    resolution: {integrity: sha512-GwOSndI5j3qBVYTmgP1mYyRTnlxb2MS17cwGlsavSxMQPSnmDf+m3LzMIpRMs+3zzQMjg3cYhHsFYizYlFI2tw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
 
   '@tanstack/react-pacer@0.23.0':
     resolution: {integrity: sha512-Ec3h+kT8kYlpGb1M8F7836q+udE/M2RmE8KLr1rhs+UDBgvxjfmyR2bIUeaDEe9Zn1YXNI986RbErXyr5fEJIg==}
@@ -6683,10 +6697,21 @@ snapshots:
 
   '@tanstack/devtools-event-client@0.5.0': {}
 
+  '@tanstack/hotkeys@0.8.0':
+    dependencies:
+      '@tanstack/store': 0.11.1
+
   '@tanstack/pacer@0.22.0':
     dependencies:
       '@tanstack/devtools-event-client': 0.5.0
       '@tanstack/store': 0.11.1
+
+  '@tanstack/react-hotkeys@0.10.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/hotkeys': 0.8.0
+      '@tanstack/react-store': 0.11.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   '@tanstack/react-pacer@0.23.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:


### PR DESCRIPTION
Stacked on #1008; GitHub retargets it to main when that merges. Pilots `@tanstack/react-hotkeys`, pinned exact at 0.10.0 (still the latest release, and alpha), behind one wrapper file, `app/hooks/use-app-hotkey.ts`, which is the only importer. Any API churn becomes a one-file fix.

**Shortcuts**, all listed in an in-app help sheet that opens with `?` or `Mod+/`:

| Key | Action | Mode |
|-----|--------|------|
| `Mod+Enter` | Run (start debugging at the default entrypoint) | edit |
| `Mod+Shift+Enter` | Stop, return to editor | debug |
| `F8` / `F9` | Step / Run–Pause toggle | debug |
| `Alt+1..4` | Focus editor / registers-or-files / memory / serial | mode-dependent |
| `?` or `Mod+/` | Shortcuts help dialog | any |

Key choices. `Alt+digit` rather than `Mod+digit`, because browsers own `Mod+digit` for tab switching. `F8`/`F9` rather than punctuation combos: the library's key union has no apostrophe, and Shift-punctuation depends on keyboard layout. Monaco swallows some keys while focused, so the edit editor mirrors `Mod+Enter` and the debug editor mirrors `F8`, `F9` and `Mod+Shift+Enter` through `editor.addCommand`, calling the same handlers. The mirrors import `KeyMod` and `KeyCode` from the static `monaco-editor` API, so they bind even when `useMonaco()` has not resolved at mount. Inside the editor, Monaco keeps `Mod+/` for toggle comment, and `?` opens the help there. The focus shortcuts find landmarks by role and accessible name; #1008 gives those landmarks `tabIndex={-1}`.

The help sheet is a pure `ShortcutsSheet` plus a connected dialog. Rows come from the spec table and join the live registry (`useHotkeyRegistrations`) on the canonical combo string to read each shortcut's `enabled` state. Shortcuts that don't apply in the current mode stay listed with a "debug only" or "edit only" hint. A spec can set `display`; the `?` spec uses it because the formatter would otherwise render `Shift+?`. The sheet has stories and passes axe at the enforced error level.

One library wart: `useHotkeys` writes to its registry store during render. Every shortcut handler is stable (`run` reads a ref that an effect keeps current, so a recompile never touches the registration), the registration lives in a memoized leaf, and the registry subscriber mounts only while the dialog is open. No setState-during-render warnings, and the React Compiler still optimises `App` because nothing reads a ref during render.

**Verification**: 68 Storybook tests across 21 files (a11y at error), 33 Playwright e2e including 4 keyboard tests that cover the `?` label and the "debug only" hint, `check`, `knip` and `build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
