### PR TITLE
Clear the recurring CI warnings

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -43,7 +43,12 @@ jobs:
         run: rustup target add ${{ matrix.arch }}-apple-darwin
 
       - name: Install zig
-        uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          # cargo-zigbuild uses zig only as a linker, so the zig cache holds
+          # little worth restoring, and this job publishes release binaries
+          # (zizmor: cache-poisoning).
+          use-cache: false
 
       - name: Install cargo-zigbuild
         run: pipx install cargo-zigbuild
@@ -84,7 +89,12 @@ jobs:
         run: rustup target add ${{ matrix.arch }}-unknown-linux-musl
 
       - name: Install zig
-        uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          # cargo-zigbuild uses zig only as a linker, so the zig cache holds
+          # little worth restoring, and this job publishes release binaries
+          # (zizmor: cache-poisoning).
+          use-cache: false
 
       - name: Install cargo-zigbuild
         run: pipx install cargo-zigbuild

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -135,15 +135,11 @@ jobs:
       - name: Add the Rust target
         run: rustup target add ${{ matrix.arch }}-pc-windows-msvc
 
+      # `cargo xwin` spends ~11 minutes fetching the CRT and Windows SDK from
+      # Microsoft's package servers, so this caches XWIN_CACHE_DIR between runs.
       - name: Restore cargo-xwin cache
+        id: xwin-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: cargo-xwin
-          key: cargo-xwin-${{ matrix.arch }}
-
-      - name: Save cargo-xwin cache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: cargo-xwin
           key: cargo-xwin-${{ matrix.arch }}
@@ -153,6 +149,15 @@ jobs:
 
       - name: Build the binary
         run: cargo xwin build --release --target=${{ matrix.arch }}-pc-windows-msvc -p z33-cli
+
+      # The save must follow the build that populates the directory. Only main
+      # writes the cache (zizmor: cache-poisoning); other refs read it.
+      - name: Save cargo-xwin cache
+        if: github.ref == 'refs/heads/main' && steps.xwin-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: cargo-xwin
+          key: cargo-xwin-${{ matrix.arch }}
 
       - name: Move the binary
         run: mv target/${{ matrix.arch }}-pc-windows-msvc/release/z33-cli.exe ./z33-cli-${{ matrix.arch }}-windows.exe

--- a/editors/web/playwright.config.ts
+++ b/editors/web/playwright.config.ts
@@ -11,7 +11,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: process.env.CI ? "github" : "html",
+  // The `github` reporter emits annotations and nothing on disk, so the
+  // workflow's report upload needs `html` too.
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "html",
   timeout: 60_000,
   expect: { timeout: 10_000 },
   use: {


### PR DESCRIPTION
Cleans up the warnings the Compile and Check workflows have been logging on every run.

## `Failed to restore: Cache service responded with 400`

`goto-bus-stop/setup-zig` has had no commits since September 2024 and bundles `@actions/cache` 3.x, which speaks the cache service API GitHub has retired. All four zig-linked jobs logged a restore failure plus a `Failed to save:` Front Door error page. Switched to `mlugg/setup-zig`, which is maintained and on `@actions/cache` 4.x.

Caching is off there: `cargo-zigbuild` uses zig only as a linker, so the zig cache holds little worth restoring, and these jobs publish release binaries. zizmor's `cache-poisoning` audit knows `mlugg/setup-zig` and flags it without `use-cache: false`.

The **Node.js 20 deprecation warning stays**. `mlugg/setup-zig` v2.2.1 declares `using: node20` too, so the runner keeps forcing it onto Node 24. Nothing to do here until upstream moves.

## Windows builds re-downloading the CRT every run

The `Save cargo-xwin cache` step sat before `Install cargo-xwin`, so it ran while `./cargo-xwin` did not exist yet:

```
Save cargo-xwin cache  [warning]Path Validation Error: Path(s) specified in the action
                                for caching do(es) not exist, hence no cache is being saved
```

Nothing ever reached the cache, so every restore missed and each Windows job paid the full CRT and Windows SDK download:

```
17:33:57  ⏬ Downloading MSVC CRT...
17:45:20  ✅ Downloaded MSVC CRT in 11m 23s.
```

11m23s of a 12m45s build step; the Rust compile itself is about 80 seconds. Moved the save after the build and gated it on a cache miss so later `main` runs do not start logging `Cache already exists`.

I looked at `cargo-xwin`'s `clang` backend as an alternative, since it skips `xwin` entirely and pulls one prebuilt `windows-msvc-sysroot.tar.xz` instead (10s download, 4s extract when I measured it). Not worth taking: it is a third-party sysroot rather than Microsoft's CRT/SDK, `cargo-xwin` resolves it from `releases/latest` at build time so it cannot be pinned to a SHA like everything else here, and it unpacks to 4.3 GB across all arches. With the cache actually working the download is a one-time cost per arch anyway.

## `No files were found with the provided path: editors/web/playwright-report/`

`playwright.config.ts` used `reporter: "github"` on CI, which emits annotations and nothing on disk, so that path never existed and the artifact carried no report. Added `html` alongside `github`.

## Checks

- `zizmor --offline .github/workflows/` clean
- `oxfmt --check app/` clean
- Playwright config parses under `CI=1` (`playwright test --list`)
