### PR TITLE
Parser: accept labels preceded by leading whitespace

### DIFF
--- a/crates/emulator/src/parser/assembly.rs
+++ b/crates/emulator/src/parser/assembly.rs
@@ -269,10 +269,8 @@ fn inline_comment<'a>() -> impl Parser<'a, &'a str, Located<String>, Extra<'a>> 
 /// Parse a single line: optional labels, then optional content, then
 /// optional inline comment.
 fn line<'a>() -> impl Parser<'a, &'a str, Line, Extra<'a>> + Clone {
-    label()
-        .then_ignore(hspace())
-        .repeated()
-        .collect::<Vec<_>>()
+    hspace()
+        .ignore_then(label().then_ignore(hspace()).repeated().collect::<Vec<_>>())
         .map(SmallVec::from_vec)
         .then_ignore(hspace())
         .then(line_content().or_not())

--- a/crates/emulator/tests/assembly.rs
+++ b/crates/emulator/tests/assembly.rs
@@ -54,6 +54,39 @@ fn line_format_label_only() {
 }
 
 #[test]
+fn line_format_indented_labels() {
+    // r[verify asm.line-format]
+    let state = compile_program(
+        indoc! {"
+            main:
+                push _str2
+                push _str1
+                reset
+                _str1: .string \"abc\"
+                _str2: .string \"abc\"
+        "},
+        "main",
+    );
+    insta::assert_snapshot!(state, @"
+    Labels:
+      main = 1000
+      _str1 = 1003
+      _str2 = 1007
+    Entrypoint: %pc = 1000
+    Memory:
+      [1000] = <push 1007>
+      [1001] = <push 1003>
+      [1002] = <reset>
+      [1003] = 97
+      [1004] = 98
+      [1005] = 99
+      [1007] = 97
+      [1008] = 98
+      [1009] = 99
+    ");
+}
+
+#[test]
 fn line_format_multiple_labels_on_line() {
     // r[verify asm.line-format]
     // r[verify asm.labels]

--- a/spec/src/07-assembly.md
+++ b/spec/src/07-assembly.md
@@ -5,7 +5,7 @@ This chapter describes the Z33 assembly language syntax as accepted by the emula
 ## Line Format
 
 r[asm.line-format]
-Each line of a Z33 assembly program has the form: `[label:] [label:] ... [instruction | directive] [// comment]`. Labels, content, and comments are all optional. Blank lines and comment-only lines are permitted.
+Each line of a Z33 assembly program has the form: `[label:] [label:] ... [instruction | directive] [// comment]`. Labels, content, and comments are all optional, and each may be preceded by any amount of leading whitespace. Blank lines and comment-only lines are permitted.
 
 ### Examples
 
@@ -14,6 +14,7 @@ start:                      // label only
     ld 1, %a                // instruction only
 loop: sub 1, %a             // label + instruction
 end: done: reset            // multiple labels + instruction
+    data: .word 42          // indented label + directive
 ```
 
 ## Labels


### PR DESCRIPTION
The line parser only looked for labels at column zero, so an indented `label:` fell through to the instruction branch and was reported as an unknown instruction, with every reference to it left undefined. The previous nom-based parser skipped leading whitespace before labels.