### PR TITLE
Restore end of program register logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ cargo build --release
 [path to]/z33-cli run samples/fact.s main
 ```
 
+The emulator's logs, including the final register dump, print on stdout
+together with anything the program writes to the serial console. Pass
+`--log <file>` to append the logs to a file instead and keep stdout for the
+program's output:
+
+```sh
+[path to]/z33-cli run --log z33.log samples/fact.s main
+```
+
 ## Interactive mode
 
 ```sh

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -94,6 +94,8 @@ impl RunOpt {
             run_with_io(&mut computer)?;
         }
 
+        info!(registers = %computer.registers, "End of program");
+
         Ok(())
     }
 }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -74,7 +74,8 @@ impl RunOpt {
             preprocess_result.preprocessed_file_id,
         );
 
-        // Show all diagnostics (parse + compilation), resolved to original files
+        // Show all diagnostics (parse + compilation), resolved to original
+        // files
         if !compile_result.diagnostics.is_empty() {
             for diag in &compile_result.diagnostics {
                 let resolved = resolve_diagnostic_spans(diag, &source_map);

--- a/crates/cli/src/framing.rs
+++ b/crates/cli/src/framing.rs
@@ -87,7 +87,8 @@ mod tests {
 
     #[test]
     fn invalid_length_yields_none() {
-        // A non-numeric value fails to parse and the headers end with no length.
+        // A non-numeric value fails to parse and the headers end with no
+        // length.
         assert_eq!(read(b"Content-Length: abc\r\n\r\n"), None);
     }
 

--- a/crates/cli/src/interactive/helper.rs
+++ b/crates/cli/src/interactive/helper.rs
@@ -43,7 +43,8 @@ fn suggest(command: &Command, input: &[String]) -> (usize, HashSet<String>) {
 
     let index = input.len().saturating_sub(1);
 
-    // Find the curresponding positional arg if it exists and add suggestions for it
+    // Find the curresponding positional arg if it exists and add suggestions
+    // for it
     if let Some(arg) = command.get_positionals().nth(index) {
         let additional: Vec<&str> = match arg.get_id().as_str() {
             "register" | "address" => vec!["%a", "%b", "%sp", "%sr"],
@@ -85,12 +86,13 @@ impl<T: CommandFactory> Completer for RunHelper<T> {
             .bytes()
             .last()
             .filter(|&c| c == b' ' || c == b'\t')
-            .is_some(); // Line is considered "complete" if the last char is a space
+            .is_some(); // Line is considered "complete" if the last char is a
+                        // space
         if let Ok(mut words) = shell_words::split(line) {
             let app = T::command();
 
-            // If the last char was a space, insert an empty word to autocomplete the next
-            // word
+            // If the last char was a space, insert an empty word to
+            // autocomplete the next word
             if complete {
                 words.push(String::new());
             }
@@ -136,11 +138,12 @@ impl<T: CommandFactory> Hinter for RunHelper<T> {
             .bytes()
             .last()
             .filter(|&c| c == b' ' || c == b'\t')
-            .is_some(); // Line is considered "complete" if the last char is a space
+            .is_some(); // Line is considered "complete" if the last char is a
+                        // space
         let mut words = shell_words::split(line).ok()?;
 
-        // If the last char was a space, insert an empty word to autocomplete the next
-        // word
+        // If the last char was a space, insert an empty word to autocomplete
+        // the next word
         if complete {
             words.push(String::new());
         }

--- a/crates/cli/src/interactive/mod.rs
+++ b/crates/cli/src/interactive/mod.rs
@@ -197,8 +197,8 @@ impl Session {
             x => info!("{} breakpoints:", x),
         }
 
-        // This might be an unnecessary copy, but we want them to be sorted by address
-        // for readability
+        // This might be an unnecessary copy, but we want them to be sorted by
+        // address for readability
         let mut bp: Vec<_> = self.breakpoints.iter().copied().collect();
         bp.sort_unstable();
         for addr in bp {
@@ -225,8 +225,8 @@ impl Session {
             (false, false) => "  ",
         };
 
-        // Find the instruction in memory. This will be `None` if the address is to high
-        // or if the cell is not an instruction.
+        // Find the instruction in memory. This will be `None` if the address is
+        // to high or if the cell is not an instruction.
         let instruction = computer
             .memory
             .get(address)
@@ -473,7 +473,8 @@ pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) {
             },
 
             (_, true) => {
-                // Computer is halted but the user asked to continue, we just warn
+                // Computer is halted but the user asked to continue, we just
+                // warn
                 warn!("Computer is halted. Use \"exit\" to quit");
             }
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -72,32 +72,28 @@ fn main() {
     // Then, setup the tracing formatter for logging and instrumentation
     let registry = tracing_subscriber::Registry::default().with(opt.filter_layer());
 
-    // LSP and DAP use stdout for their protocols, and `run` streams the guest's
-    // serial output on stdout, so for all three logging must go to stderr to
-    // keep stdout clean.
-    let use_stderr = matches!(
-        opt.command,
-        Subcommand::Run(_) | Subcommand::Lsp(_) | Subcommand::Dap(_)
-    );
+    // LSP and DAP use stdout for their own protocol, so their logs go to
+    // stderr. `run` logs to stdout, interleaved with the program's serial
+    // output.
+    let use_stderr = matches!(opt.command, Subcommand::Lsp(_) | Subcommand::Dap(_));
 
     if opt.json {
-        let json_layer = tracing_subscriber::fmt::layer()
-            .json()
-            .with_writer(std::io::stderr);
-        registry.with(json_layer).init();
-    } else if use_stderr {
-        let fmt_layer = tracing_subscriber::fmt::layer()
-            .without_time()
-            .with_ansi(opt.should_use_colors())
-            .with_target(false)
-            .with_writer(std::io::stderr);
-        registry.with(fmt_layer).init();
+        let fmt_layer = tracing_subscriber::fmt::layer().json();
+        if use_stderr {
+            registry.with(fmt_layer.with_writer(std::io::stderr)).init();
+        } else {
+            registry.with(fmt_layer.with_writer(std::io::stdout)).init();
+        }
     } else {
         let fmt_layer = tracing_subscriber::fmt::layer()
             .without_time()
             .with_ansi(opt.should_use_colors())
             .with_target(false);
-        registry.with(fmt_layer).init();
+        if use_stderr {
+            registry.with(fmt_layer.with_writer(std::io::stderr)).init();
+        } else {
+            registry.with(fmt_layer.with_writer(std::io::stdout)).init();
+        }
     }
 
     // And run the command

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,9 +1,12 @@
-use std::io::IsTerminal;
+use std::fs::{File, OpenOptions};
+use std::io::{self, IsTerminal, Write};
 use std::process::exit;
 
-use clap::{ArgAction, ArgGroup, Parser};
+use camino::Utf8PathBuf;
+use clap::{ArgAction, ArgGroup, Parser, ValueHint};
 use tracing::error;
 use tracing_subscriber::filter::EnvFilter;
+use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::prelude::*;
 
 mod commands;
@@ -31,6 +34,10 @@ struct Opt {
     #[clap(short, long, action = ArgAction::SetTrue, global(true), group = "format")]
     json: bool,
 
+    /// Append the logs to this file instead of printing them
+    #[clap(long, global(true), value_hint = ValueHint::FilePath)]
+    log: Option<Utf8PathBuf>,
+
     #[clap(subcommand)]
     command: Subcommand,
 }
@@ -46,13 +53,19 @@ impl Opt {
         }
     }
 
-    fn should_use_colors(&self) -> bool {
+    /// `--color` and `--no-color` win. Without them, colors are on when the
+    /// target stream is a terminal, and off for a file.
+    fn should_use_colors(&self, target: &LogTarget) -> bool {
         if self.color {
-            true
-        } else if self.no_color {
-            false
-        } else {
-            std::io::stdout().is_terminal()
+            return true;
+        }
+        if self.no_color {
+            return false;
+        }
+        match target {
+            LogTarget::Stdout => io::stdout().is_terminal(),
+            LogTarget::Stderr => io::stderr().is_terminal(),
+            LogTarget::File(_) => false,
         }
     }
 
@@ -63,6 +76,67 @@ impl Opt {
             .or_else(|_| EnvFilter::try_new(self.log_filter()))
             .unwrap()
     }
+
+    /// Where log lines go: the file from `--log` if given; otherwise stdout,
+    /// except for LSP and DAP, which use stdout for their own protocol and so
+    /// log to stderr.
+    fn log_target(&self) -> LogTarget {
+        if let Some(path) = &self.log {
+            let file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .unwrap_or_else(|e| {
+                    eprintln!("error: could not open log file {path}: {e}");
+                    exit(1);
+                });
+            LogTarget::File(file)
+        } else if matches!(self.command, Subcommand::Lsp(_) | Subcommand::Dap(_)) {
+            LogTarget::Stderr
+        } else {
+            LogTarget::Stdout
+        }
+    }
+}
+
+/// Where the tracing subscriber writes formatted log lines.
+enum LogTarget {
+    Stdout,
+    Stderr,
+    File(File),
+}
+
+impl<'a> MakeWriter<'a> for LogTarget {
+    type Writer = Box<dyn Write + Send + 'a>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        match self {
+            Self::Stdout => Box::new(io::stdout()),
+            Self::Stderr => Box::new(io::stderr()),
+            Self::File(file) => Box::new(file),
+        }
+    }
+}
+
+/// Build and install the global tracing subscriber, writing to `target` in
+/// either the plain or JSON format.
+fn init_tracing(filter: EnvFilter, json: bool, target: LogTarget, ansi: bool) {
+    let registry = tracing_subscriber::Registry::default().with(filter);
+    if json {
+        registry
+            .with(tracing_subscriber::fmt::layer().json().with_writer(target))
+            .init();
+    } else {
+        registry
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .without_time()
+                    .with_ansi(ansi)
+                    .with_target(false)
+                    .with_writer(target),
+            )
+            .init();
+    }
 }
 
 fn main() {
@@ -70,31 +144,9 @@ fn main() {
     let opt = Opt::parse();
 
     // Then, setup the tracing formatter for logging and instrumentation
-    let registry = tracing_subscriber::Registry::default().with(opt.filter_layer());
-
-    // LSP and DAP use stdout for their own protocol, so their logs go to
-    // stderr. `run` logs to stdout, interleaved with the program's serial
-    // output.
-    let use_stderr = matches!(opt.command, Subcommand::Lsp(_) | Subcommand::Dap(_));
-
-    if opt.json {
-        let fmt_layer = tracing_subscriber::fmt::layer().json();
-        if use_stderr {
-            registry.with(fmt_layer.with_writer(std::io::stderr)).init();
-        } else {
-            registry.with(fmt_layer.with_writer(std::io::stdout)).init();
-        }
-    } else {
-        let fmt_layer = tracing_subscriber::fmt::layer()
-            .without_time()
-            .with_ansi(opt.should_use_colors())
-            .with_target(false);
-        if use_stderr {
-            registry.with(fmt_layer.with_writer(std::io::stderr)).init();
-        } else {
-            registry.with(fmt_layer.with_writer(std::io::stdout)).init();
-        }
-    }
+    let target = opt.log_target();
+    let ansi = opt.should_use_colors(&target);
+    init_tracing(opt.filter_layer(), opt.json, target, ansi);
 
     // And run the command
     let res = opt.command.exec();

--- a/crates/cli/tests/run.rs
+++ b/crates/cli/tests/run.rs
@@ -21,3 +21,19 @@ fn dumps_registers_on_stdout() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("End of program registers=%a = 120"));
 }
+
+#[test]
+fn log_flag_appends_to_file() {
+    let path = std::path::Path::new(env!("CARGO_TARGET_TMPDIR")).join("z33-log-test.log");
+    let _ = std::fs::remove_file(&path);
+    let path = path.to_str().unwrap();
+
+    for _ in 0..2 {
+        let output = run_fact(&["--log", path]);
+        assert!(output.status.success());
+        assert!(output.stdout.is_empty());
+    }
+
+    let logs = std::fs::read_to_string(path).unwrap();
+    assert_eq!(logs.matches("End of program registers=%a = 120").count(), 2);
+}

--- a/crates/cli/tests/run.rs
+++ b/crates/cli/tests/run.rs
@@ -15,9 +15,9 @@ fn run_fact(extra_args: &[&str]) -> Output {
 }
 
 #[test]
-fn dumps_registers_at_end_of_program() {
+fn dumps_registers_on_stdout() {
     let output = run_fact(&[]);
     assert!(output.status.success());
-    let logs = [output.stdout, output.stderr].concat();
-    assert!(String::from_utf8_lossy(&logs).contains("End of program registers=%a = 120"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("End of program registers=%a = 120"));
 }

--- a/crates/cli/tests/run.rs
+++ b/crates/cli/tests/run.rs
@@ -1,0 +1,23 @@
+//! End-to-end tests for `z33-cli run`.
+
+use std::process::{Command, Output, Stdio};
+
+/// Run `z33-cli run <extra_args> samples/fact.s main` with stdin closed.
+fn run_fact(extra_args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_z33-cli"))
+        .arg("run")
+        .args(extra_args)
+        .arg(concat!(env!("CARGO_MANIFEST_DIR"), "/../../samples/fact.s"))
+        .arg("main")
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run z33-cli")
+}
+
+#[test]
+fn dumps_registers_at_end_of_program() {
+    let output = run_fact(&[]);
+    assert!(output.status.success());
+    let logs = [output.stdout, output.stderr].concat();
+    assert!(String::from_utf8_lossy(&logs).contains("End of program registers=%a = 120"));
+}

--- a/crates/cli/tests/serial.rs
+++ b/crates/cli/tests/serial.rs
@@ -21,10 +21,8 @@ fn sample(name: &str) -> PathBuf {
 /// Run `z33-cli run <sample> main`, feed `input` to stdin, and return the raw
 /// stdout bytes.
 ///
-/// Logs go to stderr (routed there for the `run` subcommand precisely so they
-/// never garble the guest's serial output on stdout), which we discard.
-/// `RUST_LOG=warn` additionally quiets the per-instruction info logging so the
-/// discarded stderr stays cheap; it is no longer needed for stdout cleanliness.
+/// Logs share stdout with the guest's serial output, so `RUST_LOG=warn` keeps
+/// stdout down to the echoed bytes: none of these runs log at warn or above.
 fn run_echo_raw(sample_name: &str, input: &[u8]) -> Vec<u8> {
     let mut child = Command::new(env!("CARGO_BIN_EXE_z33-cli"))
         .args(["run", sample(sample_name).to_str().unwrap(), "main"])

--- a/crates/emulator/src/dap/index.rs
+++ b/crates/emulator/src/dap/index.rs
@@ -102,8 +102,8 @@ impl LineIndex {
             });
             let (line, column) = files[file_index].line_col(original_range.start);
 
-            // Record the first (lowest) address seen on each line so breakpoints
-            // resolve deterministically.
+            // Record the first (lowest) address seen on each line so
+            // breakpoints resolve deterministically.
             files[file_index]
                 .lines_with_code
                 .entry(line)

--- a/crates/emulator/src/dap/mod.rs
+++ b/crates/emulator/src/dap/mod.rs
@@ -540,7 +540,8 @@ impl DebugSession {
                 ..Default::default()
             });
         } else if let Some((start, end)) = self.frame_stack_range(args.frame_id) {
-            // Synthesized caller frame: best-effort view of the words it pushed.
+            // Synthesized caller frame: best-effort view of the words it
+            // pushed.
             let handle = self.alloc_dyn(DynRef::FrameStack { start, end });
             scopes.push(Scope {
                 name: "Frame stack".to_owned(),
@@ -843,10 +844,11 @@ impl DebugSession {
 
         // REPL console input while the program is running: treat the typed line
         // as serial input (Enter is `\n`) rather than an expression. Only while
-        // `Running` — when stopped at a breakpoint the user is inspecting state,
-        // so `evaluate` keeps its expression-evaluation behavior there. The
-        // response `result` is empty because the Debug Console already renders
-        // the line the user typed; any device echo streams back as `stdout`.
+        // `Running` — when stopped at a breakpoint the user is inspecting
+        // state, so `evaluate` keeps its expression-evaluation behavior
+        // there. The response `result` is empty because the Debug
+        // Console already renders the line the user typed; any device
+        // echo streams back as `stdout`.
         if self.state == State::Running && args.context.as_deref() == Some("repl") {
             let mut line = args.expression;
             line.push('\n');
@@ -1055,14 +1057,15 @@ impl DebugSession {
         // Flush any serial output first so program output (category "stdout")
         // always precedes the stopped/terminated/exception events, and — on the
         // `Pending` path — streams to the Debug Console during long print loops
-        // instead of buffering until the next stop. The halt/exception summaries
-        // below use category "console", so they stay visually distinct.
+        // instead of buffering until the next stop. The halt/exception
+        // summaries below use category "console", so they stay visually
+        // distinct.
         //
         // On terminal outcomes (halt/exception) no more serial bytes will come,
         // so any incomplete UTF-8 sequence held back from a previous drain must
         // be flushed now (lossily) rather than silently dropped. On a plain
-        // `Stopped` the program will resume, so the held-back bytes are kept and
-        // completed by the next drain.
+        // `Stopped` the program will resume, so the held-back bytes are kept
+        // and completed by the next drain.
         let flush = matches!(outcome, Outcome::Terminated(_) | Outcome::Exception(_));
         let mut out = self.serial_output_events(flush);
         match outcome {
@@ -1332,9 +1335,10 @@ fn execution_variables(computer: &Computer) -> Vec<Variable> {
 fn flags_variables(computer: &Computer) -> Vec<Variable> {
     let sr = computer.registers.sr;
     // Derive the child variables straight from `StatusRegister` so the list can
-    // never drift from the bitflags definition. `iter_names` yields the flags in
-    // declaration order with their uppercase identifiers; lowercase them to keep
-    // the historical variable names (`carry`, `interrupt_enable`, ...).
+    // never drift from the bitflags definition. `iter_names` yields the flags
+    // in declaration order with their uppercase identifiers; lowercase them
+    // to keep the historical variable names (`carry`, `interrupt_enable`,
+    // ...).
     StatusRegister::all()
         .iter_names()
         .map(|(name, flag)| Variable {

--- a/crates/emulator/src/diagnostic.rs
+++ b/crates/emulator/src/diagnostic.rs
@@ -108,7 +108,8 @@ pub fn preprocessor_error_to_diagnostics(error: &PreprocessorError) -> Vec<Diagn
             inner,
         } => {
             let mut diagnostics = preprocessor_error_to_diagnostics(inner);
-            // Add a secondary label at the #include site to the first diagnostic
+            // Add a secondary label at the #include site to the first
+            // diagnostic
             if let Some(first) = diagnostics.first_mut() {
                 first.labels.push(
                     Label::secondary(*file_id, span.clone()).with_message("included from here"),

--- a/crates/emulator/src/lsp/completion.rs
+++ b/crates/emulator/src/lsp/completion.rs
@@ -123,7 +123,8 @@ fn macro_completions(analysis: Option<&DocumentState>) -> Vec<CompletionItem> {
         return Vec::new();
     };
 
-    // Deduplicate: later #defines override earlier ones, show only the last value
+    // Deduplicate: later #defines override earlier ones, show only the last
+    // value
     let mut seen = std::collections::HashSet::new();
     annotations
         .definitions
@@ -229,7 +230,8 @@ fn detect_context_from_text(line_text: &str, pos_in_line: usize) -> CursorContex
     if mnemonic_text.is_empty() {
         // Check if it starts with '.' (directive)
         if let Some(after_dot) = trimmed.strip_prefix('.') {
-            // If there's content after the directive name, we're in its argument
+            // If there's content after the directive name, we're in its
+            // argument
             let directive_end = after_dot
                 .find(|c: char| !c.is_ascii_alphabetic())
                 .unwrap_or(after_dot.len());
@@ -240,9 +242,9 @@ fn detect_context_from_text(line_text: &str, pos_in_line: usize) -> CursorContex
         return CursorContext::Mnemonic;
     }
 
-    // Resolve the mnemonic through the derived `FromStr`. Unknown mnemonics (and
-    // the `<error>` placeholder, which never matches an alphabetic word) fall
-    // back to offering mnemonic completions.
+    // Resolve the mnemonic through the derived `FromStr`. Unknown mnemonics
+    // (and the `<error>` placeholder, which never matches an alphabetic
+    // word) fall back to offering mnemonic completions.
     let Ok(kind) = mnemonic_text
         .to_ascii_lowercase()
         .parse::<InstructionKind>()
@@ -369,7 +371,8 @@ mod tests {
     fn second_arg_must_be_register() {
         let src = "    add 1, ";
         let items = completions(None, src, 11); // after ", "
-                                                // Second arg of ADD is Reg — should only offer registers
+                                                // Second arg of ADD is Reg —
+                                                // should only offer registers
         assert!(items.iter().any(|i| i.label == "%a"));
         assert!(!items.iter().any(|i| i.label == "[...]"));
     }
@@ -378,7 +381,8 @@ mod tests {
     fn label_completion_in_arg() {
         let src = "foo:\n    jmp ";
         let analysis = DocumentState::new(src.to_string());
-        let items = completions(Some(&analysis), src, src.len()); // after "jmp "
+        let items = completions(Some(&analysis), src, src.len()); // after "jmp
+                                                                  // "
                                                                   // JMP arg 0 is ImmRegDirIndIdx — should offer labels
         assert!(items.iter().any(|i| i.label == "foo"));
         assert!(items.iter().any(|i| i.label == "%a"));

--- a/crates/emulator/src/lsp/instructions.rs
+++ b/crates/emulator/src/lsp/instructions.rs
@@ -357,7 +357,8 @@ mod tests {
             let m = meta(kind);
             assert!(!m.summary.is_empty(), "empty summary for {kind}");
             assert!(!m.hover.is_empty(), "empty hover for {kind}");
-            // Display / FromStr round-trip through the derived parse_display impls.
+            // Display / FromStr round-trip through the derived parse_display
+            // impls.
             assert_eq!(
                 format!("{kind}").parse::<InstructionKind>().ok(),
                 Some(kind),
@@ -371,7 +372,8 @@ mod tests {
 
     #[test]
     fn error_kind_does_not_parse_from_a_mnemonic() {
-        // `Error` displays as `<error>`, so a real mnemonic never resolves to it.
+        // `Error` displays as `<error>`, so a real mnemonic never resolves to
+        // it.
         assert!("error".parse::<InstructionKind>().is_err());
         assert_eq!(
             "<error>".parse::<InstructionKind>().ok(),

--- a/crates/emulator/src/lsp/session.rs
+++ b/crates/emulator/src/lsp/session.rs
@@ -265,9 +265,9 @@ impl LspSession {
         });
         // Client-side commands the client can execute, advertised through the
         // open-ended `experimental` capability (same convention as
-        // rust-analyzer): `{"experimental": {"commands": ["zorglub33.run", ...]}}`.
-        // Server-produced `Command`s (e.g. the run code lens) are only
-        // emitted when the client declared it can handle them.
+        // rust-analyzer): `{"experimental": {"commands": ["zorglub33.run",
+        // ...]}}`. Server-produced `Command`s (e.g. the run code lens)
+        // are only emitted when the client declared it can handle them.
         let client_commands = parse_client_commands(params.capabilities.experimental.as_ref());
 
         self.manager.set_root(root_uri);

--- a/crates/emulator/src/parser/assembly.rs
+++ b/crates/emulator/src/parser/assembly.rs
@@ -82,8 +82,8 @@ fn instruction_argument<'a>() -> impl Parser<'a, &'a str, InstructionArgument, E
                 .map(|_| InstructionArgument::Error),
         ));
 
-    // Order: try bracketed first (starts with [), then register (starts with %),
-    // then value
+    // Order: try bracketed first (starts with [), then register (starts with
+    // %), then value
     bracketed.or(reg).or(value)
 }
 
@@ -103,7 +103,8 @@ fn instruction_kind<'a>() -> impl Parser<'a, &'a str, InstructionKind, Extra<'a>
         .validate(|s: &str, e, emitter| {
             // Resolve through the derived `FromStr`. The `<error>` placeholder
             // displays as `<error>`, so it can never be produced from an
-            // alphabetic mnemonic — an unknown mnemonic falls into the arm below.
+            // alphabetic mnemonic — an unknown mnemonic falls into the arm
+            // below.
             match s.to_ascii_lowercase().parse::<K>() {
                 Ok(kind) if kind != K::Error => kind,
                 _ => {

--- a/crates/emulator/src/parser/expression.rs
+++ b/crates/emulator/src/parser/expression.rs
@@ -291,8 +291,9 @@ impl Node {
 
                 Node::BinaryNot(operand) => {
                     let _operand: Value = operand.inner.evaluate(context)?;
-                    // TODO: bit inversion is tricky because we're not supposed to know the word
-                    // length here. It's a bit opiniated, but for now it tries
+                    // TODO: bit inversion is tricky because we're not supposed
+                    // to know the word length here. It's a
+                    // bit opiniated, but for now it tries
                     // casting down to u16 before negating.
 
                     /*

--- a/crates/emulator/src/parser/line.rs
+++ b/crates/emulator/src/parser/line.rs
@@ -70,7 +70,8 @@ impl std::fmt::Display for LineContent {
                 write!(f, "{:4}", kind.inner)?;
 
                 // then the list of arguments
-                let mut first = true; // This is to properly show comma between arguments
+                let mut first = true; // This is to properly show comma between
+                                      // arguments
                 for arg in arguments {
                     if !first {
                         write!(f, ",")?;

--- a/crates/emulator/src/runtime/instructions.rs
+++ b/crates/emulator/src/runtime/instructions.rs
@@ -488,16 +488,19 @@ impl Instruction {
                 let value = arg.extract_cell(computer)?;
                 let value2 = reg.extract_cell(computer)?;
 
-                // And set the value of the register specified by the second argument
+                // And set the value of the register specified by the second
+                // argument
                 computer.set_register(*reg, value)?;
 
-                // Then handle the two kind of cases: a register and a memory address
+                // Then handle the two kind of cases: a register and a memory
+                // address
                 if let RegDirIndIdx::Reg(arg) = arg {
                     // Set the value of the register by the first argument
                     computer.set_register(*arg, value2)?;
                 } else {
-                    // Convert the reg/dir/ind/idx arg to only dir/ind/idx, since we already
-                    // handled the reg case. Despite the unwrap, this should never fail.
+                    // Convert the reg/dir/ind/idx arg to only dir/ind/idx,
+                    // since we already handled the reg
+                    // case. Despite the unwrap, this should never fail.
                     let arg: DirIndIdx = arg.clone().try_into().unwrap();
 
                     // Resolve the address and write the second value
@@ -530,8 +533,8 @@ impl Instruction {
     /// Get the total cost of an instruction in terms of CPU cycles
     // r[impl exec.cycles]
     pub(crate) const fn cost(&self) -> usize {
-        // All instruction cost one CPU cycle itself, plus the cost of each of its
-        // arguments
+        // All instruction cost one CPU cycle itself, plus the cost of each of
+        // its arguments
         match self {
             // imm|reg|dir|ind|idx, reg
             Self::Div(a, _)

--- a/crates/emulator/src/runtime/mod.rs
+++ b/crates/emulator/src/runtime/mod.rs
@@ -121,8 +121,8 @@ impl Computer {
             tracing::Span::current().record("cost", cost);
             info!("Executing instruction \"{}\"", inst);
             // This clone is necessary as `inst` is borrowed from `self`.
-            // The computer might modify the cell where the instruction is stored when
-            // executing it.
+            // The computer might modify the cell where the instruction is
+            // stored when executing it.
             inst.clone().execute(c)?;
             Ok(cost)
         }
@@ -164,7 +164,8 @@ impl Computer {
         exception: &Exception,
     ) -> std::result::Result<(), Exception> {
         // r[impl exc.handling.check-handler]
-        // We don't want to recover from the exception if there is no handler setup
+        // We don't want to recover from the exception if there is no handler
+        // setup
         let handler = self.memory.get(C::INTERRUPT_HANDLER)?;
         if handler.extract_instruction().is_err() {
             tracing::warn!(

--- a/crates/emulator/tests/assembly.rs
+++ b/crates/emulator/tests/assembly.rs
@@ -372,7 +372,8 @@ fn directive_string() {
         "#},
         "main",
     );
-    // Should be: [500] = 'H' (72), [501] = 'i' (105), [502] = 0 (null terminator)
+    // Should be: [500] = 'H' (72), [501] = 'i' (105), [502] = 0 (null
+    // terminator)
     insta::assert_snapshot!(state, @r"
     Labels:
       msg = 500

--- a/crates/emulator/tests/control_flow.rs
+++ b/crates/emulator/tests/control_flow.rs
@@ -40,7 +40,8 @@ fn call_basic() {
 #[test]
 fn call_pushes_return_address() {
     // r[verify inst.call]
-    // After call, SP should be decremented and stack should contain return address
+    // After call, SP should be decremented and stack should contain return
+    // address
     let state = run_program(
         indoc! {"
             main:
@@ -419,7 +420,8 @@ fn rti_returns_from_exception() {
 #[test]
 fn rti_restores_sr() {
     // r[verify inst.rti]
-    // rti should restore the saved SR, clearing SUPERVISOR if it was not set before
+    // rti should restore the saved SR, clearing SUPERVISOR if it was not set
+    // before
     let state = run_program(
         indoc! {"
             .addr 200
@@ -519,8 +521,8 @@ fn reset_halts_computer() {
 #[test]
 fn reset_pc_points_at_reset_instruction() {
     // r[verify inst.reset]
-    // After reset, PC should point at the reset instruction itself (decremented by
-    // 1)
+    // After reset, PC should point at the reset instruction itself (decremented
+    // by 1)
     let state = run_program(
         indoc! {"
             main:
@@ -602,7 +604,8 @@ fn nop_does_nothing() {
 #[test]
 fn nop_costs_one_cycle() {
     // r[verify inst.nop]
-    // Compare cycle count with and without nop to verify it costs exactly 1 cycle
+    // Compare cycle count with and without nop to verify it costs exactly 1
+    // cycle
     let without_nop = run_program(
         indoc! {"
             main:

--- a/crates/emulator/tests/diagnostics.rs
+++ b/crates/emulator/tests/diagnostics.rs
@@ -72,8 +72,8 @@ fn unknown_instruction() {
 
 #[test]
 fn unknown_instruction_with_args() {
-    // "invalid" should be reported as unknown instruction, not as a label missing
-    // ':'
+    // "invalid" should be reported as unknown instruction, not as a label
+    // missing ':'
     insta::assert_snapshot!(check_parse_errors("    invalid %a"));
 }
 

--- a/crates/emulator/tests/exceptions.rs
+++ b/crates/emulator/tests/exceptions.rs
@@ -30,8 +30,8 @@ fn exception_saves_state() {
         "main",
         Steps::RunToCompletion,
     );
-    // mem[100] = saved PC, mem[101] = saved SR, mem[102] = exception code (1 = div
-    // by zero) SR should have SUPERVISOR bit set when handler runs
+    // mem[100] = saved PC, mem[101] = saved SR, mem[102] = exception code (1 =
+    // div by zero) SR should have SUPERVISOR bit set when handler runs
     insta::assert_snapshot!(state, @r"
     Registers:
       %a  = 42
@@ -79,7 +79,8 @@ fn exception_no_handler_is_fatal() {
 #[test]
 fn exception_handler_at_200_must_be_instruction() {
     // r[verify exc.handling.check-handler]
-    // Address 200 contains a word, not an instruction — handler check should fail.
+    // Address 200 contains a word, not an instruction — handler check should
+    // fail.
     let state = run_program(
         indoc! {"
             .addr 200
@@ -191,7 +192,8 @@ fn invalid_instruction_exception() {
 fn privileged_instruction_exception() {
     // r[verify exc.code.privileged-instruction]
     // r[verify exc.handling.save-state]
-    // Enter user mode via rti trick, then attempt to write %sr which is privileged.
+    // Enter user mode via rti trick, then attempt to write %sr which is
+    // privileged.
     let state = run_program(
         indoc! {"
             .addr 100
@@ -333,7 +335,8 @@ fn trap_preserves_interrupt_enable() {
         "main",
         Steps::RunToCompletion,
     );
-    // SR should still have INTERRUPT_ENABLE set (256) along with SUPERVISOR (512)
+    // SR should still have INTERRUPT_ENABLE set (256) along with SUPERVISOR
+    // (512)
     insta::assert_snapshot!(state, @r"
     Registers:
       %a  = 0
@@ -376,8 +379,8 @@ fn rti_restores_state() {
         "main",
         Steps::RunToCompletion,
     );
-    // After rti, execution resumes after trap. %a should be 99 (set by handler),
-    // %b should be 7 (set after returning from handler).
+    // After rti, execution resumes after trap. %a should be 99 (set by
+    // handler), %b should be 7 (set after returning from handler).
     insta::assert_snapshot!(state, @r"
     Registers:
       %a  = 99
@@ -545,8 +548,8 @@ fn exception_step_count_check() {
         "main",
         Steps::Count(3),
     );
-    // After 3 steps: (1) ld 0,%b (2) div triggers exception + jump to 200 (3) ld
-    // 77,%a
+    // After 3 steps: (1) ld 0,%b (2) div triggers exception + jump to 200 (3)
+    // ld 77,%a
     insta::assert_snapshot!(state, @r"
     Registers:
       %a  = 77

--- a/crates/emulator/tests/execution.rs
+++ b/crates/emulator/tests/execution.rs
@@ -39,9 +39,9 @@ fn fetch_from_pc() {
 #[test]
 fn pc_incremented_after_fetch() {
     // r[verify exec.pc-increment]
-    // After fetching at 1000, %pc should be 1001 before the instruction executes.
-    // We run 1 step (ld 42, %a) and check that %pc has advanced past the
-    // instruction.
+    // After fetching at 1000, %pc should be 1001 before the instruction
+    // executes. We run 1 step (ld 42, %a) and check that %pc has advanced
+    // past the instruction.
     let state = run_program(
         indoc! {"
             main:
@@ -69,8 +69,9 @@ fn pc_incremented_after_fetch() {
 #[test]
 fn decode_word_as_instruction_raises_exception() {
     // r[verify exec.decode]
-    // Place a .word where %pc will try to fetch — should raise invalid instruction
-    // exception (code 2). The exception handler at 200 does a reset.
+    // Place a .word where %pc will try to fetch — should raise invalid
+    // instruction exception (code 2). The exception handler at 200 does a
+    // reset.
     let state = run_program(
         indoc! {"
             .addr 200
@@ -190,8 +191,8 @@ fn cycles_register_operand() {
 #[test]
 fn cycles_exception_recovery() {
     // r[verify exec.cycles.exception]
-    // Division by zero triggers an exception. The exception recovery costs 1 cycle
-    // (replacing the instruction's normal cost).
+    // Division by zero triggers an exception. The exception recovery costs 1
+    // cycle (replacing the instruction's normal cost).
     // ld 42, %a = 1 cycle, div 0, %a triggers exception = 1 cycle (recovery).
     // Reset doesn't count (returns before adding cost). Total = 2 cycles.
     let state = run_program(
@@ -293,8 +294,8 @@ fn rti_enters_user_mode() {
 #[test]
 fn exception_enters_supervisor_mode() {
     // r[verify exec.privilege.transition-up]
-    // Enter user mode via rti, then trigger an exception (e.g., division by zero).
-    // The exception handler should run in supervisor mode.
+    // Enter user mode via rti, then trigger an exception (e.g., division by
+    // zero). The exception handler should run in supervisor mode.
     let state = run_program(
         indoc! {"
             .addr 100

--- a/crates/emulator/tests/io.rs
+++ b/crates/emulator/tests/io.rs
@@ -102,14 +102,16 @@ fn in_reads_bytes_from_serial() {
     run(&mut computer);
     assert_eq!(word_at(&computer, 10), 90); // 'Z'
     assert_eq!(word_at(&computer, 11), 120); // 'x'
-                                             // The queue is now empty; a further read would yield 0.
+                                             // The queue is now empty; a
+                                             // further read would yield 0.
     assert!(!computer.io.serial.input_ready());
 }
 
 #[test]
 fn in_never_blocks_on_empty_queue() {
     // r[verify inst.in]
-    // Reading an empty serial console returns 0 immediately instead of blocking.
+    // Reading an empty serial console returns 0 immediately instead of
+    // blocking.
     let (mut computer, _) = build(
         indoc! {"
             .addr 1000
@@ -153,8 +155,8 @@ fn hardware_interrupt_is_delivered_between_instructions() {
     // %sr.IE is not set yet so nothing is delivered.
     computer.step().unwrap();
     assert_eq!(computer.registers.pc, 1001);
-    // Step 2: `or 1 << 8, %sr` enables interrupts; the pending interrupt is then
-    // delivered between this instruction and the next.
+    // Step 2: `or 1 << 8, %sr` enables interrupts; the pending interrupt is
+    // then delivered between this instruction and the next.
     computer.step().unwrap();
 
     // We jumped to the handler at 200.

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -576,7 +576,8 @@ impl MemoryObserver {
             if let Some(address_subscribers) = subscribers.get_mut(&address) {
                 address_subscribers.remove(&index);
 
-                // If there are no more subscribers for the address, remove the address
+                // If there are no more subscribers for the address, remove the
+                // address
                 if address_subscribers.is_empty() {
                     subscribers.remove(&address);
                 }

--- a/editors/zed/src/lib.rs
+++ b/editors/zed/src/lib.rs
@@ -330,7 +330,8 @@ mod tests {
 
     #[test]
     fn version_key_orders_numerically() {
-        // Lexicographic ordering would rank v0.9.0 above v0.10.0; the key must not.
+        // Lexicographic ordering would rank v0.9.0 above v0.10.0; the key must
+        // not.
         let v0_9 = version_key("z33-cli-v0.9.0").expect("v0.9.0 parses");
         let v0_10 = version_key("z33-cli-v0.10.0").expect("v0.10.0 parses");
         assert_eq!(v0_9, (0, 9, 0));


### PR DESCRIPTION
This adds back the `End of program` log line with the register dumps at the end of the program. **It also restores logging to `stdout` by default** which will mix up with the serial I/O device. There's a new `--log <file>` for outputting the logs to a filename to avoid this problem