### PR TITLE
Debug adapter fixes: pending breakpoints, second launch, fault frame, memory bounds

### DIFF
--- a/crates/emulator/src/dap/mod.rs
+++ b/crates/emulator/src/dap/mod.rs
@@ -178,6 +178,10 @@ struct LoadedProgram {
     computer: Computer,
     index: LineIndex,
     labels: BTreeMap<String, Address>,
+    /// One past the highest cell the assembled program occupies, `.space`
+    /// reservations included even though those read back as `Cell::Empty`.
+    /// Bounds the last label's region in [`label_regions`].
+    program_end: Address,
     /// Requested breakpoint source lines per path, each paired with the id
     /// handed to the client, in request order (last `setBreakpoints` wins).
     /// Kept as the raw client request so they can be re-resolved against a
@@ -788,7 +792,7 @@ impl DebugSession {
     fn globals_variables(&mut self, start: u32, count: Option<u32>, hex: bool) -> Vec<Variable> {
         let regions = {
             let program = self.program.as_ref().expect("program loaded");
-            label_regions(&program.labels)
+            label_regions(&program.labels, program.program_end)
         };
         let count = count.map_or(usize::MAX, |c| c as usize);
         let mut out = Vec::new();
@@ -868,7 +872,7 @@ impl DebugSession {
             GLOBALS_REF => {
                 // Only single-cell labels are settable at the scope level.
                 let &base = program.labels.get(name)?;
-                let regions = label_regions(&program.labels);
+                let regions = label_regions(&program.labels, program.program_end);
                 let len = regions
                     .iter()
                     .find(|(l, _, _)| l == name)
@@ -1799,10 +1803,13 @@ fn frame_stack_variables(
 }
 
 /// The label regions `(name, base, len)`, sorted by address, each bounded by
-/// the next label's address and the memory size (at least one cell). The full
-/// `len` is reported as `indexedVariables`; per-request paging (see
+/// the next label's address and the end of the program (at least one cell).
+/// The full `len` is reported as `indexedVariables`; per-request paging (see
 /// [`DEFAULT_PAGE`]) keeps large regions like a 5000-word `.space` responsive.
-fn label_regions(labels: &BTreeMap<String, Address>) -> Vec<(String, Address, u32)> {
+fn label_regions(
+    labels: &BTreeMap<String, Address>,
+    program_end: Address,
+) -> Vec<(String, Address, u32)> {
     let mut by_addr: Vec<(Address, String)> = labels.iter().map(|(n, &a)| (a, n.clone())).collect();
     by_addr.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
 
@@ -1811,7 +1818,7 @@ fn label_regions(labels: &BTreeMap<String, Address>) -> Vec<(String, Address, u3
         let (addr, name) = &by_addr[i];
         let next = by_addr
             .get(i + 1)
-            .map_or(C::MEMORY_SIZE, |(a, _)| *a)
+            .map_or(program_end, |(a, _)| *a)
             .max(*addr);
         let len = (next - addr).max(1);
         out.push((name.clone(), *addr, len));
@@ -2168,6 +2175,16 @@ fn compile_program<FS: Filesystem>(
 
     let index = LineIndex::build(&assembled.debug_info, &ref_map, workspace.file_db());
     let labels = assembled.debug_info.labels.clone();
+    // The source map has an entry for every placement the layout made, so its
+    // last address is the last cell the program occupies. The memory itself
+    // cannot answer this: a `.space` reservation is a `Cell::Empty`,
+    // indistinguishable from never-written memory.
+    let program_end = assembled
+        .debug_info
+        .source_map
+        .keys()
+        .next_back()
+        .map_or(0, |&a| a.saturating_add(1));
 
     let computer = match assembled.into_computer(&entrypoint) {
         Ok(computer) => computer,
@@ -2185,6 +2202,7 @@ fn compile_program<FS: Filesystem>(
         computer,
         index,
         labels,
+        program_end,
         requested_lines: HashMap::new(),
         bp_by_file: HashMap::new(),
         breakpoints: HashSet::new(),

--- a/crates/emulator/src/dap/mod.rs
+++ b/crates/emulator/src/dap/mod.rs
@@ -1897,6 +1897,11 @@ fn cell_word(cell: &Cell) -> i64 {
 /// Returns `(first_cell_address, data, unreadable_trailing_bytes)`, or an error
 /// if the client-supplied `base`/`offset` overflow when converted to a byte
 /// address.
+///
+/// A start below address 0 is clamped to 0 rather than rejected: a memory
+/// viewer scrolling up past the start of memory sends such offsets, and the
+/// returned first address tells it where the data really begins. A start past
+/// the end of memory is not clamped — it reads back as unreadable bytes.
 fn read_memory(
     computer: &Computer,
     base: i64,
@@ -1906,7 +1911,8 @@ fn read_memory(
     let start_byte = base
         .checked_mul(CELL_BYTES)
         .and_then(|b| b.checked_add(offset))
-        .ok_or_else(|| "memory address out of range".to_owned())?;
+        .ok_or_else(|| "memory address out of range".to_owned())?
+        .max(0);
     let mut data = Vec::new();
     let mut unreadable = 0;
     for i in 0..count {
@@ -1916,7 +1922,7 @@ fn read_memory(
         };
         let cell_index = p.div_euclid(CELL_BYTES);
         let byte_in = usize::try_from(p.rem_euclid(CELL_BYTES)).unwrap_or(0);
-        if p < 0 || cell_index >= i64::from(C::MEMORY_SIZE) {
+        if cell_index >= i64::from(C::MEMORY_SIZE) {
             unreadable = count - i;
             break;
         }

--- a/crates/emulator/src/dap/mod.rs
+++ b/crates/emulator/src/dap/mod.rs
@@ -245,6 +245,13 @@ pub struct DebugSession {
     /// replacements (see [`DebugSession::serial_output_events`]). At most 3
     /// bytes; reset whenever the computer is (re)loaded.
     serial_utf8_carry: Vec<u8>,
+    /// `pc` at the instant an unhandled exception was raised, i.e. before
+    /// `computer.step()` advanced it. Only [`DebugSession::stack_frames`] reads
+    /// it, so that the top frame points at the faulting instruction rather than
+    /// the one after it; the Registers scope, `evaluate "%pc"` and every other
+    /// view keep reporting the live `pc`, which is the machine's real state and
+    /// what an exception handler would have saved. Cleared on the next resume.
+    exception_pc: Option<Address>,
 }
 
 impl Default for DebugSession {
@@ -273,6 +280,7 @@ impl DebugSession {
             dyn_handles: HashMap::new(),
             next_dyn: 0,
             serial_utf8_carry: Vec::new(),
+            exception_pc: None,
         }
     }
 
@@ -483,6 +491,7 @@ impl DebugSession {
         self.program = Some(program);
         self.entered = false;
         self.exception_pending = false;
+        self.exception_pc = None;
         self.pause_requested = false;
         self.serial_utf8_carry.clear();
         self.stop_on_entry = stop_on_entry;
@@ -899,8 +908,10 @@ impl DebugSession {
             out.extend(self.terminate_now(EXIT_EXCEPTION));
             return Some(out);
         }
-        // Resuming: any handle handed out during the last stop is now stale.
+        // Only reached once the resume is accepted: any handle handed out
+        // during the last stop is now stale, and so is the faulting pc.
         self.invalidate_handles();
+        self.exception_pc = None;
         None
     }
 
@@ -1137,6 +1148,7 @@ impl DebugSession {
         };
 
         for _ in 0..CHUNK_SIZE {
+            let pc_before = program.computer.registers.pc;
             match program.computer.step() {
                 Ok(()) => {
                     let pc = program.computer.registers.pc;
@@ -1160,7 +1172,10 @@ impl DebugSession {
                     }
                 }
                 Err(ProcessorError::Reset) => return Outcome::Terminated(EXIT_OK),
-                Err(e) => return Outcome::Exception(e.to_string()),
+                Err(e) => {
+                    self.exception_pc = Some(pc_before);
+                    return Outcome::Exception(e.to_string());
+                }
             }
         }
         Outcome::Pending
@@ -1197,6 +1212,13 @@ impl DebugSession {
                 self.state = State::Stopped;
                 self.exception_pending = true;
                 self.invalidate_handles();
+                // The live `pc` a client reads from the Registers scope has
+                // already moved past the fault, so name the faulting address
+                // here.
+                let msg = match self.exception_pc {
+                    Some(pc) => format!("{msg} (at address {pc})"),
+                    None => msg,
+                };
                 out.push(self.make_event(
                     "output",
                     json!({ "category": "console", "output": format!("Exception: {msg}\n") }),
@@ -1268,7 +1290,7 @@ impl DebugSession {
             return Vec::new();
         };
         let mut frames = Vec::new();
-        let pc = program.computer.registers.pc;
+        let pc = self.exception_pc.unwrap_or(program.computer.registers.pc);
         frames.push(self.frame(0, pc));
 
         // Best-effort synthesis of caller frames from the return-address scan.

--- a/crates/emulator/src/dap/mod.rs
+++ b/crates/emulator/src/dap/mod.rs
@@ -451,15 +451,8 @@ impl DebugSession {
         };
 
         match load_program(&args) {
-            Ok(mut program) => {
-                self.stop_on_entry = args.stop_on_entry;
-                self.serial_utf8_carry.clear();
-                let pending = std::mem::take(&mut self.pending_breakpoints);
-                if !pending.is_empty() {
-                    program.requested_lines = pending;
-                    program.reresolve_breakpoints();
-                }
-                self.program = Some(program);
+            Ok(program) => {
+                self.install_program(program, args.stop_on_entry);
                 self.launch_args = Some(args);
                 let resp = self.response(req, Value::Null);
                 let mut out = vec![resp];
@@ -469,6 +462,34 @@ impl DebugSession {
             }
             Err(msg) => vec![self.response_err(req, msg)],
         }
+    }
+
+    /// Make a freshly loaded program the session's program, carrying the
+    /// requested breakpoint lines over and clearing everything that described
+    /// the program it replaces. Shared by `launch` and `restart`, which differ
+    /// only in where the launch arguments come from.
+    ///
+    /// The client does not re-send `setBreakpoints` (no second `initialized`
+    /// event), so the requested source lines are re-resolved against the new
+    /// line index; addresses may have shifted.
+    fn install_program(&mut self, mut program: LoadedProgram, stop_on_entry: bool) {
+        let mut requested = self
+            .program
+            .take()
+            .map_or_else(HashMap::new, |old| old.requested_lines);
+        requested.extend(std::mem::take(&mut self.pending_breakpoints));
+        program.requested_lines = requested;
+        program.reresolve_breakpoints();
+        self.program = Some(program);
+        self.entered = false;
+        self.exception_pending = false;
+        self.pause_requested = false;
+        self.serial_utf8_carry.clear();
+        self.stop_on_entry = stop_on_entry;
+        self.state = State::Initialized;
+        // A `variablesReference` from the previous program would otherwise
+        // read the new program's memory.
+        self.invalidate_handles();
     }
 
     /// A `changed` `breakpoint` event for every source line the client has
@@ -1062,22 +1083,8 @@ impl DebugSession {
             return vec![self.response_err(req, "nothing to restart")];
         };
         match load_program(&args) {
-            Ok(mut program) => {
-                // Carry breakpoints across the restart: the client will not
-                // re-send `setBreakpoints` (no `initialized` is re-emitted), so
-                // re-resolve the previously requested source lines against the
-                // freshly built line index (addresses may have shifted).
-                if let Some(old) = self.program.take() {
-                    program.requested_lines = old.requested_lines;
-                    program.reresolve_breakpoints();
-                }
-                self.program = Some(program);
-                self.entered = false;
-                self.exception_pending = false;
-                self.pause_requested = false;
-                self.serial_utf8_carry.clear();
-                self.stop_on_entry = args.stop_on_entry;
-                self.state = State::Initialized;
+            Ok(program) => {
+                self.install_program(program, args.stop_on_entry);
                 let resp = self.response(req, Value::Null);
                 let mut out = vec![resp];
                 out.extend(self.maybe_enter());

--- a/crates/emulator/src/dap/mod.rs
+++ b/crates/emulator/src/dap/mod.rs
@@ -92,6 +92,10 @@ const DEFAULT_PAGE: u32 = 256;
 const MAX_FRAMES: usize = 64;
 /// Bytes on the wire for a single Z33 cell (one `i64` word, little-endian).
 const CELL_BYTES: i64 = 8;
+/// Rejection message for a requested breakpoint line the line index cannot map
+/// to an instruction. Shared so the `setBreakpoints` response and the
+/// `breakpoint` events that re-report the same line agree.
+const NO_CODE_AT_LINE: &str = "no code at or after this line";
 
 /// What a dynamically allocated `variablesReference` expands to. Rebuilt on
 /// every stop; see [`DynRef`] allocation in [`DebugSession::alloc_dyn`].
@@ -161,15 +165,24 @@ enum Outcome {
     Exception(String),
 }
 
+/// One source line from a `setBreakpoints` request and the id reported for it,
+/// which every later `breakpoint` event for that line repeats.
+#[derive(Debug, Clone, Copy)]
+struct RequestedLine {
+    line: u32,
+    id: i64,
+}
+
 /// A compiled, runnable program plus everything needed to debug it.
 struct LoadedProgram {
     computer: Computer,
     index: LineIndex,
     labels: BTreeMap<String, Address>,
-    /// Requested breakpoint source lines per path (last `setBreakpoints` wins).
+    /// Requested breakpoint source lines per path, each paired with the id
+    /// handed to the client, in request order (last `setBreakpoints` wins).
     /// Kept as the raw client request so they can be re-resolved against a
     /// fresh [`LineIndex`] after a `restart` (addresses may shift).
-    requested_lines: HashMap<String, Vec<u32>>,
+    requested_lines: HashMap<String, Vec<RequestedLine>>,
     /// Breakpoint addresses per source path (last `setBreakpoints` wins).
     bp_by_file: HashMap<String, Vec<Address>>,
     /// Union of all breakpoint addresses.
@@ -192,7 +205,7 @@ impl LoadedProgram {
             .map(|(path, lines)| {
                 let addrs = lines
                     .iter()
-                    .filter_map(|&line| self.index.resolve_breakpoint(path, line).map(|(_, a)| a))
+                    .filter_map(|r| self.index.resolve_breakpoint(path, r.line).map(|(_, a)| a))
                     .collect();
                 (path.clone(), addrs)
             })
@@ -215,6 +228,12 @@ pub struct DebugSession {
     run_mode: RunMode,
     program: Option<LoadedProgram>,
     launch_args: Option<LaunchArguments>,
+    /// Source lines from `setBreakpoints` requests that arrived before a
+    /// program was launched, keyed by path; resolved on launch.
+    pending_breakpoints: HashMap<String, Vec<RequestedLine>>,
+    /// Monotonic allocator for breakpoint ids. Never reset, so an id is never
+    /// reused for a different requested line within a session.
+    next_bp_id: i64,
     /// Live dynamic `variablesReference` handles for the current stop.
     dyn_handles: HashMap<i64, DynRef>,
     /// Monotonic allocator for dynamic handles (never reset, so stale handles
@@ -249,10 +268,19 @@ impl DebugSession {
             run_mode: RunMode::Continue,
             program: None,
             launch_args: None,
+            pending_breakpoints: HashMap::new(),
+            next_bp_id: 1,
             dyn_handles: HashMap::new(),
             next_dyn: 0,
             serial_utf8_carry: Vec::new(),
         }
+    }
+
+    /// Allocate a fresh breakpoint id for a requested source line.
+    fn alloc_bp_id(&mut self) -> i64 {
+        let id = self.next_bp_id;
+        self.next_bp_id += 1;
+        id
     }
 
     /// Allocate a fresh dynamic `variablesReference` for the current stop.
@@ -423,18 +451,67 @@ impl DebugSession {
         };
 
         match load_program(&args) {
-            Ok(program) => {
+            Ok(mut program) => {
                 self.stop_on_entry = args.stop_on_entry;
                 self.serial_utf8_carry.clear();
+                let pending = std::mem::take(&mut self.pending_breakpoints);
+                if !pending.is_empty() {
+                    program.requested_lines = pending;
+                    program.reresolve_breakpoints();
+                }
                 self.program = Some(program);
                 self.launch_args = Some(args);
                 let resp = self.response(req, Value::Null);
                 let mut out = vec![resp];
+                out.extend(self.pending_breakpoint_events());
                 out.extend(self.maybe_enter());
                 out
             }
             Err(msg) => vec![self.response_err(req, msg)],
         }
+    }
+
+    /// A `changed` `breakpoint` event for every source line the client has
+    /// requested, re-resolved against the loaded program's line index. Lines
+    /// answered as unverified before launch need an event even when they still
+    /// do not resolve, otherwise the client shows them as pending forever.
+    fn pending_breakpoint_events(&mut self) -> Vec<Value> {
+        let requested: Vec<(String, RequestedLine, Option<u32>)> = match self.program.as_ref() {
+            Some(program) => program
+                .requested_lines
+                .iter()
+                .flat_map(|(path, lines)| {
+                    lines.iter().map(|&r| {
+                        let resolved = program
+                            .index
+                            .resolve_breakpoint(path, r.line)
+                            .map(|(line, _)| line);
+                        (path.clone(), r, resolved)
+                    })
+                })
+                .collect(),
+            None => Vec::new(),
+        };
+        requested
+            .into_iter()
+            .map(|(path, r, resolved)| {
+                let breakpoint = Breakpoint {
+                    id: Some(r.id),
+                    verified: resolved.is_some(),
+                    line: Some(resolved.unwrap_or(r.line)),
+                    source: Some(Source {
+                        name: None,
+                        path: Some(path),
+                    }),
+                    message: resolved.is_none().then(|| NO_CODE_AT_LINE.to_owned()),
+                    reason: resolved.is_none().then(|| "failed".to_owned()),
+                };
+                self.make_event(
+                    "breakpoint",
+                    json!({ "reason": "changed", "breakpoint": breakpoint }),
+                )
+            })
+            .collect()
     }
 
     fn on_set_breakpoints(&mut self, req: &IncomingRequest) -> Vec<Value> {
@@ -443,36 +520,65 @@ impl DebugSession {
             Err(e) => return vec![self.response_err(req, format!("invalid arguments: {e}"))],
         };
 
+        let source = args.source;
+        let path = source
+            .path
+            .clone()
+            .or_else(|| source.name.clone())
+            .unwrap_or_default();
+        // Ids are allocated per requested line, before resolution, so the
+        // pending and the resolved branch report the same id for the same
+        // entry of this request.
+        let requested: Vec<RequestedLine> = args
+            .breakpoints
+            .iter()
+            .map(|bp| RequestedLine {
+                line: bp.line,
+                id: self.alloc_bp_id(),
+            })
+            .collect();
+
         let body = {
             let Some(program) = self.program.as_mut() else {
-                return vec![self.response_err(req, "no program launched")];
+                // Before launch there is no line index to resolve against;
+                // keep the request and answer once the program is loaded.
+                let result: Vec<Breakpoint> = requested
+                    .iter()
+                    .map(|r| Breakpoint {
+                        id: Some(r.id),
+                        verified: false,
+                        line: Some(r.line),
+                        source: Some(source.clone()),
+                        message: Some("pending launch".to_owned()),
+                        reason: Some("pending".to_owned()),
+                    })
+                    .collect();
+                self.pending_breakpoints.insert(path, requested);
+                return vec![self.response(req, json!({ "breakpoints": result }))];
             };
-            let source = args.source;
-            let path = source
-                .path
-                .clone()
-                .or_else(|| source.name.clone())
-                .unwrap_or_default();
 
             let mut result: Vec<Breakpoint> = Vec::new();
             let mut addrs: Vec<Address> = Vec::new();
-            let requested: Vec<u32> = args.breakpoints.iter().map(|bp| bp.line).collect();
-            for bp in args.breakpoints {
-                match program.index.resolve_breakpoint(&path, bp.line) {
+            for r in &requested {
+                match program.index.resolve_breakpoint(&path, r.line) {
                     Some((line, address)) => {
                         addrs.push(address);
                         result.push(Breakpoint {
+                            id: Some(r.id),
                             verified: true,
                             line: Some(line),
                             source: Some(source.clone()),
                             message: None,
+                            reason: None,
                         });
                     }
                     None => result.push(Breakpoint {
+                        id: Some(r.id),
                         verified: false,
-                        line: Some(bp.line),
+                        line: Some(r.line),
                         source: Some(source.clone()),
-                        message: Some("no code at or after this line".to_owned()),
+                        message: Some(NO_CODE_AT_LINE.to_owned()),
+                        reason: Some("failed".to_owned()),
                     }),
                 }
             }

--- a/crates/emulator/src/dap/mod.rs
+++ b/crates/emulator/src/dap/mod.rs
@@ -866,8 +866,10 @@ impl DebugSession {
         let program = self.program.as_ref()?;
         match reference {
             STACK_REF => {
+                // `set_cell` rejects an address past the end of memory with a
+                // message naming it; only the overflow has to be caught here.
                 let n = name.strip_prefix("sp+")?.trim().parse::<u32>().ok()?;
-                Some(program.computer.registers.sp + n)
+                program.computer.registers.sp.checked_add(n)
             }
             GLOBALS_REF => {
                 // Only single-cell labels are settable at the scope level.
@@ -879,10 +881,17 @@ impl DebugSession {
                     .map_or(1, |&(_, _, len)| len);
                 (len <= 1).then_some(base)
             }
-            r if r >= DYN_BASE => match self.dyn_handles.get(&r)? {
-                // Both children encode the absolute address in `name (addr)`.
-                DynRef::GlobalLabel { .. } | DynRef::FrameStack { .. } => parse_addr_suffix(name),
-            },
+            r if r >= DYN_BASE => {
+                // Both children encode the absolute address in `name (addr)`,
+                // but the name comes from the client, so it only names a cell
+                // the handle actually covers.
+                let (start, end) = match self.dyn_handles.get(&r)? {
+                    DynRef::GlobalLabel { base, len, .. } => (*base, base.saturating_add(*len)),
+                    DynRef::FrameStack { start, end } => (*start, *end),
+                };
+                let addr = parse_addr_suffix(name)?;
+                (start..end).contains(&addr).then_some(addr)
+            }
             _ => None,
         }
     }

--- a/crates/emulator/src/dap/protocol.rs
+++ b/crates/emulator/src/dap/protocol.rs
@@ -111,6 +111,11 @@ pub struct SetBreakpointsArguments {
 /// A breakpoint as reported back to the client.
 #[derive(Debug, Serialize)]
 pub struct Breakpoint {
+    /// Ties a later `breakpoint` event to an entry of the `setBreakpoints`
+    /// response that created it. Two breakpoints whose lines snap to the same
+    /// instruction are otherwise indistinguishable in an event.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<i64>,
     pub verified: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line: Option<u32>,
@@ -118,6 +123,10 @@ pub struct Breakpoint {
     pub source: Option<Source>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    /// Machine-readable counterpart to `message`. The spec defines `"pending"`
+    /// (may still be verified later) and `"failed"` (will not be).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 /// A stack frame in a `stackTrace` response.

--- a/crates/emulator/src/dap/tests.rs
+++ b/crates/emulator/src/dap/tests.rs
@@ -180,6 +180,72 @@ fn a_pending_breakpoint_with_no_code_after_it_is_reported_unverified() {
     assert_eq!(bp["message"], json!("no code at or after this line"));
 }
 
+#[test]
+fn second_launch_replaces_the_program_and_stops_on_entry() {
+    let mut h = Harness::new();
+    let out = h.launch(true);
+    assert!(find_event(&out, "stopped").is_some());
+
+    let mut out = h.send(
+        "launch",
+        json!({
+            "program": "/other.s",
+            "entrypoint": "main",
+            "stopOnEntry": true,
+            "files": { "/other.s": "main:\n    ld 1, %a\n    reset\n" },
+        }),
+    );
+    out.extend(h.drive());
+    let stopped = find_event(&out, "stopped").expect("second launch stops on entry");
+    assert_eq!(stopped["body"]["reason"], json!("entry"));
+
+    let frames = h.send("stackTrace", json!({ "threadId": 1 }));
+    assert_eq!(frames[0]["body"]["stackFrames"][0]["line"], json!(2));
+}
+
+#[test]
+fn second_launch_keeps_the_breakpoints_of_the_first() {
+    let mut h = Harness::new();
+    h.launch(true);
+    let out = h.send(
+        "setBreakpoints",
+        json!({ "source": { "path": "/fact.s" }, "breakpoints": [{ "line": 7 }] }),
+    );
+    assert_eq!(out[0]["body"]["breakpoints"][0]["verified"], json!(true));
+
+    let mut out = h.send(
+        "launch",
+        json!({
+            "program": "/fact.s",
+            "entrypoint": "main",
+            "stopOnEntry": false,
+            "files": { "/fact.s": FACT_SOURCE },
+        }),
+    );
+    out.extend(h.drive());
+    let stopped = find_event(&out, "stopped").expect("stopped event");
+    assert_eq!(stopped["body"]["reason"], json!("breakpoint"));
+
+    let st = h.send("stackTrace", json!({ "threadId": 1 }));
+    let resp = find_response(&st, "stackTrace").expect("stackTrace response");
+    assert_eq!(resp["body"]["stackFrames"][0]["line"], json!(7));
+}
+
+#[test]
+fn restart_invalidates_handles_from_the_previous_program() {
+    let mut h = Harness::new();
+    launch_globals(&mut h);
+
+    let globals = scope_ref(&mut h, 0, "Globals");
+    let handle = var(&variables(&mut h, globals, json!({})), "array")["variablesReference"]
+        .as_i64()
+        .unwrap();
+    assert!(!variables(&mut h, handle, json!({})).is_empty());
+
+    h.send("restart", json!({}));
+    assert_eq!(variables(&mut h, handle, json!({})), Vec::<Value>::new());
+}
+
 /// Find the first event with the given name in a list of messages.
 fn find_event<'a>(messages: &'a [Value], name: &str) -> Option<&'a Value> {
     messages

--- a/crates/emulator/src/dap/tests.rs
+++ b/crates/emulator/src/dap/tests.rs
@@ -525,6 +525,48 @@ fn set_variable_updates_register() {
 }
 
 #[test]
+fn set_variable_on_stack_scope_rejects_overflowing_offset() {
+    let mut h = Harness::new();
+    h.launch(true);
+
+    // `sp + 4294967295` overflows the u32 address the offset is added to.
+    let resp = h.send(
+        "setVariable",
+        json!({ "variablesReference": 4, "name": "sp+4294967295", "value": "1" }),
+    );
+    let resp = find_response(&resp, "setVariable").expect("setVariable response");
+    assert_eq!(resp["success"], json!(false));
+}
+
+#[test]
+fn set_variable_on_a_region_handle_rejects_an_address_outside_it() {
+    let mut h = Harness::new();
+    launch_globals(&mut h);
+
+    let globals = scope_ref(&mut h, 0, "Globals");
+    let array = var(&variables(&mut h, globals, json!({})), "array")["variablesReference"]
+        .as_i64()
+        .unwrap();
+
+    // A child variable is written through the address encoded in its name, so
+    // a name the adapter never produced must not reach a cell outside the
+    // region the handle covers.
+    let resp = h.send(
+        "setVariable",
+        json!({ "variablesReference": array, "name": "whatever (0)", "value": "777" }),
+    );
+    let resp = find_response(&resp, "setVariable").expect("setVariable response");
+    assert_eq!(resp["success"], json!(false));
+
+    let out = h.send(
+        "readMemory",
+        json!({ "memoryReference": "0", "offset": 0, "count": 8 }),
+    );
+    let resp = find_response(&out, "readMemory").expect("readMemory response");
+    assert_eq!(resp["body"]["data"], json!("AAAAAAAAAAA="));
+}
+
+#[test]
 fn evaluate_resolves_a_label() {
     let mut h = Harness::new();
     h.launch(true);

--- a/crates/emulator/src/dap/tests.rs
+++ b/crates/emulator/src/dap/tests.rs
@@ -102,6 +102,84 @@ impl Harness {
     }
 }
 
+#[test]
+fn breakpoints_set_before_launch_are_kept_and_verified_on_launch() {
+    let mut h = Harness::new();
+    h.send("initialize", json!({}));
+
+    // The `initialized` event ships with the initialize response, so
+    // `setBreakpoints` can reach the adapter before `launch`. Line 7 is
+    // `ld [%sp+1],%a` and line 3 is `call factorielle`.
+    let out = h.send(
+        "setBreakpoints",
+        json!({ "source": { "path": "/fact.s" }, "breakpoints": [{ "line": 7 }, { "line": 3 }] }),
+    );
+    assert_eq!(out[0]["success"], json!(true));
+    let requested = out[0]["body"]["breakpoints"].as_array().unwrap().clone();
+    assert_eq!(requested[0]["verified"], json!(false));
+    assert_eq!(requested[0]["reason"], json!("pending"));
+    let ids: Vec<&Value> = requested.iter().map(|bp| &bp["id"]).collect();
+    assert!(ids.iter().all(|id| id.is_i64()), "ids assigned: {ids:?}");
+
+    let out = h.send(
+        "launch",
+        json!({
+            "program": "/fact.s",
+            "entrypoint": "main",
+            "stopOnEntry": false,
+            "files": { "/fact.s": FACT_SOURCE },
+        }),
+    );
+    let events: Vec<&Value> = out.iter().filter(|m| m["event"] == "breakpoint").collect();
+    assert_eq!(events.len(), 2, "one event per requested line");
+    let event_ids: Vec<&Value> = events
+        .iter()
+        .map(|e| &e["body"]["breakpoint"]["id"])
+        .collect();
+    assert_eq!(event_ids, ids, "events carry the response ids");
+
+    let seven = events
+        .iter()
+        .find(|e| e["body"]["breakpoint"]["id"] == requested[0]["id"])
+        .expect("event for line 7");
+    assert_eq!(seven["body"]["breakpoint"]["verified"], json!(true));
+    assert_eq!(seven["body"]["breakpoint"]["line"], json!(7));
+
+    let mut out = h.send("configurationDone", json!({}));
+    out.extend(h.drive());
+    let stopped = find_event(&out, "stopped").expect("stops at the breakpoint");
+    assert_eq!(stopped["body"]["reason"], json!("breakpoint"));
+}
+
+#[test]
+fn a_pending_breakpoint_with_no_code_after_it_is_reported_unverified() {
+    let mut h = Harness::new();
+    h.send("initialize", json!({}));
+
+    // Line 100 is past the end of the source, so it never resolves; without an
+    // event of its own the client would show it as pending for the whole
+    // session.
+    h.send(
+        "setBreakpoints",
+        json!({ "source": { "path": "/fact.s" }, "breakpoints": [{ "line": 100 }] }),
+    );
+    let out = h.send(
+        "launch",
+        json!({
+            "program": "/fact.s",
+            "entrypoint": "main",
+            "stopOnEntry": true,
+            "files": { "/fact.s": FACT_SOURCE },
+        }),
+    );
+    let events: Vec<&Value> = out.iter().filter(|m| m["event"] == "breakpoint").collect();
+    assert_eq!(events.len(), 1);
+    let bp = &events[0]["body"]["breakpoint"];
+    assert_eq!(bp["verified"], json!(false));
+    assert_eq!(bp["reason"], json!("failed"));
+    assert_eq!(bp["message"], json!("no code at or after this line"));
+}
+
 /// Find the first event with the given name in a list of messages.
 fn find_event<'a>(messages: &'a [Value], name: &str) -> Option<&'a Value> {
     messages

--- a/crates/emulator/src/dap/tests.rs
+++ b/crates/emulator/src/dap/tests.rs
@@ -661,6 +661,56 @@ fn resume_after_unhandled_exception_terminates() {
 }
 
 #[test]
+fn exception_stack_trace_reports_the_faulting_line() {
+    const BAD_ADDRESS_SOURCE: &str = indoc::indoc! {r"
+        main:
+            ld [99999], %a
+            reset
+    "};
+
+    let mut h = Harness::new();
+    h.send("initialize", json!({}));
+    h.send(
+        "launch",
+        json!({
+            "program": "/boom.s",
+            "entrypoint": "main",
+            "stopOnEntry": false,
+            "files": { "/boom.s": BAD_ADDRESS_SOURCE },
+        }),
+    );
+    let mut out = h.send("configurationDone", json!({}));
+    out.extend(h.drive());
+    let stopped = find_event(&out, "stopped").expect("stopped event");
+    assert_eq!(stopped["body"]["reason"], json!("exception"));
+
+    // The faulting `ld [99999], %a` is line 2 (1-based); pc has already
+    // advanced past it by the time the exception is reported, so the frame
+    // must not report line 3 (the `reset`).
+    let st = h.send("stackTrace", json!({ "threadId": 1 }));
+    let resp = find_response(&st, "stackTrace").expect("stackTrace response");
+    assert_eq!(resp["body"]["stackFrames"][0]["line"], json!(2));
+
+    // The stopped event names the faulting address, which the live pc in the
+    // Registers scope no longer matches.
+    let text = stopped["body"]["text"].as_str().unwrap();
+    assert!(text.contains("at address 100"), "text = {text}");
+
+    // A resume that is rejected must not drop the faulting pc: `continue`
+    // after the exception terminates the session, and `stepIn` is then
+    // refused, so the frame still points at line 2.
+    h.send("continue", json!({ "threadId": 1 }));
+    let resp = h.send("stepIn", json!({ "threadId": 1 }));
+    assert_eq!(
+        find_response(&resp, "stepIn").expect("stepIn response")["success"],
+        json!(false)
+    );
+    let st = h.send("stackTrace", json!({ "threadId": 1 }));
+    let resp = find_response(&st, "stackTrace").expect("stackTrace response");
+    assert_eq!(resp["body"]["stackFrames"][0]["line"], json!(2));
+}
+
+#[test]
 fn continue_after_termination_is_rejected() {
     let mut h = Harness::new();
     // Runs straight to `reset` and terminates.

--- a/crates/emulator/src/dap/tests.rs
+++ b/crates/emulator/src/dap/tests.rs
@@ -877,6 +877,12 @@ fn globals_scope_single_and_multi_cell() {
     // Single-cell code label renders the instruction.
     assert_eq!(var(&vars, "main")["type"], json!("instruction"));
 
+    // `last` is the final label and holds a single `.word`, so its region is
+    // one cell.
+    let last = var(&vars, "last");
+    assert_eq!(last["value"], json!("7"));
+    assert_eq!(last["variablesReference"], json!(0));
+
     // Multi-cell region expands and reports its length.
     let array = var(&vars, "array");
     assert_eq!(array["indexedVariables"], json!(3));
@@ -904,6 +910,36 @@ fn globals_scope_single_and_multi_cell() {
         256,
         "default page size caps the response"
     );
+}
+
+#[test]
+fn a_trailing_space_label_reports_its_full_length() {
+    // `.space` compiles to reserved cells that read back as empty, so the
+    // program's extent has to come from the layout rather than from memory.
+    const TRAILING_SPACE_SOURCE: &str = indoc::indoc! {r"
+        main:
+            reset
+
+        buf:
+            .space 100
+    "};
+
+    let mut h = Harness::new();
+    h.send("initialize", json!({}));
+    h.send(
+        "launch",
+        json!({
+            "program": "/s.s",
+            "entrypoint": "main",
+            "stopOnEntry": true,
+            "files": { "/s.s": TRAILING_SPACE_SOURCE },
+        }),
+    );
+    h.send("configurationDone", json!({}));
+
+    let globals = scope_ref(&mut h, 0, "Globals");
+    let vars = variables(&mut h, globals, json!({}));
+    assert_eq!(var(&vars, "buf")["indexedVariables"], json!(100));
 }
 
 #[test]

--- a/crates/emulator/src/dap/tests.rs
+++ b/crates/emulator/src/dap/tests.rs
@@ -246,6 +246,25 @@ fn restart_invalidates_handles_from_the_previous_program() {
     assert_eq!(variables(&mut h, handle, json!({})), Vec::<Value>::new());
 }
 
+#[test]
+fn read_memory_before_address_zero_is_clamped_to_zero() {
+    let mut h = Harness::new();
+    h.launch(true);
+    // VS Code's memory viewer sends offsets that reach below address 0 when
+    // scrolling up. The response's `address` says where the data it returns
+    // actually starts.
+    let out = h.send(
+        "readMemory",
+        json!({ "memoryReference": "1015", "offset": -100_000, "count": 4 }),
+    );
+    let resp = find_response(&out, "readMemory").expect("readMemory response");
+    assert_eq!(resp["success"], json!(true));
+    assert_eq!(resp["body"]["address"], json!("0"));
+    // Cell 0 is empty, so it reads as a zero word.
+    assert_eq!(resp["body"]["data"], json!("AAAAAA=="));
+    assert_eq!(resp["body"]["unreadableBytes"], Value::Null);
+}
+
 /// Find the first event with the given name in a list of messages.
 fn find_event<'a>(messages: &'a [Value], name: &str) -> Option<&'a Value> {
     messages


### PR DESCRIPTION
Six fixes to the debug adapter, each with tests in `dap/tests.rs`. Revised after a review round; the second half of each bullet is what the review added.

- Breakpoints set before `launch` were rejected and lost. Clients can send `setBreakpoints` before `launch` because the `initialized` event ships with the initialize response, and this repo's VS Code wrapper and nvim-dap both do. They are now kept as pending lines, answered as unverified with `reason: "pending"`, and resolved with `breakpoint` events once the program loads. Every breakpoint now carries an `id`, echoed in the events, so clients can match them; lines that never resolve get an event too, with `reason: "failed"`.
- A second `launch` in the same session loaded the program but never stopped on entry nor ran, because the `entered` flag stayed set. `launch` and `restart` now share one `install_program` path that resets the session state, carries the requested breakpoint lines over and invalidates the previous program's `variablesReference` handles.
- On an unhandled exception, the top stack frame pointed at the instruction after the fault. The pc is remembered before the step and used by `stackTrace` only; the Registers scope keeps the live pc, which is the machine's real state, and the `stopped` event names the faulting address. A rejected resume no longer clears it.
- The last label's region extended to the end of memory. It now ends at the end of the program, computed from the layout so a trailing `buf: .space 100` reports 100 cells.
- `readMemory` with a negative offset returned a successful response with a negative address and no data. The start is now clamped to 0 and the response `address` says where the data begins, which is what VS Code's memory viewer needs when scrolling up.
- `setVariable` on the Stack scope added `sp+<n>` with plain `u32` addition: panic in debug, unrelated address in release. It uses `checked_add`, and writes through a region handle are bounded to that region, so a client-supplied name cannot reach another cell.

Verified: `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets`, `cargo test -p z33-emulator` (480 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
