### PR TITLE
Set up pnpm before the release version bump

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,6 +59,14 @@ jobs:
             exit 1
           fi
 
+      # set-version.sh regenerates the tree-sitter parser through the pnpm
+      # workspace, and the runner image ships npm but not pnpm.
+      - name: Set up Node and pnpm
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+        with:
+          runtime: node@24
+          require-lockfile: true
+
       - name: Bump the versions
         run: scripts/set-version.sh "$VERSION"
 


### PR DESCRIPTION
The release workflow's version bump fails before it can open the release PR:

```
scripts/set-version.sh: line 47: pnpm: command not found
```

11cc654 moved `set-version.sh` from a self-contained `npm install && npx tree-sitter generate` to `pnpm --filter tree-sitter-z33 run generate`. The runner image ships npm but not pnpm, and the `release-pr` job runs the script straight after checkout. Adds the same `pnpm/setup` step the tree-sitter job in `check.yaml` already uses.

## Verified

Ran the full script in a clean git clone with pnpm available. It completes (`Set version 0.8.5 (grammar rev df27c6c…)`) and touches exactly the seven files the `Commit the bumps on the release branch` step expects:

```
Cargo.lock  Cargo.toml  editors/vscode/package.json  editors/zed/extension.toml
tree-sitter-z33/package.json  tree-sitter-z33/src/parser.c  tree-sitter-z33/tree-sitter.json
```

`pnpm --filter tree-sitter-z33 run generate` also leaves the committed parser unchanged, so the regenerated `src/` is in sync.
