### PR TITLE
Web IDE fixes: file overwrite, entrypoint selection, persisted breakpoints, display

### DIFF
--- a/editors/web/app/App.tsx
+++ b/editors/web/app/App.tsx
@@ -61,11 +61,13 @@ const App = () => {
   // the file store.
   useEffect(() => {
     setRunCommandHandler(({ path, label }) => {
-      const { mode, stopDebug } = useAppStore.getState();
-      if (mode.type === "debug") stopDebug();
+      const { mode: current, stopDebug } = useAppStore.getState();
+      if (current.type === "debug") stopDebug();
       runFile(path, label);
     });
-    return () => setRunCommandHandler(null);
+    return () => {
+      setRunCommandHandler(null);
+    };
   }, [runFile]);
 
   const handleEditorMount = useCallback(

--- a/editors/web/app/computer.stories.tsx
+++ b/editors/web/app/computer.stories.tsx
@@ -4,6 +4,7 @@ import { expect, within } from "storybook/test";
 import { MemoryViewer } from "./computer";
 import type { Pointers } from "./computer-types";
 import { emptyScene, factorialScene, sceneLabels } from "./testing/fixtures";
+import { useDisplayStore } from "./stores/display-store";
 import { FakeComputer } from "./testing/fake-computer";
 
 const meta = preview.meta({
@@ -73,8 +74,12 @@ export const EmptyMemory = meta.story({
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    // Empty cells render as a muted zero word.
-    const zeros = await canvas.findAllByText("00000000");
+    // Empty cells render as a muted zero in the selected format.
+    const zeros = await canvas.findAllByText("0");
     await expect(zeros.length).toBeGreaterThan(0);
+    useDisplayStore.setState({ format: "hex" });
+    const hexZeros = await canvas.findAllByText("0x0");
+    await expect(hexZeros.length).toBeGreaterThan(0);
+    useDisplayStore.setState({ format: "decimal" });
   },
 });

--- a/editors/web/app/computer.tsx
+++ b/editors/web/app/computer.tsx
@@ -80,6 +80,12 @@ export const Word: React.FC<{ word: number; labels: Labels }> = ({
   return <WordValue word={word} format={format} />;
 };
 
+/** A never-written cell reads as zero; muted to tell it from a stored 0. */
+const EmptyWord: React.FC = () => {
+  const format = useDisplayStore((s) => s.format);
+  return <WordValue word={0} format={format} muted />;
+};
+
 export const CellView: React.FC<{ cell: Cell; labels: Labels }> = ({
   cell,
   labels,
@@ -89,7 +95,7 @@ export const CellView: React.FC<{ cell: Cell; labels: Labels }> = ({
   ) : cell.type === "instruction" ? (
     cell.instruction
   ) : (
-    <WordValue word="00000000" muted />
+    <EmptyWord />
   );
 
 const normalize = (value: number): number =>

--- a/editors/web/app/debug-layout.tsx
+++ b/editors/web/app/debug-layout.tsx
@@ -15,7 +15,7 @@ import { ResizeHandle } from "./panel-resize-handle";
 import { SerialConsole } from "./serial-console";
 import { useAppStore } from "./stores/app-store";
 import { useFileStore } from "./stores/file-store";
-import { Group, Panel } from "react-resizable-panels";
+import { Group, Panel, useDefaultLayout } from "react-resizable-panels";
 
 type DebugLayoutProps = {
   onEditorMount: (editor: monaco.editor.IStandaloneCodeEditor) => void;
@@ -68,6 +68,17 @@ const DebugLayoutInner: React.FC<DebugLayoutInnerProps> = ({
   const activeFile = useFileStore((s) => s.activeFile);
   const setActiveFile = useFileStore((s) => s.setActiveFile);
 
+  const vertical = useDefaultLayout({
+    id: "z33:layout-vertical",
+    panelIds: ["z33-main", "z33-console"],
+    storage: localStorage,
+  });
+  const horizontal = useDefaultLayout({
+    id: "z33:layout-horizontal",
+    panelIds: ["z33-editor", "z33-right"],
+    storage: localStorage,
+  });
+
   const [editor, setEditor] =
     useState<monaco.editor.IStandaloneCodeEditor | null>(null);
 
@@ -104,9 +115,21 @@ const DebugLayoutInner: React.FC<DebugLayoutInnerProps> = ({
         onFileChange={setActiveFile}
         onStop={onStopDebug}
       />
-      <Group orientation="vertical" id="z33-v" className="flex-1 min-h-0">
+      <Group
+        orientation="vertical"
+        id="z33-v"
+        className="flex-1 min-h-0"
+        defaultLayout={vertical.defaultLayout}
+        onLayoutChanged={vertical.onLayoutChanged}
+      >
         <Panel defaultSize="75%" minSize="30%" id="z33-main">
-          <Group orientation="horizontal" id="z33-h" className="h-full">
+          <Group
+            orientation="horizontal"
+            id="z33-h"
+            className="h-full"
+            defaultLayout={horizontal.defaultLayout}
+            onLayoutChanged={horizontal.onLayoutChanged}
+          >
             <Panel defaultSize="65%" minSize="40%" id="z33-editor">
               <MultiFileEditor
                 filePath={activeFile}

--- a/editors/web/app/edit-toolbar.tsx
+++ b/editors/web/app/edit-toolbar.tsx
@@ -50,7 +50,8 @@ export const EditToolbar: React.FC<EditToolbarProps> = memo(
     labels,
     defaultEntrypoint,
   }) => {
-    const canRun = compilationStatus === "success" && labels.length > 0;
+    const hasLabels = labels.length > 0;
+    const canRun = compilationStatus === "success" && hasLabels;
     const [chosen, setChosen] = useState<string | null>(null);
     const entrypoint =
       chosen !== null && labels.includes(chosen)
@@ -89,12 +90,12 @@ export const EditToolbar: React.FC<EditToolbarProps> = memo(
         )}
 
         <div className="ml-auto flex items-center gap-1">
-          {canRun && (
+          {hasLabels && (
             <form
               className="flex items-center gap-1"
               onSubmit={(e: React.SubmitEvent<HTMLFormElement>) => {
                 e.preventDefault();
-                if (entrypoint) onRun(entrypoint);
+                if (canRun && entrypoint) onRun(entrypoint);
               }}
             >
               <span className="text-xs text-muted-foreground">Start at</span>
@@ -124,7 +125,7 @@ export const EditToolbar: React.FC<EditToolbarProps> = memo(
                   ))}
                 </SelectContent>
               </Select>
-              <Button type="submit" size="xs">
+              <Button type="submit" size="xs" disabled={!canRun}>
                 <PlayIcon data-icon="inline-start" />
                 Run
               </Button>

--- a/editors/web/app/edit-toolbar.tsx
+++ b/editors/web/app/edit-toolbar.tsx
@@ -4,7 +4,7 @@ import {
   PlayIcon,
   XCircleIcon,
 } from "lucide-react";
-import { memo } from "react";
+import { memo, useState } from "react";
 import { Button } from "./components/ui/button";
 import {
   Select,
@@ -51,6 +51,11 @@ export const EditToolbar: React.FC<EditToolbarProps> = memo(
     defaultEntrypoint,
   }) => {
     const canRun = compilationStatus === "success" && labels.length > 0;
+    const [chosen, setChosen] = useState<string | null>(null);
+    const entrypoint =
+      chosen !== null && labels.includes(chosen)
+        ? chosen
+        : pickEntrypoint(labels, defaultEntrypoint);
 
     return (
       <div
@@ -85,21 +90,20 @@ export const EditToolbar: React.FC<EditToolbarProps> = memo(
 
         <div className="ml-auto flex items-center gap-1">
           {canRun && (
-            // Remount on a changed label set so the uncontrolled Select picks
-            // up the fresh default entrypoint.
             <form
-              key={labels.join(" ")}
               className="flex items-center gap-1"
               onSubmit={(e: React.SubmitEvent<HTMLFormElement>) => {
                 e.preventDefault();
-                const value = new FormData(e.currentTarget).get("entrypoint");
-                if (typeof value === "string" && value) onRun(value);
+                if (entrypoint) onRun(entrypoint);
               }}
             >
               <span className="text-xs text-muted-foreground">Start at</span>
               <Select
                 name="entrypoint"
-                defaultValue={pickEntrypoint(labels, defaultEntrypoint)}
+                value={entrypoint}
+                onValueChange={(value) => {
+                  if (typeof value === "string") setChosen(value);
+                }}
               >
                 <SelectTrigger
                   size="xs"

--- a/editors/web/app/file-sidebar.tsx
+++ b/editors/web/app/file-sidebar.tsx
@@ -229,7 +229,7 @@ export const FileSidebarView: React.FC<FileSidebarViewProps> = ({
                     variant="ghost"
                     size="icon-xs"
                     aria-label="Download"
-                    className="opacity-0 group-hover:opacity-100"
+                    className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
                     onClick={() => {
                       onDownload(name);
                     }}
@@ -247,7 +247,7 @@ export const FileSidebarView: React.FC<FileSidebarViewProps> = ({
                     variant="ghost"
                     size="icon-xs"
                     aria-label="Delete"
-                    className="opacity-0 group-hover:opacity-100 mr-1"
+                    className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 mr-1"
                     onClick={() => {
                       onDelete(name);
                     }}

--- a/editors/web/app/hooks/use-compilation.ts
+++ b/editors/web/app/hooks/use-compilation.ts
@@ -29,8 +29,8 @@ export function useCompilation(activeFile: string, monacoInstance: Monaco) {
 
   // Keep the Zustand file store and Monaco models in sync.
   useEffect(() => {
-    if (!monacoInstance) return;
-    initMonacoSync(monacoInstance, {
+    if (!monacoInstance) return () => {};
+    return initMonacoSync(monacoInstance, {
       onEdit: (name, content) => {
         useFileStore.getState().onMonacoEdit(name, content);
       },

--- a/editors/web/app/memory-panel.tsx
+++ b/editors/web/app/memory-panel.tsx
@@ -64,7 +64,7 @@ const LabelList: React.FC<{
   onLabelClick: (name: string, address: number) => void;
 }> = ({ computer, labels, following, onLabelClick }) => {
   const sorted = useMemo(
-    () => Array.from(computer.labels).sort(([, a], [, b]) => a - b),
+    () => Array.from(computer.labels).toSorted(([, a], [, b]) => a - b),
     [computer.labels],
   );
 

--- a/editors/web/app/multi-file-editor.tsx
+++ b/editors/web/app/multi-file-editor.tsx
@@ -129,8 +129,10 @@ export const MultiFileEditor: React.FC<Props> = ({
             requestedLineForClick(e.target.position.lineNumber, fileResolved),
           );
         });
-        // Re-apply glyphs after a model (file) switch.
-        editor.onDidChangeModel(() => {
+        // Glyphs for the model currently shown: needed once at mount, because
+        // the effect above ran before the refs existed, and again after every
+        // model (file) switch.
+        const applyGlyphs = () => {
           const decorations = decorationsRef.current;
           if (!decorations) return;
           const { breakpoints: bp, resolved: res } =
@@ -141,7 +143,9 @@ export const MultiFileEditor: React.FC<Props> = ({
               res[filePathRef.current],
             ),
           );
-        });
+        };
+        applyGlyphs();
+        editor.onDidChangeModel(applyGlyphs);
 
         onEditorMount?.(editor);
       }}

--- a/editors/web/app/serial-terminal.tsx
+++ b/editors/web/app/serial-terminal.tsx
@@ -83,7 +83,7 @@ const SerialTerminal: React.FC<SerialTerminalProps> = ({ computer, ref }) => {
   // Create the terminal once and wire up resize handling.
   useEffect(() => {
     const container = containerRef.current;
-    if (!container) return undefined;
+    if (!container) return () => {};
 
     const { effective } = useThemeStore.getState();
     const terminal = new Terminal({
@@ -146,7 +146,7 @@ const SerialTerminal: React.FC<SerialTerminalProps> = ({ computer, ref }) => {
   // Reset scrollback and (re)wire I/O whenever the debug session changes.
   useEffect(() => {
     const terminal = terminalRef.current;
-    if (!terminal) return undefined;
+    if (!terminal) return () => {};
 
     terminal.reset();
 

--- a/editors/web/app/serial-terminal.tsx
+++ b/editors/web/app/serial-terminal.tsx
@@ -99,8 +99,10 @@ const SerialTerminal: React.FC<SerialTerminalProps> = ({ computer, ref }) => {
     terminal.open(container);
     terminalRef.current = terminal;
 
-    // Expose the instance for e2e tests.
-    (globalThis as { __z33Terminal?: Terminal }).__z33Terminal = terminal;
+    // Expose the instance for e2e tests, like the editor's `__z33e2e` hook.
+    if (import.meta.env.DEV) {
+      (globalThis as { __z33Terminal?: Terminal }).__z33Terminal = terminal;
+    }
 
     // Fit to the container, guarding against the collapsed-panel pitfall:
     // fitting at zero size yields NaN/Infinity dimensions and can runaway.

--- a/editors/web/app/stores/file-store.ts
+++ b/editors/web/app/stores/file-store.ts
@@ -48,7 +48,10 @@ export const useFileStore = create<FileState & FileActions>()(
 
       createFile: (name, content = "") => {
         set((state) => ({
-          files: { ...state.files, [name]: content },
+          files:
+            name in state.files
+              ? state.files
+              : { ...state.files, [name]: content },
           activeFile: name,
         }));
       },

--- a/editors/web/app/stores/theme-store.ts
+++ b/editors/web/app/stores/theme-store.ts
@@ -4,6 +4,11 @@ import { persist } from "zustand/middleware";
 type EffectiveTheme = "dark" | "light";
 type Theme = EffectiveTheme | "system";
 
+const THEMES: readonly Theme[] = ["dark", "light", "system"];
+
+const isTheme = (value: unknown): value is Theme =>
+  typeof value === "string" && (THEMES as readonly string[]).includes(value);
+
 const darkMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
 
 function resolveEffective(theme: Theme): EffectiveTheme {
@@ -29,10 +34,13 @@ export const useThemeStore = create<ThemeState>()(
     {
       name: "z33:theme",
       partialize: (state) => ({ theme: state.theme }),
-      onRehydrateStorage: () => (state) => {
-        if (state) {
-          state.effective = resolveEffective(state.theme);
-        }
+      merge: (persisted, current) => {
+        const stored =
+          persisted && typeof persisted === "object" && "theme" in persisted
+            ? persisted.theme
+            : undefined;
+        const theme = isTheme(stored) ? stored : "system";
+        return { ...current, theme, effective: resolveEffective(theme) };
       },
     },
   ),

--- a/editors/web/e2e/breakpoints.spec.ts
+++ b/editors/web/e2e/breakpoints.spec.ts
@@ -44,6 +44,21 @@ test.describe("Breakpoints & fast run", () => {
     await expect(toolbar.getByRole("alert")).toHaveCount(0);
   });
 
+  test("persisted breakpoints are drawn after a reload", async ({
+    cleanPage: page,
+  }) => {
+    await toggleBreakpointOnLine(page, "[%sp+1],%a");
+    const glyphCount = () =>
+      page.evaluate(
+        () =>
+          document.querySelectorAll(".bp-glyph, .bp-glyph-unverified").length,
+      );
+    await expect.poll(glyphCount).toBe(1);
+
+    await page.reload();
+    await expect.poll(glyphCount).toBe(1);
+  });
+
   test("fast run completes a large loop quickly", async ({ page }) => {
     // ~200k iterations (~600k instructions).
     await loadWorkspace(

--- a/editors/web/e2e/core-flows.spec.ts
+++ b/editors/web/e2e/core-flows.spec.ts
@@ -48,6 +48,24 @@ test.describe("Core flows", () => {
     await waitForCompileSuccess(page);
   });
 
+  test("a transient compile error keeps the Run controls in place", async ({
+    cleanPage: page,
+  }) => {
+    await waitForCompileSuccess(page);
+    const run = page.getByRole("button", { name: "Run", exact: true });
+    await expect(run).toBeEnabled();
+
+    await page.locator(".monaco-editor").click();
+    await page.keyboard.press("Control+End");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("sh");
+    await waitForCompileError(page);
+    await expect(run).toBeDisabled();
+    await expect(
+      page.getByRole("combobox", { name: "Entrypoint" }),
+    ).toBeVisible();
+  });
+
   test("chosen entrypoint survives a change to the label set", async ({
     cleanPage: page,
   }) => {

--- a/editors/web/e2e/core-flows.spec.ts
+++ b/editors/web/e2e/core-flows.spec.ts
@@ -48,6 +48,24 @@ test.describe("Core flows", () => {
     await waitForCompileSuccess(page);
   });
 
+  test("chosen entrypoint survives a change to the label set", async ({
+    cleanPage: page,
+  }) => {
+    await waitForCompileSuccess(page);
+    const entrypoint = page.getByRole("combobox", { name: "Entrypoint" });
+    await entrypoint.click();
+    await page.getByRole("option", { name: "casparticulier" }).click();
+    await expect(entrypoint).toContainText("casparticulier");
+
+    // Adding a label recompiles with a different label set.
+    await page.locator(".monaco-editor").click();
+    await page.keyboard.press("Control+End");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("newlabel:");
+    await waitForCompileSuccess(page);
+    await expect(entrypoint).toContainText("casparticulier");
+  });
+
   test("debug session lifecycle", async ({ cleanPage: page }) => {
     await enterDebugMode(page);
 

--- a/editors/web/e2e/debug-details.spec.ts
+++ b/editors/web/e2e/debug-details.spec.ts
@@ -1,4 +1,10 @@
-import { enterDebugMode, expect, getCycleCount, test } from "./fixtures";
+import {
+  enterDebugMode,
+  exitDebugMode,
+  expect,
+  getCycleCount,
+  test,
+} from "./fixtures";
 
 test.describe("Debug details", () => {
   test("run increases cycle count", async ({ cleanPage: page }) => {
@@ -63,5 +69,25 @@ test.describe("Debug details", () => {
 
     // Switch back to decimal
     await registers.getByLabel("Decimal", { exact: true }).click();
+  });
+  test("panel layout survives leaving and re-entering debug mode", async ({
+    cleanPage: page,
+  }) => {
+    await enterDebugMode(page);
+    const separator = page.getByRole("separator").last();
+    const size = () => separator.getAttribute("aria-valuenow");
+    const before = await size();
+    await separator.focus();
+    for (let i = 0; i < 5; i++) await page.keyboard.press("ArrowUp");
+    await expect.poll(size).not.toBe(before);
+    const resized = await size();
+
+    await exitDebugMode(page);
+    await enterDebugMode(page);
+    await expect
+      .poll(() =>
+        page.getByRole("separator").last().getAttribute("aria-valuenow"),
+      )
+      .toBe(resized);
   });
 });

--- a/editors/web/e2e/file-management.spec.ts
+++ b/editors/web/e2e/file-management.spec.ts
@@ -14,6 +14,18 @@ test.describe("File management", () => {
     ).toBeVisible();
   });
 
+  test("creating a file with an existing name keeps its content", async ({
+    cleanPage: page,
+  }) => {
+    await page.getByRole("button", { name: "New file" }).click();
+    const input = page.getByRole("textbox", { name: "File name" });
+    await input.fill("fact.s");
+    await input.press("Enter");
+
+    await expect(page.getByRole("button", { name: "fact.s" })).toHaveCount(1);
+    await expect(page.locator(".monaco-editor")).toContainText("factorielle");
+  });
+
   test("delete a file", async ({ cleanPage: page }) => {
     // Create a file first
     await page.getByRole("button", { name: "New file" }).click();

--- a/editors/web/index.html
+++ b/editors/web/index.html
@@ -3,7 +3,9 @@
 
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>z33-emulator</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <script src="app/index.tsx" type="module"></script>
 </head>
 

--- a/editors/web/public/favicon.svg
+++ b/editors/web/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0f766e"/>
+  <text x="16" y="22" font-family="ui-monospace, Menlo, monospace" font-size="15" font-weight="700" fill="#f0fdfa" text-anchor="middle">z33</text>
+</svg>


### PR DESCRIPTION
Twelve small fixes to the web IDE, one commit each. The behaviour fixes come with Playwright or Storybook coverage.

Data loss and state:
- "New file" with an existing name wiped that file with no warning. It now only selects the file.
- The entrypoint select reset to the default whenever the label set changed, so typing a new label anywhere lost the choice.
- The Run controls unmounted on every transient compile error, so the toolbar reflowed on each keystroke that briefly broke the program.
- Breakpoints restored from storage stayed invisible until one was toggled.
- The debug panel layout now persists across Edit/Run round trips and reloads.
- A stored theme outside light/dark/system was applied verbatim as a class on the root element.

Display and accessibility:
- Empty memory cells rendered as `00000000` whatever the display format. They now go through `formatWord`.
- Viewport meta tag and a favicon (the favicon request was a 404 on every load).
- The per-file Download and Delete buttons are revealed on keyboard focus, not only on hover.

Housekeeping:
- The Monaco sync disposer returned by `initMonacoSync` was dropped by the compilation effect.
- The serial terminal test hook is installed in dev builds only, like the editor's.
- The mechanical oxlint warnings are cleared.

Verified: `tsc --noEmit`, `pnpm run check`, 66 Storybook tests, 34 Playwright tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
