### PR TITLE
Fix panics reachable from source input

### DIFF
--- a/crates/cli/src/interactive/parse.rs
+++ b/crates/cli/src/interactive/parse.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use chumsky::prelude::*;
 use thiserror::Error;
 use z33_emulator::parser::location::Locatable;
-use z33_emulator::parser::shared::{expression, register};
+use z33_emulator::parser::shared::{expression, register, reject_deep_nesting};
 use z33_emulator::parser::{ExpressionContext, ExpressionNode};
 use z33_emulator::runtime::{Computer, ExtractValue, Reg};
 
@@ -79,6 +79,7 @@ fn run_parser<'a, T, P>(parser: P, input: &'a str) -> Result<T, String>
 where
     P: Parser<'a, &'a str, T, Extra<'a>>,
 {
+    reject_deep_nesting(input)?;
     parser
         .then_ignore(end())
         .parse(input)
@@ -150,6 +151,13 @@ mod tests {
             "%a-2".parse::<Argument>(),
             Ok(Argument::Indexed(Reg::A, _))
         ));
+    }
+
+    #[test]
+    fn argument_rejects_nesting_the_parser_cannot_descend() {
+        let input = format!("{}1{}", "(".repeat(50_000), ")".repeat(50_000));
+        let err = input.parse::<Argument>().unwrap_err();
+        assert!(err.to_string().contains("nesting"), "{err}");
     }
 
     #[test]

--- a/crates/emulator/src/compiler/layout.rs
+++ b/crates/emulator/src/compiler/layout.rs
@@ -5,7 +5,7 @@ use parse_display::Display;
 use thiserror::Error;
 use tracing::{debug, trace};
 
-use crate::constants::{Address, PROGRAM_START};
+use crate::constants::{Address, MEMORY_SIZE, PROGRAM_START};
 use crate::parser::expression::{
     Context as ExpressionContext, EmptyContext as EmptyExpressionContext,
     EvaluationError as ExpressionEvaluationError,
@@ -69,6 +69,10 @@ impl Layout {
         placement: Placement,
         location: Range<usize>,
     ) -> Result<(), MemoryLayoutError> {
+        if address >= MEMORY_SIZE {
+            return Err(MemoryLayoutError::OutOfBounds { address, location });
+        }
+
         if let Some((_, original_location)) = self.memory.get(&address) {
             return Err(MemoryLayoutError::MemoryOverlap {
                 address,
@@ -127,6 +131,66 @@ pub enum MemoryLayoutError {
         /// Location of the directive that is trying to overwrite it.
         new_location: Range<usize>,
     },
+
+    #[error("address {address} is outside of memory (valid range is 0..{MEMORY_SIZE})")]
+    OutOfBounds {
+        address: Address,
+        location: Range<usize>,
+    },
+
+    #[error(
+        "reserving {size} cells from address {address} does not fit in memory (valid range is 0..{MEMORY_SIZE})"
+    )]
+    SpaceDoesNotFit {
+        address: Address,
+        size: Address,
+        location: Range<usize>,
+    },
+}
+
+/// Where the next placement goes, and whether the current run of placements
+/// already reported an out-of-bounds address. A run ends at the next `.addr`.
+struct Cursor {
+    position: Address,
+    reported_out_of_bounds: bool,
+}
+
+impl Cursor {
+    fn new() -> Self {
+        Cursor {
+            position: PROGRAM_START,
+            reported_out_of_bounds: false,
+        }
+    }
+
+    /// Continue laying out at `address`, starting a new run.
+    fn seek(&mut self, address: Address) {
+        self.position = address;
+        self.reported_out_of_bounds = false;
+    }
+
+    /// Place one cell at the cursor and advance past it. A run of placements
+    /// past the end of memory reports only its first address, and the cursor
+    /// saturates rather than wrapping past the last one.
+    fn place(
+        &mut self,
+        layout: &mut Layout,
+        placement: Placement,
+        location: &Range<usize>,
+        errors: &mut Vec<MemoryLayoutError>,
+    ) {
+        match layout.insert_placement(self.position, placement, location.clone()) {
+            Ok(()) => {}
+            Err(error @ MemoryLayoutError::OutOfBounds { .. }) => {
+                if !self.reported_out_of_bounds {
+                    self.reported_out_of_bounds = true;
+                    errors.push(error);
+                }
+            }
+            Err(error) => errors.push(error),
+        }
+        self.position = self.position.saturating_add(1);
+    }
 }
 
 /// Lays out the memory, collecting all errors instead of stopping at the first.
@@ -142,13 +206,13 @@ pub(crate) fn layout_memory(program: &[Located<Line>]) -> (Layout, Vec<MemoryLay
     debug!(lines = program.len(), "Laying out memory");
     let mut layout: Layout = Layout::default();
     let mut errors: Vec<MemoryLayoutError> = Vec::new();
-    let mut position = PROGRAM_START;
+    let mut cursor = Cursor::new();
 
     for line in program {
         let line = &line.inner;
         for key in line.symbols.clone() {
-            trace!(key = %key.inner, position, "Inserting label");
-            if let Err(e) = layout.insert_label(key, position) {
+            trace!(key = %key.inner, position = cursor.position, "Inserting label");
+            if let Err(e) = layout.insert_label(key, cursor.position) {
                 errors.push(e);
             }
         }
@@ -160,15 +224,13 @@ pub(crate) fn layout_memory(program: &[Located<Line>]) -> (Layout, Vec<MemoryLay
                     kind: Located { inner: Word, .. },
                     ..
                 } => {
-                    if let Err(e) = layout.insert_placement(
-                        position,
+                    trace!(position = cursor.position, content = %content.inner, "Inserting line");
+                    cursor.place(
+                        &mut layout,
                         Placement::Line(content.clone()),
-                        content.location.clone(),
-                    ) {
-                        errors.push(e);
-                    }
-                    trace!(position, content = %content.inner, "Inserting line");
-                    position += 1;
+                        &content.location,
+                        &mut errors,
+                    );
                 }
 
                 // Valid instructions (skip error placeholder instructions)
@@ -177,15 +239,13 @@ pub(crate) fn layout_memory(program: &[Located<Line>]) -> (Layout, Vec<MemoryLay
                         // Skip — the diagnostic was already emitted by the
                         // parser
                     } else {
-                        if let Err(e) = layout.insert_placement(
-                            position,
+                        trace!(position = cursor.position, content = %content.inner, "Inserting line");
+                        cursor.place(
+                            &mut layout,
                             Placement::Line(content.clone()),
-                            content.location.clone(),
-                        ) {
-                            errors.push(e);
-                        }
-                        trace!(position, content = %content.inner, "Inserting line");
-                        position += 1;
+                            &content.location,
+                            &mut errors,
+                        );
                     }
                 }
 
@@ -197,18 +257,30 @@ pub(crate) fn layout_memory(program: &[Located<Line>]) -> (Layout, Vec<MemoryLay
                             inner: DirectiveArgument::Expression(e),
                             ..
                         },
-                } => match e.evaluate(&EmptyExpressionContext) {
+                } => match e.evaluate::<_, Address>(&EmptyExpressionContext) {
                     Ok(size) => {
-                        trace!(size, position, "Reserving space");
-                        for _ in 0..size {
-                            if let Err(e) = layout.insert_placement(
-                                position,
-                                Placement::Reserved,
-                                content.location.clone(),
-                            ) {
-                                errors.push(e);
+                        trace!(size, position = cursor.position, "Reserving space");
+                        // The whole reservation is checked before the loop, so
+                        // a `.space` argument naming billions of cells costs
+                        // one diagnostic rather than that many insertions.
+                        match cursor.position.checked_add(size) {
+                            Some(end) if end <= MEMORY_SIZE => {
+                                for _ in 0..size {
+                                    cursor.place(
+                                        &mut layout,
+                                        Placement::Reserved,
+                                        &content.location,
+                                        &mut errors,
+                                    );
+                                }
                             }
-                            position += 1;
+                            _ => {
+                                errors.push(MemoryLayoutError::SpaceDoesNotFit {
+                                    address: cursor.position,
+                                    size,
+                                    location: content.location.clone(),
+                                });
+                            }
                         }
                     }
                     Err(source) => {
@@ -230,7 +302,7 @@ pub(crate) fn layout_memory(program: &[Located<Line>]) -> (Layout, Vec<MemoryLay
                 } => match e.evaluate(&EmptyExpressionContext) {
                     Ok(addr) => {
                         debug!(addr, "Changing address");
-                        position = addr;
+                        cursor.seek(addr);
                     }
                     Err(source) => {
                         errors.push(MemoryLayoutError::DirectiveArgumentEvaluation {
@@ -249,24 +321,21 @@ pub(crate) fn layout_memory(program: &[Located<Line>]) -> (Layout, Vec<MemoryLay
                             ..
                         },
                 } => {
-                    trace!(position, string = string.as_str(), "Inserting string");
+                    trace!(
+                        position = cursor.position,
+                        string = string.as_str(),
+                        "Inserting string"
+                    );
                     for c in string.chars() {
-                        if let Err(e) = layout.insert_placement(
-                            position,
+                        cursor.place(
+                            &mut layout,
                             Placement::Char(c),
-                            content.location.clone(),
-                        ) {
-                            errors.push(e);
-                        }
-                        position += 1;
+                            &content.location,
+                            &mut errors,
+                        );
                     }
 
-                    if let Err(e) =
-                        layout.insert_placement(position, Placement::Nul, content.location.clone())
-                    {
-                        errors.push(e);
-                    }
-                    position += 1;
+                    cursor.place(&mut layout, Placement::Nul, &content.location, &mut errors);
                 }
 
                 LineContent::Directive { kind, .. } => {
@@ -287,7 +356,7 @@ pub(crate) fn layout_memory(program: &[Located<Line>]) -> (Layout, Vec<MemoryLay
 
 #[cfg(test)]
 mod tests {
-    use InstructionKind::{Add, Jmp};
+    use InstructionKind::{Add, Jmp, Nop};
 
     use super::*;
     use crate::parser::expression::Node;
@@ -478,6 +547,95 @@ mod tests {
         match &errors[0] {
             MemoryLayoutError::MemoryOverlap { address, .. } => assert_eq!(*address, 14),
             other => panic!("expected MemoryOverlap, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn addr_directive_out_of_bounds_test() {
+        // .addr 9999 leaves only address 9999 valid; the second nop lands on
+        // address 10000.
+        let program: Vec<Located<Line>> = vec![
+            Line::empty().directive(DirectiveKind::Addr, 9999),
+            Line::empty().instruction(Nop, vec![]),
+            Line::empty().instruction(Nop, vec![]),
+        ];
+
+        let (_, errors) = layout_memory(&program);
+        assert_eq!(errors.len(), 1);
+        match &errors[0] {
+            MemoryLayoutError::OutOfBounds { address, .. } => assert_eq!(*address, 10000),
+            other => panic!("expected OutOfBounds, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn space_directive_out_of_bounds_test() {
+        let program: Vec<Located<Line>> = vec![
+            Line::empty().directive(DirectiveKind::Addr, 9990),
+            Line::empty().directive(DirectiveKind::Space, 20),
+        ];
+
+        let (_, errors) = layout_memory(&program);
+        assert_eq!(errors.len(), 1);
+        match &errors[0] {
+            MemoryLayoutError::SpaceDoesNotFit { address, size, .. } => {
+                assert_eq!(*address, 9990);
+                assert_eq!(*size, 20);
+            }
+            other => panic!("expected SpaceDoesNotFit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn space_directive_huge_argument_does_not_loop_test() {
+        // The bounds check runs before the loop, so `layout.memory` stays
+        // empty for an argument this large.
+        let program: Vec<Located<Line>> =
+            vec![Line::empty().directive(DirectiveKind::Space, 50_000_000)];
+
+        let (layout, errors) = layout_memory(&program);
+        assert_eq!(errors.len(), 1);
+        assert!(matches!(
+            errors[0],
+            MemoryLayoutError::SpaceDoesNotFit { .. }
+        ));
+        assert!(layout.memory.is_empty());
+    }
+
+    #[test]
+    fn addr_directive_at_the_last_address_test() {
+        // The cursor sits on the highest address an expression can name;
+        // advancing past it must not overflow.
+        let program: Vec<Located<Line>> = vec![
+            Line::empty().directive(DirectiveKind::Addr, i128::from(Address::MAX)),
+            Line::empty().instruction(Nop, vec![]),
+            Line::empty().instruction(Nop, vec![]),
+        ];
+
+        let (_, errors) = layout_memory(&program);
+        assert_eq!(errors.len(), 1);
+        match &errors[0] {
+            MemoryLayoutError::OutOfBounds { address, .. } => {
+                assert_eq!(*address, Address::MAX);
+            }
+            other => panic!("expected OutOfBounds, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn out_of_bounds_run_is_reported_once_test() {
+        // `.string` places one cell per character plus a NUL; only the first
+        // address past the end of memory is reported.
+        let program: Vec<Located<Line>> = vec![
+            Line::empty().directive(DirectiveKind::Addr, 9998),
+            Line::empty().directive(DirectiveKind::String, "hello"),
+        ];
+
+        let (_, errors) = layout_memory(&program);
+        assert_eq!(errors.len(), 1);
+        match &errors[0] {
+            MemoryLayoutError::OutOfBounds { address, .. } => assert_eq!(*address, 10000),
+            other => panic!("expected OutOfBounds, got {other:?}"),
         }
     }
 }

--- a/crates/emulator/src/compiler/memory.rs
+++ b/crates/emulator/src/compiler/memory.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 use tracing::{Level, debug, span, trace};
 
 use super::layout::{Labels, Layout, Placement};
+use crate::constants::Address;
 use crate::parser::expression::EvaluationError as ExpressionEvaluationError;
 use crate::parser::line::LineContent;
 use crate::parser::location::Located;
@@ -35,6 +36,14 @@ pub enum MemoryFillError {
         /// Spans of each argument (indexed same as the instruction arguments)
         argument_spans: SmallVec<[Range<usize>; 2]>,
         source: InstructionCompilationError,
+    },
+
+    /// `Layout::insert_placement` rejects addresses outside `MEMORY_SIZE`,
+    /// so this only fires if that invariant is broken upstream.
+    #[error("address {address} is out of bounds")]
+    AddressOutOfBounds {
+        address: Address,
+        location: Range<usize>,
     },
 }
 
@@ -411,14 +420,19 @@ pub(crate) fn fill_memory(layout: &Layout) -> (Memory, Vec<MemoryFillError>) {
     let mut memory = Memory::default();
     let mut errors = Vec::new();
 
-    for (index, (placement, _location)) in &layout.memory {
+    for (index, (placement, location)) in &layout.memory {
         let span = span!(Level::TRACE, "placement", index);
         let _guard = span.enter();
         match compile_placement(&layout.labels, placement) {
             Ok(cell) => {
                 trace!(address = index, content = %cell, "Filling cell");
-                let dest = memory.get_mut(*index).unwrap();
-                *dest = cell;
+                match memory.get_mut(*index) {
+                    Ok(dest) => *dest = cell,
+                    Err(_) => errors.push(MemoryFillError::AddressOutOfBounds {
+                        address: *index,
+                        location: location.clone(),
+                    }),
+                }
             }
             Err(e) => {
                 errors.push(e);

--- a/crates/emulator/src/dap/mod.rs
+++ b/crates/emulator/src/dap/mod.rs
@@ -1449,11 +1449,12 @@ fn eval_address(program: &LoadedProgram, input: &str) -> Result<Address, String>
             let offset: i128 = node
                 .evaluate::<_, i128>(&program.labels)
                 .map_err(|e| e.to_string())?;
-            if is_plus {
-                base + offset
+            let indexed = if is_plus {
+                base.checked_add(offset)
             } else {
-                base - offset
-            }
+                base.checked_sub(offset)
+            };
+            indexed.ok_or_else(|| format!("offset out of range: {offset}"))?
         }
     };
     Address::try_from(value).map_err(|_| format!("address out of range: {value}"))
@@ -1484,7 +1485,9 @@ enum AddrArg {
 fn parse_addr_arg(input: &str) -> Result<AddrArg, String> {
     use chumsky::prelude::*;
 
-    use crate::parser::shared::{expression, register};
+    use crate::parser::shared::{expression, register, reject_deep_nesting};
+
+    reject_deep_nesting(input)?;
 
     let indexed = register()
         .then(choice((just('+').to(true), just('-').to(false))).then(expression()))

--- a/crates/emulator/src/dap/tests.rs
+++ b/crates/emulator/src/dap/tests.rs
@@ -388,6 +388,44 @@ fn evaluate_resolves_a_label() {
 }
 
 #[test]
+fn evaluate_rejects_input_the_expression_parser_cannot_descend() {
+    let mut h = Harness::new();
+    h.launch(true);
+
+    let deep = format!("{}1{}", "(".repeat(50_000), ")".repeat(50_000));
+    let resp = h.send("evaluate", json!({ "expression": deep }));
+    let resp = find_response(&resp, "evaluate").expect("evaluate response");
+    assert_eq!(resp["success"], json!(false));
+    assert!(
+        resp["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("nesting")),
+        "{resp}"
+    );
+}
+
+#[test]
+fn evaluate_rejects_an_indexed_offset_that_overflows() {
+    let mut h = Harness::new();
+    h.launch(true);
+
+    // Literals cap at u64, so i128::MAX has to be computed to reach the
+    // add that combines the register with the offset.
+    let resp = h.send(
+        "evaluate",
+        json!({ "expression": "%sp+(1 << 126) - 1 + (1 << 126)" }),
+    );
+    let resp = find_response(&resp, "evaluate").expect("evaluate response");
+    assert_eq!(resp["success"], json!(false));
+    assert!(
+        resp["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("out of range")),
+        "{resp}"
+    );
+}
+
+#[test]
 fn running_to_completion_terminates() {
     let mut h = Harness::new();
     // Do not stop on entry: the program runs to the `reset` immediately.

--- a/crates/emulator/src/diagnostic.rs
+++ b/crates/emulator/src/diagnostic.rs
@@ -15,6 +15,7 @@ use codespan_reporting::files::SimpleFiles;
 use codespan_reporting::term;
 
 use crate::compiler::CompilationError;
+use crate::constants::MEMORY_SIZE;
 use crate::parser::shared::{DiagnosticSeverity, ParseDiagnostic};
 use crate::preprocessor::PreprocessorError;
 
@@ -228,6 +229,24 @@ fn layout_error_to_diagnostic(
                 Label::secondary(file_id, original_location.clone())
                     .with_message("already filled by this directive"),
             ]),
+
+        MLE::OutOfBounds { address, location } => Diagnostic::error()
+            .with_message(format!("address {address} is outside of memory"))
+            .with_labels(vec![
+                Label::primary(file_id, location.clone()).with_message("does not fit in memory"),
+            ]),
+
+        MLE::SpaceDoesNotFit {
+            address,
+            size,
+            location,
+        } => Diagnostic::error()
+            .with_message(format!(
+                "reserving {size} cells from address {address} does not fit in memory (0..{MEMORY_SIZE})"
+            ))
+            .with_labels(vec![
+                Label::primary(file_id, location.clone()).with_message("reservation is too large"),
+            ]),
     }
 }
 
@@ -348,6 +367,12 @@ fn memory_fill_error_to_diagnostic(
                     .with_labels(labels)
             }
         },
+
+        MFE::AddressOutOfBounds { address, location } => Diagnostic::error()
+            .with_message(format!("address {address} is out of bounds"))
+            .with_labels(vec![
+                Label::primary(file_id, location.clone()).with_message("does not fit in memory"),
+            ]),
     }
 }
 

--- a/crates/emulator/src/lsp/diagnostics.rs
+++ b/crates/emulator/src/lsp/diagnostics.rs
@@ -93,6 +93,22 @@ fn convert_layout_error(
             format!("memory overlap at address {address}"),
             severity,
         ),
+        MemoryLayoutError::OutOfBounds { address, location } => make_resolved_diagnostic(
+            state,
+            location.clone(),
+            format!("address {address} is outside of memory"),
+            severity,
+        ),
+        MemoryLayoutError::SpaceDoesNotFit {
+            address,
+            size,
+            location,
+        } => make_resolved_diagnostic(
+            state,
+            location.clone(),
+            format!("reserving {size} cells from address {address} does not fit in memory"),
+            severity,
+        ),
     }
 }
 
@@ -171,6 +187,16 @@ fn convert_fill_error(
                 }
             }
         },
+        MemoryFillError::AddressOutOfBounds { address, location } => {
+            if let Some(d) = make_resolved_diagnostic(
+                state,
+                location.clone(),
+                format!("address {address} is out of bounds"),
+                severity,
+            ) {
+                out.push(d);
+            }
+        }
     }
 }
 

--- a/crates/emulator/src/lsp/tests.rs
+++ b/crates/emulator/src/lsp/tests.rs
@@ -158,6 +158,27 @@ fn did_open_with_broken_program_publishes_diagnostics() {
 }
 
 #[test]
+fn deeply_nested_expression_is_a_diagnostic_not_a_crash() {
+    let mut h = Harness::new();
+    h.initialize();
+    let source = format!(
+        "main:\n    ld {}1{}, %a\n",
+        "(".repeat(200),
+        ")".repeat(200)
+    );
+    let out = h.open("main.s", &source);
+    let uri = format!("{ROOT_URI}/main.s");
+    let diags = find_diagnostics(&out, &uri).expect("diagnostics published");
+    let diags = diags["params"]["diagnostics"].as_array().unwrap();
+    assert!(
+        diags
+            .iter()
+            .any(|d| d["message"].as_str().is_some_and(|m| m.contains("nesting"))),
+        "{diags:?}"
+    );
+}
+
+#[test]
 fn workspace_files_seed_cross_file_goto_definition() {
     let mut h = Harness::new();
     h.initialize();

--- a/crates/emulator/src/parser/assembly.rs
+++ b/crates/emulator/src/parser/assembly.rs
@@ -9,11 +9,14 @@ use smallvec::SmallVec;
 use super::line::{Line, LineContent, Program};
 use super::location::{Locatable, Located};
 use super::shared::{
-    Extra, ParseDiagnostic, expression, hspace, hspace1, register, span_to_range, string_literal,
+    DiagnosticSeverity, Extra, ParseDiagnostic, expression, hspace, hspace1, register,
+    span_to_range, string_literal,
 };
 use super::value::{DirectiveArgument, DirectiveKind, InstructionArgument, InstructionKind};
 use crate::parser::expression::Node as ExpressionNode;
-use crate::parser::shared::{is_identifier_char, is_start_identifier_char, rich_to_diagnostic};
+use crate::parser::shared::{
+    is_identifier_char, is_start_identifier_char, reject_deep_nesting, rich_to_diagnostic,
+};
 
 /// Result of parsing: always produces a program, plus accumulated diagnostics.
 pub struct ParseResult {
@@ -307,6 +310,26 @@ pub fn parse(input: &str) -> ParseResult {
         let line_len = raw_line.len();
         let raw_line = raw_line.strip_suffix('\r').unwrap_or(raw_line);
 
+        if let Err(message) = reject_deep_nesting(raw_line) {
+            let span = offset..offset + raw_line.len();
+            diagnostics.push(ParseDiagnostic {
+                span: span.clone(),
+                message,
+                severity: DiagnosticSeverity::Error,
+                labels: SmallVec::new(),
+            });
+            lines.push(
+                Line {
+                    symbols: SmallVec::new(),
+                    content: Some(LineContent::Error.with_location(span.clone())),
+                    comment: None,
+                }
+                .with_location(span),
+            );
+            offset += line_len + 1;
+            continue;
+        }
+
         let result = line_parser.parse(raw_line);
 
         let parsed_line = if let Some(mut l) = result.output().cloned() {
@@ -354,6 +377,33 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
+    use crate::parser::shared::MAX_EXPRESSION_DEPTH;
+
+    #[test]
+    fn nesting_at_the_limit_parses_and_one_more_is_reported() {
+        std::thread::Builder::new()
+            .stack_size(2 << 20)
+            .spawn(|| {
+                let at_limit = format!(
+                    "    ld {}1{}, %a",
+                    "(".repeat(MAX_EXPRESSION_DEPTH),
+                    ")".repeat(MAX_EXPRESSION_DEPTH)
+                );
+                assert!(parse(&at_limit).diagnostics.is_empty());
+
+                let over_limit = format!(
+                    "    ld {}1{}, %a",
+                    "(".repeat(MAX_EXPRESSION_DEPTH + 1),
+                    ")".repeat(MAX_EXPRESSION_DEPTH + 1)
+                );
+                let diagnostics = parse(&over_limit).diagnostics;
+                assert_eq!(diagnostics.len(), 1);
+                assert!(diagnostics[0].message.contains("nesting"));
+            })
+            .expect("spawn")
+            .join()
+            .expect("the parser must not overflow a 2 MiB stack");
+    }
     use crate::runtime::Reg;
 
     #[test]

--- a/crates/emulator/src/parser/condition.rs
+++ b/crates/emulator/src/parser/condition.rs
@@ -28,7 +28,9 @@ use super::expression::{
 };
 use super::location::{Locatable, Located};
 use super::precedence::Precedence;
-use super::shared::{Extra, bool_literal, expression, hspace, identifier, span_to_range};
+use super::shared::{
+    Extra, bool_literal, expression, hspace, identifier, reject_deep_nesting, span_to_range,
+};
 
 type ChildNode = Located<Box<Node>>;
 type ExpressionNode = Located<ENode>;
@@ -315,13 +317,16 @@ fn number_comparison<'a>() -> impl Parser<'a, &'a str, Node, Extra<'a>> + Clone 
             Cmp::Le => Node::LesserOrEqual(a, b),
             Cmp::Lt => Node::LesserThan(a, b),
         })
+        .boxed()
 }
 
 /// Parse a condition expression.
 pub(crate) fn condition_parser<'a>() -> impl Parser<'a, &'a str, Node, Extra<'a>> + Clone {
     recursive(|condition| {
         // Atoms: parenthesized, defined(), bool literal, or number comparison
-        let paren = condition.delimited_by(just('(').then(hspace()), hspace().then(just(')')));
+        let paren = condition
+            .delimited_by(just('(').then(hspace()), hspace().then(just(')')))
+            .boxed();
 
         let atom = choice((
             paren,
@@ -329,46 +334,54 @@ pub(crate) fn condition_parser<'a>() -> impl Parser<'a, &'a str, Node, Extra<'a>
             bool_literal().map(Node::Literal),
             number_comparison(),
         ))
-        .padded_by(hspace());
+        .padded_by(hspace())
+        .boxed();
 
         // Logical NOT
         let logical_expr = just('!')
             .ignore_then(hspace())
             .ignore_then(atom.clone())
             .map_with(|node, e| Node::Not(Box::new(node).with_location(span_to_range(e.span()))))
-            .or(atom);
+            .or(atom)
+            .boxed();
 
         // Logical AND
-        let logical_and = logical_expr.clone().foldl_with(
-            hspace()
-                .ignore_then(just("&&"))
-                .then_ignore(hspace())
-                .ignore_then(logical_expr)
-                .repeated(),
-            |lhs, rhs, e| {
-                let span = e.span();
-                Node::And(
-                    Box::new(lhs).with_location(span.start..span.start),
-                    Box::new(rhs).with_location(span.end..span.end),
-                )
-            },
-        );
+        let logical_and = logical_expr
+            .clone()
+            .foldl_with(
+                hspace()
+                    .ignore_then(just("&&"))
+                    .then_ignore(hspace())
+                    .ignore_then(logical_expr)
+                    .repeated(),
+                |lhs, rhs, e| {
+                    let span = e.span();
+                    Node::And(
+                        Box::new(lhs).with_location(span.start..span.start),
+                        Box::new(rhs).with_location(span.end..span.end),
+                    )
+                },
+            )
+            .boxed();
 
         // Logical OR
-        logical_and.clone().foldl_with(
-            hspace()
-                .ignore_then(just("||"))
-                .then_ignore(hspace())
-                .ignore_then(logical_and)
-                .repeated(),
-            |lhs, rhs, e| {
-                let span = e.span();
-                Node::Or(
-                    Box::new(lhs).with_location(span.start..span.start),
-                    Box::new(rhs).with_location(span.end..span.end),
-                )
-            },
-        )
+        logical_and
+            .clone()
+            .foldl_with(
+                hspace()
+                    .ignore_then(just("||"))
+                    .then_ignore(hspace())
+                    .ignore_then(logical_and)
+                    .repeated(),
+                |lhs, rhs, e| {
+                    let span = e.span();
+                    Node::Or(
+                        Box::new(lhs).with_location(span.start..span.start),
+                        Box::new(rhs).with_location(span.end..span.end),
+                    )
+                },
+            )
+            .boxed()
     })
     .boxed()
 }
@@ -377,6 +390,7 @@ pub(crate) fn condition_parser<'a>() -> impl Parser<'a, &'a str, Node, Extra<'a>
 ///
 /// Returns the condition AST node, or an error string on parse failure.
 pub(crate) fn parse_condition(input: &str) -> Result<Node, String> {
+    reject_deep_nesting(input)?;
     let result = condition_parser().then_ignore(end()).parse(input);
     result.into_result().map_err(|errs| {
         errs.into_iter()
@@ -391,6 +405,33 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    #[test]
+    fn nesting_at_the_limit_parses_and_one_more_is_rejected() {
+        use crate::parser::shared::MAX_EXPRESSION_DEPTH;
+
+        std::thread::Builder::new()
+            .stack_size(2 << 20)
+            .spawn(|| {
+                let at_limit = format!(
+                    "{}1{} > 0",
+                    "(".repeat(MAX_EXPRESSION_DEPTH),
+                    ")".repeat(MAX_EXPRESSION_DEPTH)
+                );
+                parse_condition(&at_limit).expect("must parse at the limit");
+
+                let over_limit = format!(
+                    "{}1{} > 0",
+                    "(".repeat(MAX_EXPRESSION_DEPTH + 1),
+                    ")".repeat(MAX_EXPRESSION_DEPTH + 1)
+                );
+                let err = parse_condition(&over_limit).expect_err("must be rejected");
+                assert!(err.contains("nesting"), "{err}");
+            })
+            .expect("spawn")
+            .join()
+            .expect("the parser must not overflow a 2 MiB stack");
+    }
 
     #[track_caller]
     fn evaluate(input: &str) -> bool {

--- a/crates/emulator/src/parser/expression.rs
+++ b/crates/emulator/src/parser/expression.rs
@@ -290,18 +290,8 @@ impl Node {
                 }
 
                 Node::BinaryNot(operand) => {
-                    let _operand: Value = operand.inner.evaluate(context)?;
-                    // TODO: bit inversion is tricky because we're not supposed
-                    // to know the word length here. It's a
-                    // bit opiniated, but for now it tries
-                    // casting down to u16 before negating.
-
-                    /*
-                    u16::try_from(v) // try casting it down to u16
-                        .map(|v| !v) // invert the bits
-                        .map(|v| v as _) // cast it back up
-                    */
-                    todo!()
+                    let operand: Value = operand.inner.evaluate(context)?;
+                    !operand
                 }
 
                 Node::Literal(value) => *value,

--- a/crates/emulator/src/parser/preprocessor.rs
+++ b/crates/emulator/src/parser/preprocessor.rs
@@ -290,7 +290,9 @@ fn parse_chunks(input: &str, base_offset: usize) -> Result<Children, String> {
 
         if let Ok(condition) = p_if.parse(line).into_result() {
             let node_start = pos;
-            let block_start = pos + full_line_len + 1;
+            // The body starts after the newline; a file ending on the `#if`
+            // line has no newline to skip, and the block is then unterminated.
+            let block_start = (pos + full_line_len + 1).min(input.len());
             let (node, block_end) =
                 parse_conditional_block(input, block_start, base_offset, node_start, condition)?;
 
@@ -464,6 +466,14 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    #[test]
+    fn unterminated_if_on_the_last_line_is_an_error() {
+        for input in ["#if 1", "#if 1\n", "#if 1\nfoo", "#if 1\n#else"] {
+            let err = parse(input).expect_err(input);
+            assert!(err.contains("unterminated #if"), "{input:?}: {err}");
+        }
+    }
 
     #[test]
     fn parse_raw_test() {

--- a/crates/emulator/src/parser/preprocessor.rs
+++ b/crates/emulator/src/parser/preprocessor.rs
@@ -250,9 +250,17 @@ fn push_newline(
 // Top-level parse function
 // ---------------------------------------------------------------------------
 
+/// Deepest nesting of `#if` blocks.
+///
+/// `parse_chunks` and `parse_conditional_block` recurse once per level, and
+/// [`crate::preprocessor`] walks the resulting tree with the same shape. A
+/// debug build overflows a 2 MiB thread — what cargo gives a test thread and
+/// tokio an LSP worker — past 240 levels.
+pub(crate) const MAX_CONDITIONAL_DEPTH: usize = 64;
+
 /// Parse preprocessor directives and raw assembly lines.
 pub(crate) fn parse(input: &str) -> Result<Children, String> {
-    let chunks = parse_chunks(input, 0)?;
+    let chunks = parse_chunks(input, 0, 0)?;
 
     let consumed: usize = chunks.last().map_or(0, |c| c.location.end);
     let remaining = input[consumed..].trim();
@@ -266,8 +274,8 @@ pub(crate) fn parse(input: &str) -> Result<Children, String> {
     Ok(chunks)
 }
 
-/// Recursive chunk parser.
-fn parse_chunks(input: &str, base_offset: usize) -> Result<Children, String> {
+/// Recursive chunk parser. `depth` counts the enclosing `#if` blocks.
+fn parse_chunks(input: &str, base_offset: usize, depth: usize) -> Result<Children, String> {
     let mut chunks = Vec::new();
     let mut pos = 0;
 
@@ -289,12 +297,25 @@ fn parse_chunks(input: &str, base_offset: usize) -> Result<Children, String> {
         let full_line_len = line_end;
 
         if let Ok(condition) = p_if.parse(line).into_result() {
+            if depth >= MAX_CONDITIONAL_DEPTH {
+                return Err(format!(
+                    "conditional blocks nested too deep (more than \
+                     {MAX_CONDITIONAL_DEPTH} levels): {line}"
+                ));
+            }
+
             let node_start = pos;
             // The body starts after the newline; a file ending on the `#if`
             // line has no newline to skip, and the block is then unterminated.
             let block_start = (pos + full_line_len + 1).min(input.len());
-            let (node, block_end) =
-                parse_conditional_block(input, block_start, base_offset, node_start, condition)?;
+            let (node, block_end) = parse_conditional_block(
+                input,
+                block_start,
+                base_offset,
+                node_start,
+                condition,
+                depth + 1,
+            )?;
 
             chunks.push(node.with_location((pos + base_offset)..(block_end + base_offset)));
             pos = block_end;
@@ -346,6 +367,7 @@ fn parse_conditional_block(
     base_offset: usize,
     node_start: usize,
     first_condition: Located<String>,
+    depth: usize,
 ) -> Result<(Node, usize), String> {
     let mut branches = Vec::new();
     let mut fallback = None;
@@ -356,7 +378,7 @@ fn parse_conditional_block(
     let p_else = else_parser();
     let p_endif = endif_parser();
 
-    let (body_chunks, body_end) = parse_body_until_boundary(input, body_start)?;
+    let (body_chunks, body_end) = parse_body_until_boundary(input, body_start, depth)?;
     let body = body_chunks.with_location(
         (body_start - node_start + base_offset)..(body_end - node_start + base_offset),
     );
@@ -396,7 +418,7 @@ fn parse_conditional_block(
             }
 
             body_start = pos;
-            let (body_chunks, body_end) = parse_body_until_boundary(input, body_start)?;
+            let (body_chunks, body_end) = parse_body_until_boundary(input, body_start, depth)?;
             let body = body_chunks.with_location(
                 (body_start - node_start + base_offset)..(body_end - node_start + base_offset),
             );
@@ -409,7 +431,7 @@ fn parse_conditional_block(
             }
 
             body_start = pos;
-            let (body_chunks, body_end) = parse_body_until_boundary(input, body_start)?;
+            let (body_chunks, body_end) = parse_body_until_boundary(input, body_start, depth)?;
             let body = body_chunks.with_location(
                 (body_start - node_start + base_offset)..(body_end - node_start + base_offset),
             );
@@ -424,11 +446,15 @@ fn parse_conditional_block(
 }
 
 /// Parse chunks from `input[start..]` until hitting a boundary directive.
-fn parse_body_until_boundary(input: &str, start: usize) -> Result<(Children, usize), String> {
+fn parse_body_until_boundary(
+    input: &str,
+    start: usize,
+    depth: usize,
+) -> Result<(Children, usize), String> {
     let body_input = &input[start..];
     let boundary = find_body_boundary(body_input)?;
     let body_slice = &body_input[..boundary];
-    let chunks = parse_chunks(body_slice, 0)?;
+    let chunks = parse_chunks(body_slice, 0, depth)?;
     Ok((chunks, start + boundary))
 }
 
@@ -466,6 +492,30 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    #[test]
+    fn nesting_at_the_limit_parses_and_one_more_is_rejected() {
+        fn nested(depth: usize) -> String {
+            format!(
+                "{}nop\n{}",
+                "#if 1\n".repeat(depth),
+                "#endif\n".repeat(depth)
+            )
+        }
+
+        std::thread::Builder::new()
+            .stack_size(2 << 20)
+            .spawn(|| {
+                parse(&nested(MAX_CONDITIONAL_DEPTH)).expect("must parse at the limit");
+
+                let err = parse(&nested(MAX_CONDITIONAL_DEPTH + 1))
+                    .expect_err("one level deeper must be rejected");
+                assert!(err.contains("nested too deep"), "{err}");
+            })
+            .expect("spawn")
+            .join()
+            .expect("the parser must not overflow a 2 MiB stack");
+    }
 
     #[test]
     fn unterminated_if_on_the_last_line_is_an_error() {

--- a/crates/emulator/src/parser/shared.rs
+++ b/crates/emulator/src/parser/shared.rs
@@ -248,6 +248,64 @@ pub fn register<'a>() -> impl Parser<'a, &'a str, Reg, Extra<'a>> + Clone {
 }
 
 // ---------------------------------------------------------------------------
+// Expression nesting guard
+// ---------------------------------------------------------------------------
+
+/// Deepest parenthesis nesting an expression may contain.
+///
+/// Each level of parentheses costs one recursion through [`expression`]. A
+/// debug build overflows a 1 MiB thread, the dev wasm build's stack, at 14
+/// levels, and a 2 MiB thread (cargo test threads, tokio LSP workers) at 30.
+pub const MAX_EXPRESSION_DEPTH: usize = 8;
+
+/// Maximum parenthesis nesting in `input`, ignoring string literals and
+/// anything after a `//` comment.
+pub(crate) fn paren_depth(input: &str) -> usize {
+    let mut depth = 0usize;
+    let mut max = 0usize;
+    let mut in_string = false;
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if in_string {
+            match c {
+                '\\' => {
+                    chars.next();
+                }
+                '"' => in_string = false,
+                _ => {}
+            }
+            continue;
+        }
+        match c {
+            '"' => in_string = true,
+            '/' if chars.peek() == Some(&'/') => break,
+            '(' => {
+                depth += 1;
+                max = max.max(depth);
+            }
+            ')' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    max
+}
+
+/// Check `input` before handing it to [`expression`].
+///
+/// # Errors
+///
+/// Returns a diagnostic message when the parenthesis nesting exceeds
+/// [`MAX_EXPRESSION_DEPTH`].
+pub fn reject_deep_nesting(input: &str) -> Result<(), String> {
+    if paren_depth(input) > MAX_EXPRESSION_DEPTH {
+        return Err(format!(
+            "expression nesting is too deep (more than {MAX_EXPRESSION_DEPTH} levels)"
+        ));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Expressions
 // ---------------------------------------------------------------------------
 
@@ -260,6 +318,11 @@ pub fn expression<'a>() -> impl Parser<'a, &'a str, ExpressionNode, Extra<'a>> +
     // outermost bitwise-or tier) rather than back into the atom tier. Without
     // this, `( ... )` could only wrap a bare atom and operator expressions like
     // `(1 << 8)` failed to parse.
+    //
+    // Every tier is `.boxed()`: each one embeds the tier below it twice, so
+    // without the type erasure a single recursion step carries the whole
+    // ladder inlined and costs a debug stack frame six times larger. See
+    // MAX_EXPRESSION_DEPTH.
     recursive(|expr| {
         let number = number_literal().map(|v| ExpressionNode::Literal(ExpressionValue::from(v)));
 
@@ -269,7 +332,7 @@ pub fn expression<'a>() -> impl Parser<'a, &'a str, ExpressionNode, Extra<'a>> +
         // any operator expression is valid between the parentheses.
         let paren = expr.delimited_by(just('(').then(hspace()), hspace().then(just(')')));
 
-        let atom = number.or(variable).or(paren);
+        let atom = number.or(variable).or(paren).boxed();
 
         // Unary operators
         let unary = choice((
@@ -286,82 +349,95 @@ pub fn expression<'a>() -> impl Parser<'a, &'a str, ExpressionNode, Extra<'a>> +
                     ExpressionNode::BinaryNot(Box::new(rhs).with_location(span_to_range(e.span())))
                 }),
             atom,
-        ));
+        ))
+        .boxed();
 
         // Multiplication / Division
         let op = just('*').to(true).or(just('/').to(false));
-        let product = unary.clone().foldl_with(
-            hspace()
-                .ignore_then(op)
-                .then_ignore(hspace())
-                .then(unary)
-                .repeated(),
-            |lhs, (is_mul, rhs), e| {
-                let span = e.span();
-                let lhs = Box::new(lhs).with_location(span.start..span.start);
-                let rhs = Box::new(rhs).with_location(span.end..span.end);
-                if is_mul {
-                    ExpressionNode::Multiply(lhs, rhs)
-                } else {
-                    ExpressionNode::Divide(lhs, rhs)
-                }
-            },
-        );
+        let product = unary
+            .clone()
+            .foldl_with(
+                hspace()
+                    .ignore_then(op)
+                    .then_ignore(hspace())
+                    .then(unary)
+                    .repeated(),
+                |lhs, (is_mul, rhs), e| {
+                    let span = e.span();
+                    let lhs = Box::new(lhs).with_location(span.start..span.start);
+                    let rhs = Box::new(rhs).with_location(span.end..span.end);
+                    if is_mul {
+                        ExpressionNode::Multiply(lhs, rhs)
+                    } else {
+                        ExpressionNode::Divide(lhs, rhs)
+                    }
+                },
+            )
+            .boxed();
 
         // Addition / Subtraction
         let op = just('+').to(true).or(just('-').to(false));
-        let sum = product.clone().foldl_with(
-            hspace()
-                .ignore_then(op)
-                .then_ignore(hspace())
-                .then(product)
-                .repeated(),
-            |lhs, (is_add, rhs), e| {
-                let span = e.span();
-                let lhs = Box::new(lhs).with_location(span.start..span.start);
-                let rhs = Box::new(rhs).with_location(span.end..span.end);
-                if is_add {
-                    ExpressionNode::Sum(lhs, rhs)
-                } else {
-                    ExpressionNode::Substract(lhs, rhs)
-                }
-            },
-        );
+        let sum = product
+            .clone()
+            .foldl_with(
+                hspace()
+                    .ignore_then(op)
+                    .then_ignore(hspace())
+                    .then(product)
+                    .repeated(),
+                |lhs, (is_add, rhs), e| {
+                    let span = e.span();
+                    let lhs = Box::new(lhs).with_location(span.start..span.start);
+                    let rhs = Box::new(rhs).with_location(span.end..span.end);
+                    if is_add {
+                        ExpressionNode::Sum(lhs, rhs)
+                    } else {
+                        ExpressionNode::Substract(lhs, rhs)
+                    }
+                },
+            )
+            .boxed();
 
         // Shifts
         let op = just("<<").to(true).or(just(">>").to(false));
-        let shift = sum.clone().foldl_with(
-            hspace()
-                .ignore_then(op)
-                .then_ignore(hspace())
-                .then(sum)
-                .repeated(),
-            |lhs, (is_left, rhs), e| {
-                let span = e.span();
-                let lhs = Box::new(lhs).with_location(span.start..span.start);
-                let rhs = Box::new(rhs).with_location(span.end..span.end);
-                if is_left {
-                    ExpressionNode::LeftShift(lhs, rhs)
-                } else {
-                    ExpressionNode::RightShift(lhs, rhs)
-                }
-            },
-        );
+        let shift = sum
+            .clone()
+            .foldl_with(
+                hspace()
+                    .ignore_then(op)
+                    .then_ignore(hspace())
+                    .then(sum)
+                    .repeated(),
+                |lhs, (is_left, rhs), e| {
+                    let span = e.span();
+                    let lhs = Box::new(lhs).with_location(span.start..span.start);
+                    let rhs = Box::new(rhs).with_location(span.end..span.end);
+                    if is_left {
+                        ExpressionNode::LeftShift(lhs, rhs)
+                    } else {
+                        ExpressionNode::RightShift(lhs, rhs)
+                    }
+                },
+            )
+            .boxed();
 
         // Bitwise AND (must not match &&)
-        let band = shift.clone().foldl_with(
-            hspace()
-                .ignore_then(just('&').then_ignore(just('&').not()))
-                .then_ignore(hspace())
-                .ignore_then(shift)
-                .repeated(),
-            |lhs, rhs, e| {
-                let span = e.span();
-                let lhs = Box::new(lhs).with_location(span.start..span.start);
-                let rhs = Box::new(rhs).with_location(span.end..span.end);
-                ExpressionNode::BinaryAnd(lhs, rhs)
-            },
-        );
+        let band = shift
+            .clone()
+            .foldl_with(
+                hspace()
+                    .ignore_then(just('&').then_ignore(just('&').not()))
+                    .then_ignore(hspace())
+                    .ignore_then(shift)
+                    .repeated(),
+                |lhs, rhs, e| {
+                    let span = e.span();
+                    let lhs = Box::new(lhs).with_location(span.start..span.start);
+                    let rhs = Box::new(rhs).with_location(span.end..span.end);
+                    ExpressionNode::BinaryAnd(lhs, rhs)
+                },
+            )
+            .boxed();
 
         // Bitwise OR (must not match ||)
         band.clone()
@@ -389,6 +465,7 @@ pub fn expression<'a>() -> impl Parser<'a, &'a str, ExpressionNode, Extra<'a>> +
 
 /// Parse a complete expression string, returning the AST node.
 pub fn parse_expression_str(input: &str) -> Result<ExpressionNode, String> {
+    reject_deep_nesting(input)?;
     let result = expression().then_ignore(end()).parse(input);
     result.into_result().map_err(|errs| {
         errs.into_iter()
@@ -403,7 +480,18 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::super::expression::{EmptyContext, Node};
-    use super::parse_expression_str;
+    use super::{MAX_EXPRESSION_DEPTH, paren_depth, parse_expression_str};
+
+    /// Run `f` on a thread with the smallest stack the parser is expected to
+    /// run on: what cargo gives a test thread and tokio an LSP worker.
+    fn on_a_small_stack(f: impl FnOnce() + Send + 'static) {
+        std::thread::Builder::new()
+            .stack_size(2 << 20)
+            .spawn(f)
+            .expect("spawn")
+            .join()
+            .expect("the parser must not overflow a 2 MiB stack");
+    }
 
     #[track_caller]
     fn eval(input: &str) -> i128 {
@@ -447,6 +535,33 @@ mod tests {
         assert_eq!(eval("1 | 2 & 3"), 3); // or binds looser than and
         assert_eq!(eval("7 - 2 - 1"), 4); // subtraction is left associative
         assert_eq!(eval("2 * 3 + 4 / 2"), 8);
+    }
+
+    #[test]
+    fn paren_depth_ignores_strings_and_comments() {
+        assert_eq!(paren_depth("ld ((1)), %a"), 2);
+        assert_eq!(paren_depth(r#".string "((((" // (((("#), 0);
+        assert_eq!(paren_depth("nop"), 0);
+    }
+
+    #[test]
+    fn nesting_at_the_limit_parses_and_one_more_is_rejected() {
+        on_a_small_stack(|| {
+            let at_limit = format!(
+                "{}1{}",
+                "(".repeat(MAX_EXPRESSION_DEPTH),
+                ")".repeat(MAX_EXPRESSION_DEPTH)
+            );
+            assert!(parse_expression_str(&at_limit).is_ok());
+
+            let over_limit = format!(
+                "{}1{}",
+                "(".repeat(MAX_EXPRESSION_DEPTH + 1),
+                ")".repeat(MAX_EXPRESSION_DEPTH + 1)
+            );
+            let err = parse_expression_str(&over_limit).expect_err("must be rejected");
+            assert!(err.contains("nesting"), "{err}");
+        });
     }
 
     #[test]

--- a/crates/emulator/src/parser/shared.rs
+++ b/crates/emulator/src/parser/shared.rs
@@ -450,9 +450,11 @@ mod tests {
     }
 
     #[test]
-    fn binary_not_still_parses_in_parens() {
-        // `~` parses fine (its *evaluation* is a deliberate `todo!()`), so only
-        // check that a parenthesized bitwise-not produces the expected node.
+    fn binary_not_evaluates_as_bitwise_not() {
+        // r[verify asm.expressions]
+        assert_eq!(eval("~0"), -1);
+        assert_eq!(eval("~1"), -2);
+        assert_eq!(eval("(~1)"), -2);
         assert!(matches!(
             parse_expression_str("(~1)"),
             Ok(Node::BinaryNot(_))

--- a/crates/emulator/src/preprocessor/fs.rs
+++ b/crates/emulator/src/preprocessor/fs.rs
@@ -1,6 +1,24 @@
 use std::collections::HashMap;
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
+
+/// Resolve `.` and `..` in `path` lexically, without consulting the
+/// filesystem, so that two spellings of the same file compare equal.
+fn normalize(path: &Utf8Path) -> Utf8PathBuf {
+    let mut out = Utf8PathBuf::new();
+    for component in path.components() {
+        match component {
+            Utf8Component::CurDir => {}
+            Utf8Component::ParentDir => {
+                if !out.pop() {
+                    out.push(component);
+                }
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
 
 /// Abstraction over a filesystem
 pub trait Filesystem {
@@ -16,12 +34,16 @@ pub trait Filesystem {
         Utf8Path::new("")
     }
 
-    /// Get the absolute path of a file relative to the root
+    /// Get the absolute path of a file relative to the root.
+    ///
+    /// The result is lexically normalized: the include stack compares paths as
+    /// strings, so `b/../c.S` and `c.S` have to resolve to the same one.
     fn relative(&self, sibling: Option<&Utf8Path>, path: &Utf8Path) -> Utf8PathBuf {
-        sibling
+        let joined = sibling
             .and_then(Utf8Path::parent)
             .unwrap_or(self.root()) // Default to the "root" path
-            .join(path) // And join relative to that
+            .join(path); // And join relative to that
+        normalize(&joined)
     }
 }
 
@@ -75,5 +97,28 @@ impl Filesystem for NativeFilesystem {
 
     fn root(&self) -> &Utf8Path {
         &self.root
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relative_normalizes_dot_and_dotdot() {
+        let fs = InMemoryFilesystem::new([]);
+        let sibling = Utf8Path::new("/dir/c.S");
+        assert_eq!(
+            fs.relative(Some(sibling), Utf8Path::new("b/../c.S")),
+            Utf8PathBuf::from("/dir/c.S")
+        );
+        assert_eq!(
+            fs.relative(Some(sibling), Utf8Path::new("./c.S")),
+            Utf8PathBuf::from("/dir/c.S")
+        );
+        assert_eq!(
+            fs.relative(Some(sibling), Utf8Path::new("../c.S")),
+            Utf8PathBuf::from("/c.S")
+        );
     }
 }

--- a/crates/emulator/src/preprocessor/mod.rs
+++ b/crates/emulator/src/preprocessor/mod.rs
@@ -269,14 +269,17 @@ impl Workspace {
             })?;
 
         let mut buf = Vec::new();
-        self.process_chunks(
+        ctx.include_stack.push(path.to_owned());
+        let result = self.process_chunks(
             &mut buf,
             &content.chunks,
             &content.references,
             ctx,
             &stack,
             annotations,
-        )?;
+        );
+        ctx.include_stack.pop();
+        result?;
         Ok(buf)
     }
 
@@ -372,6 +375,31 @@ impl Workspace {
                     let Some(resolved) = references.get(path) else {
                         unreachable!("Referenced file wasn't resolved")
                     };
+
+                    if ctx.include_stack.len() >= MAX_INCLUDE_DEPTH {
+                        return Err(PreprocessorError::UserError {
+                            file_id: inc_stack.file_id,
+                            span: inc_stack.range.clone(),
+                            message: format!(
+                                "#include nested more than {MAX_INCLUDE_DEPTH} levels deep"
+                            ),
+                        });
+                    }
+
+                    if ctx.include_stack.contains(resolved) {
+                        let chain = ctx
+                            .include_stack
+                            .iter()
+                            .map(|p| p.as_str())
+                            .chain(std::iter::once(resolved.as_str()))
+                            .collect::<Vec<_>>()
+                            .join(" -> ");
+                        return Err(PreprocessorError::UserError {
+                            file_id: inc_stack.file_id,
+                            span: inc_stack.range.clone(),
+                            message: format!("#include cycle: {chain}"),
+                        });
+                    }
 
                     let content =
                         self.preprocess_path(resolved, ctx, annotations)
@@ -522,9 +550,17 @@ pub enum PreprocessorError {
     },
 }
 
+/// Deepest chain of `#include`s that will be expanded. Each level recurses
+/// through `preprocess_path` and `process_chunks`, and lexical normalization
+/// cannot make every spelling of a file compare equal (a symlink, say), so
+/// this backs up the cycle check.
+const MAX_INCLUDE_DEPTH: usize = 32;
+
 #[derive(Default)]
 struct Context {
     definitions: HashMap<String, Option<String>>,
+    /// Files currently being expanded, outermost first, to detect cycles.
+    include_stack: Vec<Utf8PathBuf>,
 }
 
 impl ConditionContext for Context {
@@ -851,6 +887,72 @@ mod tests {
             assert_eq!(message, "custom".to_string());
         } else {
             panic!("not a UserError");
+        }
+    }
+
+    #[test]
+    fn include_cycle_error_test() {
+        let fs = InMemoryFilesystem::new([
+            ("/a.S".into(), "#include \"b.S\"\nmain:\n".into()),
+            ("/b.S".into(), "#include \"a.S\"\n".into()),
+        ]);
+        let mut workspace = Workspace::new(&fs, "/a.S");
+        let err = workspace.preprocess().expect_err("cycle must be an error");
+        match innermost(&err) {
+            PreprocessorError::UserError { message, .. } => {
+                assert!(message.contains("#include cycle"), "{message}");
+                assert!(message.contains("/a.S -> /b.S -> /a.S"), "{message}");
+            }
+            other => panic!("expected a UserError, got {other:?}"),
+        }
+    }
+
+    /// Walk to the innermost error of a chain of `InInclude` wrappers.
+    fn innermost(error: &PreprocessorError) -> &PreprocessorError {
+        let mut inner = error;
+        while let PreprocessorError::InInclude { inner: next, .. } = inner {
+            inner = next;
+        }
+        inner
+    }
+
+    #[test]
+    fn include_cycle_through_a_relative_path_error_test() {
+        // `b/../c.S` and `c.S` name the same file, so the include stack only
+        // matches them once resolution has normalized the `..`.
+        let fs = InMemoryFilesystem::new([("/c.S".into(), "#include \"b/../c.S\"\n".into())]);
+        let mut workspace = Workspace::new(&fs, "/c.S");
+        let err = workspace.preprocess().expect_err("cycle must be an error");
+        match innermost(&err) {
+            PreprocessorError::UserError { message, .. } => {
+                assert!(message.contains("#include cycle"), "{message}");
+                assert!(message.contains("/c.S -> /c.S"), "{message}");
+            }
+            other => panic!("expected a UserError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn include_depth_cap_error_test() {
+        // A chain of distinct files never repeats a path, so only the depth
+        // cap stops it.
+        let depth = MAX_INCLUDE_DEPTH + 4;
+        let files: HashMap<Utf8PathBuf, String> = (0..depth)
+            .map(|i| {
+                (
+                    format!("/f{i}.S").into(),
+                    format!("#include \"f{}.S\"\n", i + 1),
+                )
+            })
+            .collect();
+        let fs = InMemoryFilesystem::new(files);
+        let mut workspace = Workspace::new(&fs, "/f0.S");
+        let err = workspace.preprocess().expect_err("depth cap must be hit");
+        match innermost(&err) {
+            PreprocessorError::UserError { message, .. } => {
+                assert!(message.contains("nested more than"), "{message}");
+            }
+            other => panic!("expected a UserError, got {other:?}"),
         }
     }
 

--- a/crates/emulator/src/preprocessor/mod.rs
+++ b/crates/emulator/src/preprocessor/mod.rs
@@ -957,6 +957,30 @@ mod tests {
     }
 
     #[test]
+    fn deeply_nested_conditionals_expand_within_the_parser_bound() {
+        // process_chunks walks the same tree the parser builds, so the
+        // parser's nesting bound is what keeps this off the stack limit.
+        use crate::parser::preprocessor::MAX_CONDITIONAL_DEPTH;
+
+        std::thread::Builder::new()
+            .stack_size(2 << 20)
+            .spawn(|| {
+                let source = format!(
+                    "{}main:\n    reset\n{}",
+                    "#if 1 > 0\n".repeat(MAX_CONDITIONAL_DEPTH),
+                    "#endif\n".repeat(MAX_CONDITIONAL_DEPTH)
+                );
+                let fs = InMemoryFilesystem::new([("/a.S".into(), source)]);
+                let mut workspace = Workspace::new(&fs, "/a.S");
+                let result = workspace.preprocess().expect("must preprocess");
+                assert!(result.source.contains("reset"));
+            })
+            .expect("spawn")
+            .join()
+            .expect("the preprocessor must not overflow a 2 MiB stack");
+    }
+
+    #[test]
     fn unknown_include_error_test() {
         let fs = InMemoryFilesystem::new([("/include.S".into(), r#"#include "foo.S""#.into())]);
         let mut workspace = Workspace::new(&fs, "/include.S");

--- a/crates/emulator/src/runtime/arguments.rs
+++ b/crates/emulator/src/runtime/arguments.rs
@@ -257,8 +257,9 @@ mod traits {
             let cell = c.get(&self.0);
             // and try converting it to a word
             let addr = C::Word::try_from(&cell)?;
-            // add the offset
-            let addr = addr + self.1;
+            // Wraps so debug and release agree; an out-of-range result then
+            // fails the address downcast below in both profiles.
+            let addr = addr.wrapping_add(self.1);
             // and convert it to an address
             let addr = C::Address::try_from(&addr.into())?;
             Ok(addr)

--- a/crates/emulator/src/runtime/mod.rs
+++ b/crates/emulator/src/runtime/mod.rs
@@ -236,7 +236,9 @@ impl Computer {
 
     #[tracing::instrument(skip(self))]
     fn push<T: Into<Cell> + Debug>(&mut self, value: T) -> std::result::Result<(), Exception> {
-        self.registers.sp -= 1;
+        // Wraps so debug and release agree; the invalid address then fails
+        // the memory access below with a CPU exception in both profiles.
+        self.registers.sp = self.registers.sp.wrapping_sub(1);
 
         // And write it on memeory
         let address = self.registers.sp;

--- a/crates/emulator/tests/data_movement.rs
+++ b/crates/emulator/tests/data_movement.rs
@@ -80,6 +80,30 @@ fn ld_negative_immediate() {
 }
 
 #[test]
+fn ld_binary_not_immediate() {
+    // r[verify asm.expressions]
+    let state = run_program(
+        indoc! {"
+            main:
+                ld ~1, %a
+                reset
+        "},
+        "main",
+        Steps::RunToCompletion,
+    );
+    insta::assert_snapshot!(state, @r"
+    Registers:
+      %a  = -2
+      %b  = 0
+      %pc = 1001
+      %sp = 10000
+      %sr = SUPERVISOR
+    Cycles: 1
+    Halted: reset
+    ");
+}
+
+#[test]
 fn ld_zero() {
     // r[verify inst.ld]
     let state = run_program(

--- a/crates/emulator/tests/diagnostics.rs
+++ b/crates/emulator/tests/diagnostics.rs
@@ -176,3 +176,12 @@ fn compilation_undefined_label() {
 fn compilation_unknown_entrypoint() {
     insta::assert_snapshot!(check_full_pipeline_errors("start:\n    nop"));
 }
+
+#[test]
+fn compilation_binary_not_out_of_range() {
+    // `~` inverts all 128 bits of the evaluated value, so inverting a value
+    // that already needs 64 bits leaves a result no word can hold.
+    insta::assert_snapshot!(check_full_pipeline_errors(
+        "main:\n    reset\nx: .word ~0xffffffffffffffff"
+    ));
+}

--- a/crates/emulator/tests/diagnostics.rs
+++ b/crates/emulator/tests/diagnostics.rs
@@ -176,7 +176,6 @@ fn compilation_undefined_label() {
 fn compilation_unknown_entrypoint() {
     insta::assert_snapshot!(check_full_pipeline_errors("start:\n    nop"));
 }
-
 #[test]
 fn compilation_binary_not_out_of_range() {
     // `~` inverts all 128 bits of the evaluated value, so inverting a value
@@ -184,4 +183,53 @@ fn compilation_binary_not_out_of_range() {
     insta::assert_snapshot!(check_full_pipeline_errors(
         "main:\n    reset\nx: .word ~0xffffffffffffffff"
     ));
+}
+
+#[test]
+fn compilation_addr_directive_out_of_bounds() {
+    // .addr 9999 leaves only one valid cell (address 9999); the second `nop`
+    // lands on address 10000, outside the 10000-cell memory.
+    insta::assert_snapshot!(check_full_pipeline_errors(
+        ".addr 9999\nmain:\n    nop\n    nop"
+    ));
+}
+
+#[test]
+fn compilation_space_directive_out_of_bounds() {
+    // .space 20000 cannot fit starting at PROGRAM_START (1000) in a
+    // 10000-cell memory.
+    insta::assert_snapshot!(check_full_pipeline_errors(
+        "main:\n    reset\nx: .space 20000"
+    ));
+}
+
+#[test]
+fn compilation_huge_space_directive() {
+    // The bounds check runs before the loop; the unit test in
+    // compiler::layout pins that no cell is inserted for an argument this
+    // large.
+    insta::assert_snapshot!(check_full_pipeline_errors(
+        "main:\n    reset\nx: .space 50000000"
+    ));
+}
+
+#[test]
+fn compilation_space_directive_larger_than_an_address() {
+    insta::assert_snapshot!(check_full_pipeline_errors(
+        "main:\n    reset\nx: .space 3000000000"
+    ));
+}
+
+#[test]
+fn compilation_negative_space_directive() {
+    // The argument is evaluated as an address, so a negative one cannot be
+    // downcast.
+    insta::assert_snapshot!(check_full_pipeline_errors("main:\n    reset\nx: .space -1"));
+}
+
+#[test]
+fn compilation_addr_directive_at_the_last_address() {
+    // The layout cursor sits on the highest address an expression can name;
+    // the following instruction must not advance it past it.
+    insta::assert_snapshot!(check_full_pipeline_errors(".addr 4294967295\nnop"));
 }

--- a/crates/emulator/tests/exceptions.rs
+++ b/crates/emulator/tests/exceptions.rs
@@ -305,6 +305,60 @@ fn invalid_memory_access_exception() {
     ");
 }
 
+#[test]
+fn indexed_address_arithmetic_does_not_panic_on_overflow() {
+    // r[verify inst.ld]
+    // The intermediate add wraps, so the out-of-range address reaches the
+    // downcast and reports an exception in both profiles.
+    let state = run_program(
+        indoc! {"
+            main:
+                ld 9223372036854775807, %a
+                ld [%a+1], %b
+                reset
+        "},
+        "main",
+        Steps::RunToCompletion,
+    );
+    insta::assert_snapshot!(state, @r"
+    Registers:
+      %a  = 9223372036854775807
+      %b  = 0
+      %pc = 1002
+      %sp = 10000
+      %sr = SUPERVISOR
+    Cycles: 1
+    Halted: error: extract word: cell error: could not downcast word to address: -9223372036854775808
+    ");
+}
+
+#[test]
+fn push_at_sp_zero_does_not_panic_on_underflow() {
+    // r[verify inst.push]
+    // The %sp decrement wraps, so the write goes to an out-of-bounds address
+    // and reports a CPU exception in both profiles.
+    let state = run_program(
+        indoc! {"
+            main:
+                ld 0, %sp
+                push 1
+                reset
+        "},
+        "main",
+        Steps::RunToCompletion,
+    );
+    insta::assert_snapshot!(state, @r"
+    Registers:
+      %a  = 0
+      %b  = 0
+      %pc = 1002
+      %sp = 4294967295
+      %sr = SUPERVISOR
+    Cycles: 1
+    Halted: error: CPU exception: invalid memory access (invalid address 4294967295)
+    ");
+}
+
 // Note: Hardware interrupt (exception code 0) is difficult to test directly
 // because it requires an external interrupt signal. The interrupt mechanism
 // can be partially verified through the interrupt enable/disable behavior.

--- a/crates/emulator/tests/snapshots/diagnostics__compilation_addr_directive_at_the_last_address.snap
+++ b/crates/emulator/tests/snapshots/diagnostics__compilation_addr_directive_at_the_last_address.snap
@@ -1,0 +1,9 @@
+---
+source: crates/emulator/tests/diagnostics.rs
+expression: "check_full_pipeline_errors(\".addr 4294967295\\nnop\")"
+---
+error: address 4294967295 is outside of memory
+  ┌─ <preprocessed>:2:1
+  │
+2 │ nop
+  │ ^^^ does not fit in memory

--- a/crates/emulator/tests/snapshots/diagnostics__compilation_addr_directive_out_of_bounds.snap
+++ b/crates/emulator/tests/snapshots/diagnostics__compilation_addr_directive_out_of_bounds.snap
@@ -1,0 +1,9 @@
+---
+source: crates/emulator/tests/diagnostics.rs
+expression: "check_full_pipeline_errors(\".addr 9999\\nmain:\\n    nop\\n    nop\")"
+---
+error: address 10000 is outside of memory
+  ┌─ <preprocessed>:4:5
+  │
+4 │     nop
+  │     ^^^ does not fit in memory

--- a/crates/emulator/tests/snapshots/diagnostics__compilation_binary_not_out_of_range.snap
+++ b/crates/emulator/tests/snapshots/diagnostics__compilation_binary_not_out_of_range.snap
@@ -1,0 +1,9 @@
+---
+source: crates/emulator/tests/diagnostics.rs
+expression: "check_full_pipeline_errors(\"main:\\n    reset\\nx: .word ~0xffffffffffffffff\")"
+---
+error: value out of range
+  ┌─ <preprocessed>:3:10
+  │
+3 │ x: .word ~0xffffffffffffffff
+  │          ^^^^^^^^^^^^^^^^^^^ could not convert value

--- a/crates/emulator/tests/snapshots/diagnostics__compilation_huge_space_directive.snap
+++ b/crates/emulator/tests/snapshots/diagnostics__compilation_huge_space_directive.snap
@@ -1,0 +1,9 @@
+---
+source: crates/emulator/tests/diagnostics.rs
+expression: "check_full_pipeline_errors(\"main:\\n    reset\\nx: .space 50000000\")"
+---
+error: reserving 50000000 cells from address 1001 does not fit in memory (0..10000)
+  ┌─ <preprocessed>:3:4
+  │
+3 │ x: .space 50000000
+  │    ^^^^^^^^^^^^^^^ reservation is too large

--- a/crates/emulator/tests/snapshots/diagnostics__compilation_negative_space_directive.snap
+++ b/crates/emulator/tests/snapshots/diagnostics__compilation_negative_space_directive.snap
@@ -1,0 +1,5 @@
+---
+source: crates/emulator/tests/diagnostics.rs
+expression: "check_full_pipeline_errors(\"main:\\n    reset\\nx: .space -1\")"
+---
+error: could not evaluate argument for directive '.space': could not downcast value

--- a/crates/emulator/tests/snapshots/diagnostics__compilation_space_directive_larger_than_an_address.snap
+++ b/crates/emulator/tests/snapshots/diagnostics__compilation_space_directive_larger_than_an_address.snap
@@ -1,0 +1,9 @@
+---
+source: crates/emulator/tests/diagnostics.rs
+expression: "check_full_pipeline_errors(\"main:\\n    reset\\nx: .space 3000000000\")"
+---
+error: reserving 3000000000 cells from address 1001 does not fit in memory (0..10000)
+  ┌─ <preprocessed>:3:4
+  │
+3 │ x: .space 3000000000
+  │    ^^^^^^^^^^^^^^^^^ reservation is too large

--- a/crates/emulator/tests/snapshots/diagnostics__compilation_space_directive_out_of_bounds.snap
+++ b/crates/emulator/tests/snapshots/diagnostics__compilation_space_directive_out_of_bounds.snap
@@ -1,0 +1,9 @@
+---
+source: crates/emulator/tests/diagnostics.rs
+expression: "check_full_pipeline_errors(\"main:\\n    reset\\nx: .space 20000\")"
+---
+error: reserving 20000 cells from address 1001 does not fit in memory (0..10000)
+  ┌─ <preprocessed>:3:4
+  │
+3 │ x: .space 20000
+  │    ^^^^^^^^^^^^ reservation is too large


### PR DESCRIPTION
Eight fixes for aborts and panics reachable from source input. Five were found by a libFuzzer harness over the parser, preprocessor and runtime; a review round on the first version added the rest. Each commit carries regression tests.

- `~` in an expression hit a `todo!()` and aborted the process (the release profile is `panic = "abort"`). Also killed the language server on any `~`. The result is range-checked on the downcast like every other evaluated value.
- An `#if` on the last line without a trailing newline sliced past the input. Five bytes, `#if 1`, took down `z33-cli run`, the LSP and the web compile check.
- Deeply nested parentheses overflowed the recursive expression parser, in operands, `#if` conditions, DAP `evaluate` expressions and the interactive debugger's arguments. Every precedence tier is now boxed, which takes a 2 MiB debug thread from 6 surviving levels to 30, and one guard rejects nesting past 8 levels at all four entry points. Tests pin the limit on a 2 MiB thread.
- Nested `#if` blocks recursed without bound in the preprocessor (2000 levels aborted a debug build). Nesting is capped at 64 levels; a 2 MiB debug thread survives 240.
- A file including itself, directly or through another file, recursed until the stack overflowed. The include chain is tracked with lexically normalized paths, so `#include "b/../c.S"` is caught too, and an include depth cap backs it up.
- `.space` and layout placement were never checked against `MEMORY_SIZE`. A large `.space` operand allocated gigabytes before reaching the `unwrap` in `fill_memory`; addresses at or past 10000 panicked; `.addr 4294967295` followed by an instruction overflowed the cursor. The layout cursor now saturates, a run of out-of-range placements is reported once, and `.space` gets its own message naming the size and start address.
- Indexed addressing and `push` used plain arithmetic, so debug builds panicked on overflow where release wrapped. Both profiles now agree.

Verified: `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets`, `cargo test --workspace` (525 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
