### PR TITLE
Wait for the alert dialog to finish fading in before asserting visibility

### DIFF
--- a/editors/web/app/components/ui/alert-dialog.stories.tsx
+++ b/editors/web/app/components/ui/alert-dialog.stories.tsx
@@ -51,9 +51,10 @@ export const OpenAndCancel = meta.story({
     await userEvent.click(
       canvas.getByRole("button", { name: "Delete project" }),
     );
-    // base-ui renders the dialog in a portal on document.body.
+    // base-ui renders the dialog in a portal on document.body. It mounts at
+    // opacity 0 and fades in, so visibility has to be polled.
     const dialog = await screen.findByRole("alertdialog");
-    await expect(dialog).toBeVisible();
+    await waitFor(() => expect(dialog).toBeVisible());
     await expect(
       within(dialog).getByText("Are you absolutely sure?"),
     ).toBeVisible();


### PR DESCRIPTION
Fixes the Storybook flake seen in https://github.com/sandhose/z33-emulator/actions/runs/33785240101/job/100748299082.

The `Open And Cancel` story in `alert-dialog.stories.tsx` called `toBeVisible()` right after `findByRole("alertdialog")` resolved. The dialog content mounts with `animate-in fade-in-0`, so on its first frame it has `opacity: 0`, which jest-dom treats as not visible. The plain assertion doesn't retry, so it raced the 100ms fade. The tooltip story already polls with `waitFor`; this does the same here.

Ran the story file three times locally: 2/2 passing each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)