### PR TITLE
CLI run and interactive mode fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,14 +107,23 @@ program's output:
 - `help [command]`: Print the help message of a command
 - `memory <address> [n]`: Show a block of memory. The address can be either a register with or without offset (e.g. `%sp-5`) or a literal (e.g. `100`). The second argument is the number of cells to show (one by default).
 - `registers [register]`: Show the value of a register. If no register is specified, shows the value of all five of them.
-- `list`: Show the code that will be run next.
+- `list [n]`: Show the next `n` instructions that will be run (ten by default), continuing where the previous `list` stopped.
 - `step [n]`: Run `n` step of the program (one by default).
 - `break <address>`: Set a breakpoint at given address.
 - `unbreak <address>`: Remove a breakpoint at given address.
 - `info breakpoints`: Show the list of breakpoints
-- `continue`: Run the code until the next breakpoint
+- `info labels`: Show the program's labels and their addresses
+- `info cycles`: Show the number of cycles executed so far
+- `set <target> <value>`: Write a value into a register (`set %a 42`) or a memory cell (`set 100 42`)
+- `input <text>`: Queue a line of text on the serial console's input
+- `continue`: Run the code until the next breakpoint or reset
 - `interrupt`: Trigger a hardware interrupt
-- `exit`: Exit the emulator
+- `exit`, `quit`, `q`: Exit the emulator
+
+An empty line repeats the last command. A command can be shortened to any
+unambiguous prefix (`st` for `step`, `c` for `continue`); `s` is an alias of
+`step` because `set` and `step` share that prefix, while `i` stays ambiguous
+between `info`, `input` and `interrupt`.
 
 ## Releasing
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 mod completion;
 mod dap;
 mod lsp;
-mod run;
+pub(crate) mod run;
 
 #[derive(Parser)]
 pub enum Subcommand {

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -7,7 +7,7 @@ use camino::Utf8PathBuf;
 use clap::{ArgAction, Parser, ValueHint};
 use tracing::{debug, info};
 use z33_emulator::diagnostic::{
-    preprocessor_error_to_diagnostics, render_to_string, resolve_diagnostic_spans,
+    has_errors, preprocessor_error_to_diagnostics, render_to_string, resolve_diagnostic_spans,
 };
 use z33_emulator::preprocessor::{NativeFilesystem, SourceMap, Workspace};
 use z33_emulator::runtime::{Computer, ProcessorError};
@@ -75,12 +75,12 @@ impl RunOpt {
         );
 
         // Show all diagnostics (parse + compilation), resolved to original
-        // files
-        if !compile_result.diagnostics.is_empty() {
-            for diag in &compile_result.diagnostics {
-                let resolved = resolve_diagnostic_spans(diag, &source_map);
-                eprint!("{}", render_to_string(&resolved, workspace.file_db()));
-            }
+        // files; only errors prevent the run.
+        for diag in &compile_result.diagnostics {
+            let resolved = resolve_diagnostic_spans(diag, &source_map);
+            eprint!("{}", render_to_string(&resolved, workspace.file_db()));
+        }
+        if has_errors(&compile_result.diagnostics) {
             exit(1);
         }
 

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -170,6 +170,7 @@ fn run_with_io(computer: &mut Computer) -> anyhow::Result<()> {
         // Advance the program by a bounded burst so input latency stays low.
         let mut reset = false;
         for _ in 0..IO_BATCH {
+            let pc = computer.registers.pc;
             match computer.step() {
                 Ok(()) => {}
                 Err(ProcessorError::Reset) => {
@@ -179,7 +180,8 @@ fn run_with_io(computer: &mut Computer) -> anyhow::Result<()> {
                 Err(e) => {
                     // Flush any final output before surfacing the error.
                     flush_serial_output(computer)?;
-                    return Err(e.into());
+                    return Err(anyhow::Error::from(e)
+                        .context(format!("while executing the instruction at address {pc}")));
                 }
             }
         }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -20,6 +20,16 @@ use crate::interactive::run_interactive;
 /// bookkeeping is negligible.
 const IO_BATCH: usize = 10_000;
 
+/// How a program stopped running.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Halt {
+    /// The program reset itself, which is how a program ends normally.
+    Reset,
+
+    /// The program hit an exception it could not recover from.
+    Fault,
+}
+
 /// A message from the background stdin reader thread.
 enum Input {
     /// A line of raw bytes read from stdin, including its trailing `\n`. Bytes
@@ -88,14 +98,17 @@ impl RunOpt {
         let debug_info = compile_result.debug_info;
 
         info!("Running program");
-        if self.interactive {
-            run_interactive(&mut computer, debug_info);
+        let halt = if self.interactive {
+            run_interactive(&mut computer, debug_info)
         } else {
-            run_with_io(&mut computer)?;
-        }
+            run_with_io(&mut computer)?
+        };
 
         info!(registers = %computer.registers, "End of program");
 
+        if halt == Halt::Fault {
+            anyhow::bail!("the program faulted");
+        }
         Ok(())
     }
 }
@@ -151,7 +164,10 @@ fn flush_serial_output(computer: &mut Computer) -> anyhow::Result<()> {
 /// bounded burst of instructions runs before draining serial output back to
 /// stdout. `in` never blocks; a program awaiting input simply busy-polls until
 /// a line arrives.
-fn run_with_io(computer: &mut Computer) -> anyhow::Result<()> {
+///
+/// A fault is returned as an error naming the address it happened at, so the
+/// [`Halt`] this returns describes a program that ended by resetting.
+fn run_with_io(computer: &mut Computer) -> anyhow::Result<Halt> {
     let rx = spawn_stdin_reader();
     // Once stdin hits EOF we latch it and never touch the channel again, so we
     // never busy-wait on input that will never come.
@@ -189,7 +205,7 @@ fn run_with_io(computer: &mut Computer) -> anyhow::Result<()> {
         flush_serial_output(computer)?;
 
         if reset {
-            return Ok(());
+            return Ok(Halt::Reset);
         }
     }
 }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,4 +1,4 @@
-use std::io::{BufRead, BufReader, Write};
+use std::io::{self, BufRead, BufReader, Write};
 use std::process::exit;
 use std::sync::mpsc::{self, Receiver, TryRecvError};
 use std::thread;
@@ -18,7 +18,7 @@ use crate::interactive::run_interactive;
 /// The number of instructions to execute between servicing host I/O. Small
 /// enough that input latency stays imperceptible, large enough that the I/O
 /// bookkeeping is negligible.
-const IO_BATCH: usize = 10_000;
+pub(crate) const IO_BATCH: usize = 10_000;
 
 /// How a program stopped running.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -145,7 +145,7 @@ fn spawn_stdin_reader() -> Receiver<Input> {
 /// Drain whatever the program has written to the serial console and write it
 /// straight to stdout. Output bypasses `tracing` on purpose: it is raw program
 /// output and must not be mangled by log formatting.
-fn flush_serial_output(computer: &mut Computer) -> anyhow::Result<()> {
+pub(crate) fn flush_serial_output(computer: &mut Computer) -> io::Result<()> {
     let output = computer.io.serial.drain_output();
     if !output.is_empty() {
         let stdout = std::io::stdout();

--- a/crates/cli/src/interactive/mod.rs
+++ b/crates/cli/src/interactive/mod.rs
@@ -20,7 +20,7 @@ use z33_emulator::runtime::{Cell, Computer, Exception, ProcessorError, Reg};
 mod helper;
 mod parse;
 use self::helper::RunHelper;
-use crate::commands::run::Halt;
+use crate::commands::run::{Halt, IO_BATCH, flush_serial_output};
 
 static HELP: &str = r#"
 Run "help [command]" for command-specific help.
@@ -263,21 +263,6 @@ impl Session {
     }
 }
 
-/// Drain serial output produced by the guest and write it raw to stdout.
-///
-/// Program output bypasses `tracing` on purpose: it must not be mangled by log
-/// formatting. Write errors are ignored — a broken stdout is not recoverable
-/// here and should not abort the debugging session.
-fn flush_serial_output(computer: &mut Computer) {
-    let output = computer.io.serial.drain_output();
-    if !output.is_empty() {
-        use std::io::Write;
-        let stdout = std::io::stdout();
-        let mut handle = stdout.lock();
-        let _ = handle.write_all(&output).and_then(|()| handle.flush());
-    }
-}
-
 /// Log a fault and the address of the instruction that caused it.
 fn report_fault(pc: C::Address, error: &dyn std::error::Error) -> Halt {
     warn!("Program faulted at address {pc}: {error}");
@@ -318,10 +303,20 @@ pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) ->
     let mut halt = Halt::Reset;
 
     'read: loop {
-        // Flush any serial output produced by the previous command's execution
-        // before the next prompt renders (covers step / continue / interrupt,
-        // including paths that `continue 'read`).
-        flush_serial_output(computer);
+        // Write the program's pending output before logging anything about it,
+        // so the two streams stay in order on a shared stdout. A failed write
+        // leaves nowhere to send the output, so the session ends there.
+        macro_rules! flush_or_break {
+            () => {
+                if let Err(e) = flush_serial_output(computer) {
+                    warn!(
+                        error = &e as &dyn std::error::Error,
+                        "Could not write the program's output"
+                    );
+                    break 'read;
+                }
+            };
+        }
 
         // A macro to unwrap an error, log it and continue the loop
         macro_rules! warn_and_continue {
@@ -370,10 +365,13 @@ pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) ->
                     let pc = computer.registers.pc;
                     if let Err(e) = computer.step() {
                         halted = true;
+                        flush_or_break!();
                         halt = report_halt(pc, &e);
                         continue 'read;
                     }
                 }
+
+                flush_or_break!();
             }
 
             (Command::Registers { register }, _) => {
@@ -461,19 +459,27 @@ pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) ->
                 session.remove_breakpoint(address);
             }
 
-            (Command::Continue, false) => loop {
-                let pc = computer.registers.pc;
-                if let Err(e) = computer.step() {
-                    halted = true;
-                    halt = report_halt(pc, &e);
-                    continue 'read;
-                }
+            (Command::Continue, false) => {
+                for steps in 1.. {
+                    let pc = computer.registers.pc;
+                    if let Err(e) = computer.step() {
+                        halted = true;
+                        flush_or_break!();
+                        halt = report_halt(pc, &e);
+                        continue 'read;
+                    }
 
-                if session.has_breakpoint(computer.registers.pc) {
-                    info!(address = computer.registers.pc, "Stopped at a breakpoint");
-                    break;
+                    if session.has_breakpoint(computer.registers.pc) {
+                        flush_or_break!();
+                        info!(address = computer.registers.pc, "Stopped at a breakpoint");
+                        break;
+                    }
+
+                    if steps % IO_BATCH == 0 {
+                        flush_or_break!();
+                    }
                 }
-            },
+            }
 
             (Command::Input { text }, _) => {
                 // Reconstruct the line from the parsed words and append Enter.

--- a/crates/cli/src/interactive/mod.rs
+++ b/crates/cli/src/interactive/mod.rs
@@ -32,7 +32,6 @@ An empty line re-runs the last valid command."#;
     disable_version_flag = true,
     infer_subcommands = true,
     no_binary_name = true,
-    allow_negative_numbers = true,
 )]
 /// Interactive mode commands
 enum Command {
@@ -62,7 +61,7 @@ enum Command {
         address: parse::Argument,
 
         /// Number of memory cells to show.
-        #[clap(value_parser, default_value = "1")]
+        #[clap(value_parser, default_value = "1", allow_negative_numbers = true)]
         number: i32,
     },
 
@@ -73,7 +72,7 @@ enum Command {
         target: parse::AssignmentTarget,
 
         /// The value to set
-        #[clap(value_parser)]
+        #[clap(value_parser, allow_negative_numbers = true)]
         value: parse::Argument,
     },
 
@@ -378,13 +377,16 @@ pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) {
 
                 if number.is_positive() {
                     for i in 0..(number.unsigned_abs() as C::Address) {
-                        let address = address + i;
+                        let address = address.saturating_add(i);
                         let cell = warn_and_continue!(computer.memory.get(address));
                         info!(address, value = %cell);
                     }
                 } else {
                     for i in 0..(number.unsigned_abs() as C::Address) {
-                        let address = address - i;
+                        // Stop rather than wrap around at the bottom of memory.
+                        let Some(address) = address.checked_sub(i) else {
+                            break;
+                        };
                         let cell = warn_and_continue!(computer.memory.get(address));
                         info!(address, value = %cell);
                     }

--- a/crates/cli/src/interactive/mod.rs
+++ b/crates/cli/src/interactive/mod.rs
@@ -15,11 +15,12 @@ use rustyline::{Behavior, CompletionType, Config, EditMode, Editor};
 use tracing::{debug, info, warn};
 use z33_emulator::compiler::DebugInfo;
 use z33_emulator::constants as C;
-use z33_emulator::runtime::{Cell, Computer, Exception, Reg};
+use z33_emulator::runtime::{Cell, Computer, Exception, ProcessorError, Reg};
 
 mod helper;
 mod parse;
 use self::helper::RunHelper;
+use crate::commands::run::Halt;
 
 static HELP: &str = r#"
 Run "help [command]" for command-specific help.
@@ -277,8 +278,26 @@ fn flush_serial_output(computer: &mut Computer) {
     }
 }
 
+/// Log a fault and the address of the instruction that caused it.
+fn report_fault(pc: C::Address, error: &dyn std::error::Error) -> Halt {
+    warn!("Program faulted at address {pc}: {error}");
+    Halt::Fault
+}
+
+/// Log why the program stopped while running the instruction at `pc`.
+fn report_halt(pc: C::Address, error: &ProcessorError) -> Halt {
+    if matches!(error, ProcessorError::Reset) {
+        info!("Program ended (reset)");
+        Halt::Reset
+    } else {
+        report_fault(pc, error)
+    }
+}
+
+/// Runs the debugger loop. Returns how the program stopped, or [`Halt::Reset`]
+/// if the user left before it stopped.
 #[allow(clippy::too_many_lines)]
-pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) {
+pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) -> Halt {
     info!("Running in interactive mode. Type \"help\" to list available commands.");
     let config = Config::builder()
         .history_ignore_space(true)
@@ -296,6 +315,7 @@ pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) {
 
     let mut last_command: Option<Command> = None;
     let mut halted = false;
+    let mut halt = Halt::Reset;
 
     'read: loop {
         // Flush any serial output produced by the previous command's execution
@@ -318,7 +338,7 @@ pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) {
 
         let Ok(readline) = rl.readline(">> ") else {
             info!("EOF, exitting");
-            return;
+            return halt;
         };
 
         let command = if readline.is_empty() {
@@ -347,9 +367,10 @@ pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) {
                 session.reset_list();
 
                 for _ in 0..number {
+                    let pc = computer.registers.pc;
                     if let Err(e) = computer.step() {
-                        warn!(error = &e as &dyn std::error::Error, "Halted");
                         halted = true;
+                        halt = report_halt(pc, &e);
                         continue 'read;
                     }
                 }
@@ -410,9 +431,10 @@ pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) {
             },
 
             (Command::Interrupt, false) => {
+                let pc = computer.registers.pc;
                 if let Err(e) = computer.recover_from_exception(&Exception::HardwareInterrupt) {
-                    warn!(error = &e as &dyn std::error::Error, "Halted");
                     halted = true;
+                    halt = report_fault(pc, &e);
                     continue 'read;
                 }
 
@@ -440,9 +462,10 @@ pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) {
             }
 
             (Command::Continue, false) => loop {
+                let pc = computer.registers.pc;
                 if let Err(e) = computer.step() {
-                    warn!(error = &e as &dyn std::error::Error, "Halted");
                     halted = true;
+                    halt = report_halt(pc, &e);
                     continue 'read;
                 }
 
@@ -487,4 +510,5 @@ pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) {
             }
         }
     }
+    halt
 }

--- a/crates/cli/src/interactive/mod.rs
+++ b/crates/cli/src/interactive/mod.rs
@@ -45,6 +45,7 @@ enum Command {
     },
 
     /// Exit the emulator
+    #[command(alias = "quit", alias = "q")]
     Exit,
 
     /// Show the state of registers

--- a/crates/cli/src/interactive/mod.rs
+++ b/crates/cli/src/interactive/mod.rs
@@ -66,7 +66,7 @@ enum Command {
         number: i32,
     },
 
-    /// Set a value in memory
+    /// Set a value in a register or in memory
     Set {
         /// The address or register to set.
         #[clap(value_parser)]
@@ -412,21 +412,25 @@ pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) ->
                 }
             }
 
-            (Command::Set { target, value }, false) => match &target {
-                parse::AssignmentTarget::Address(node) => {
-                    let address = warn_and_continue!(node.evaluate(&session.labels));
-                    let value = warn_and_continue!(value.evaluate(computer, &session.labels));
-                    info!("Setting memory at address {address} to {value}");
-                    let cell = warn_and_continue!(computer.memory.get_mut(address));
-                    *cell = Cell::Word(value);
+            (Command::Set { target, value }, false) => {
+                match &target {
+                    parse::AssignmentTarget::Address(node) => {
+                        let address = warn_and_continue!(node.evaluate(&session.labels));
+                        let value = warn_and_continue!(value.evaluate(computer, &session.labels));
+                        let cell = warn_and_continue!(computer.memory.get_mut(address));
+                        *cell = Cell::Word(value);
+                        info!("Set memory at address {address} to {value}");
+                    }
+
+                    parse::AssignmentTarget::Register(reg) => {
+                        let value = warn_and_continue!(value.evaluate(computer, &session.labels));
+                        warn_and_continue!(computer.registers.set(*reg, Cell::Word(value)));
+                        info!("Set register {reg} to {value}");
+                    }
                 }
 
-                parse::AssignmentTarget::Register(reg) => {
-                    let value = warn_and_continue!(value.evaluate(computer, &session.labels));
-                    info!("Setting register {reg} to {value}");
-                    warn_and_continue!(computer.registers.set(*reg, Cell::Word(value)));
-                }
-            },
+                session.reset_list();
+            }
 
             (Command::Interrupt, false) => {
                 let pc = computer.registers.pc;
@@ -460,6 +464,8 @@ pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) ->
             }
 
             (Command::Continue, false) => {
+                session.reset_list();
+
                 for steps in 1.. {
                     let pc = computer.registers.pc;
                     if let Err(e) = computer.step() {

--- a/crates/cli/src/interactive/mod.rs
+++ b/crates/cli/src/interactive/mod.rs
@@ -8,6 +8,7 @@
 //! to have it working but works nonetheless.
 
 use std::collections::{BTreeMap, HashSet};
+use std::ops::Range;
 
 use clap::Parser;
 use rustyline::{Behavior, CompletionType, Config, EditMode, Editor};
@@ -182,11 +183,13 @@ impl Session {
         self.list_address = None;
     }
 
-    /// Offset the `list` command, returns the address to show
-    fn offset_list(&mut self, computer: &Computer, offset: C::Address) -> C::Address {
-        let addr = self.list_address.unwrap_or(computer.registers.pc);
-        self.list_address = Some(addr + offset);
-        addr
+    /// Advance the `list` cursor by `count` addresses and return the range to
+    /// show, which is empty once the cursor reached the end of memory.
+    fn offset_list(&mut self, computer: &Computer, count: C::Address) -> Range<C::Address> {
+        let start = self.list_address.unwrap_or(computer.registers.pc);
+        let end = start.saturating_add(count).min(C::MEMORY_SIZE);
+        self.list_address = Some(end);
+        start..end
     }
 
     /// Display the list of breakpoints
@@ -414,9 +417,11 @@ pub(crate) fn run_interactive(computer: &mut Computer, debug_info: DebugInfo) {
             }
 
             (Command::List { number }, _) => {
-                let addr = session.offset_list(computer, number);
-                for i in 0..number {
-                    let addr = addr + i;
+                let range = session.offset_list(computer, number);
+                if range.is_empty() {
+                    warn!(address = range.start, "Nothing to list");
+                }
+                for addr in range {
                     session.display_instruction(computer, addr);
                 }
             }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -151,7 +151,9 @@ fn main() {
     // And run the command
     let res = opt.command.exec();
     if let Err(e) = res {
-        error!("{}", e);
+        // `{:#}` prints the whole anyhow chain on one line: the outermost
+        // context alone rarely says what went wrong.
+        error!("{e:#}");
         exit(1);
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -16,22 +16,24 @@ mod interactive;
 use crate::commands::Subcommand;
 
 #[derive(Parser)]
-#[clap(version, author, about, group = ArgGroup::new("format"))]
+#[clap(version, author, about, group = ArgGroup::new("colors"))]
 struct Opt {
     /// Increase the level of verbosity. Can be used multiple times.
     #[clap(short, long, action = ArgAction::Count, global(true))]
     verbose: u8,
 
-    /// Force colored output. Default is to check if the output is a tty
-    #[clap(short = 'c', long, action = ArgAction::SetTrue, global(true), group = "format")]
+    /// Force colored output of the logs. Default is to check if the output is
+    /// a tty
+    #[clap(short = 'c', long, action = ArgAction::SetTrue, global(true), group = "colors")]
     color: bool,
 
-    /// Force non-colored output. Default is to check if the output is a tty
-    #[clap(short = 'C', long, action = ArgAction::SetTrue, global(true), group = "format")]
+    /// Force non-colored output of the logs. Default is to check if the output
+    /// is a tty
+    #[clap(short = 'C', long, action = ArgAction::SetTrue, global(true), group = "colors")]
     no_color: bool,
 
     /// Use JSON output for log messages
-    #[clap(short, long, action = ArgAction::SetTrue, global(true), group = "format")]
+    #[clap(short, long, action = ArgAction::SetTrue, global(true))]
     json: bool,
 
     /// Append the logs to this file instead of printing them

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -53,13 +53,17 @@ impl Opt {
         }
     }
 
-    /// `--color` and `--no-color` win. Without them, colors are on when the
-    /// target stream is a terminal, and off for a file.
+    /// `--color` and `--no-color` win, then a non-empty `NO_COLOR` turns
+    /// colors off. Otherwise colors are on when the target stream is a
+    /// terminal, and off for a file.
     fn should_use_colors(&self, target: &LogTarget) -> bool {
         if self.color {
             return true;
         }
         if self.no_color {
+            return false;
+        }
+        if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
             return false;
         }
         match target {

--- a/crates/cli/tests/interactive.rs
+++ b/crates/cli/tests/interactive.rs
@@ -142,3 +142,24 @@ fn continue_writes_program_output_before_the_stop_message() {
         .expect("the run stopped at the breakpoint");
     assert!(echoed < stopped, "{stdout}");
 }
+
+#[test]
+fn a_failed_set_is_not_announced() {
+    let output = run_interactive("fact.s", "set 99999 1\nexit\n");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("Set memory"), "{stdout}");
+    assert!(stdout.contains("invalid address 99999"), "{stdout}");
+}
+
+#[test]
+fn set_moves_where_list_starts() {
+    // The first list leaves the cursor past %pc; the second one must start
+    // from the new %pc, and " >" marks it as the current instruction.
+    let output = run_interactive("fact.s", "list 2\nset %pc 2000\nlist 2\nexit\n");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(">  2000"), "{stdout}");
+}

--- a/crates/cli/tests/interactive.rs
+++ b/crates/cli/tests/interactive.rs
@@ -1,0 +1,55 @@
+//! End-to-end tests for the interactive mode of `z33-cli run -i`.
+//!
+//! rustyline falls back to plain reads when stdin is not a terminal, so the
+//! debugger can be scripted by piping commands into it.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+
+fn sample(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../samples")
+        .join(name)
+}
+
+/// Run `z33-cli run -i <sample> main` with the given commands on stdin.
+fn run_interactive(sample_name: &str, commands: &str) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_z33-cli"))
+        .args(["run", "-i", sample(sample_name).to_str().unwrap(), "main"])
+        .env("RUST_LOG", "info")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn z33-cli");
+
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(commands.as_bytes())
+        .expect("write stdin");
+
+    child.wait_with_output().expect("wait for z33-cli")
+}
+
+#[test]
+fn list_with_a_huge_count_stays_within_memory() {
+    let output = run_interactive("fact.s", "list 4294967295\nexit\n");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(!stderr.contains("panicked"), "stderr: {stderr}");
+    // The listing stops at the last cell of the 10_000-cell memory.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("9999"), "{stdout}");
+}
+
+#[test]
+fn list_warns_once_the_cursor_is_at_the_end_of_memory() {
+    let output = run_interactive("fact.s", "list 4294967295\nlist\nexit\n");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Nothing to list"), "{stdout}");
+}

--- a/crates/cli/tests/interactive.rs
+++ b/crates/cli/tests/interactive.rs
@@ -53,3 +53,16 @@ fn list_warns_once_the_cursor_is_at_the_end_of_memory() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Nothing to list"), "{stdout}");
 }
+
+#[test]
+fn quit_and_q_leave_the_debugger() {
+    for command in ["quit\n", "q\n"] {
+        let output = run_interactive("fact.s", command);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(output.status.success(), "{command:?}: stderr: {stderr}");
+        // Interactive log lines go to stdout, clap's parse errors included.
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(!stdout.contains("WARN"), "{command:?}: {stdout}");
+        assert!(stdout.contains("End of program"), "{command:?}: {stdout}");
+    }
+}

--- a/crates/cli/tests/interactive.rs
+++ b/crates/cli/tests/interactive.rs
@@ -66,3 +66,27 @@ fn quit_and_q_leave_the_debugger() {
         assert!(stdout.contains("End of program"), "{command:?}: {stdout}");
     }
 }
+
+#[test]
+fn negative_numbers_are_accepted_as_arguments() {
+    let output = run_interactive("fact.s", "set %a -1\nregisters a\nmemory 1000 -3\nexit\n");
+    assert!(output.status.success());
+    // Interactive log lines go to stdout, clap's parse errors included.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("%a = -1"), "{stdout}");
+    assert!(!stdout.contains("unexpected argument"), "{stdout}");
+    assert!(!stdout.contains("Invalid input"), "{stdout}");
+    for address in ["address=1000", "address=999", "address=998"] {
+        assert!(stdout.contains(address), "{stdout}");
+    }
+}
+
+#[test]
+fn a_negative_memory_count_stops_at_the_bottom_of_memory() {
+    let output = run_interactive("fact.s", "memory 0 -3\nexit\n");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(!stderr.contains("panicked"), "stderr: {stderr}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("address=0"), "{stdout}");
+}

--- a/crates/cli/tests/interactive.rs
+++ b/crates/cli/tests/interactive.rs
@@ -90,3 +90,40 @@ fn a_negative_memory_count_stops_at_the_bottom_of_memory() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("address=0"), "{stdout}");
 }
+
+#[test]
+fn a_faulting_program_makes_interactive_mode_exit_non_zero() {
+    let path = std::path::Path::new(env!("CARGO_TARGET_TMPDIR")).join("fault.s");
+    std::fs::write(&path, "main:\n    ld [99999], %a\n    reset\n").unwrap();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_z33-cli"))
+        .args(["run", "-i", path.to_str().unwrap(), "main"])
+        .env("RUST_LOG", "info")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn z33-cli");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"continue\nexit\n")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(!output.status.success(), "a fault must not exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Program faulted at address 1000"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("invalid address 99999"), "{stdout}");
+}
+
+#[test]
+fn a_reset_is_reported_as_a_normal_end() {
+    let output = run_interactive("fact.s", "continue\nexit\n");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Program ended (reset)"), "{stdout}");
+    assert!(!stdout.contains("Halted"), "{stdout}");
+}

--- a/crates/cli/tests/interactive.rs
+++ b/crates/cli/tests/interactive.rs
@@ -127,3 +127,18 @@ fn a_reset_is_reported_as_a_normal_end() {
     assert!(stdout.contains("Program ended (reset)"), "{stdout}");
     assert!(!stdout.contains("Halted"), "{stdout}");
 }
+
+#[test]
+fn continue_writes_program_output_before_the_stop_message() {
+    // 1007 is the `jmp poll` that follows the `out` in echo.s, so the run
+    // stops right after the first input byte was echoed.
+    let output = run_interactive("echo.s", "break 1007\ninput Z\ncontinue\nexit\n");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let echoed = stdout.find('Z').expect("the program echoed its input");
+    let stopped = stdout
+        .find("Stopped at a breakpoint")
+        .expect("the run stopped at the breakpoint");
+    assert!(echoed < stopped, "{stdout}");
+}

--- a/crates/cli/tests/run.rs
+++ b/crates/cli/tests/run.rs
@@ -53,3 +53,21 @@ fn a_fault_names_the_faulting_address_and_the_reason() {
     assert!(stdout.contains("address 1001"), "{stdout}");
     assert!(stdout.contains("invalid address 99999"), "{stdout}");
 }
+
+#[test]
+fn json_can_be_combined_with_the_colour_flags() {
+    for flag in ["--color", "--no-color"] {
+        let output = run_fact(&["--json", flag]);
+        assert!(
+            output.status.success(),
+            "{flag}: stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(!stdout.contains('\u{1b}'), "{flag}: {stdout}");
+        for line in stdout.lines().filter(|l| !l.trim().is_empty()) {
+            serde_json::from_str::<serde_json::Value>(line)
+                .unwrap_or_else(|e| panic!("{flag}: {line:?} is not JSON: {e}"));
+        }
+    }
+}

--- a/crates/cli/tests/run.rs
+++ b/crates/cli/tests/run.rs
@@ -37,3 +37,19 @@ fn log_flag_appends_to_file() {
     let logs = std::fs::read_to_string(path).unwrap();
     assert_eq!(logs.matches("End of program registers=%a = 120").count(), 2);
 }
+
+#[test]
+fn a_fault_names_the_faulting_address_and_the_reason() {
+    let path = std::path::Path::new(env!("CARGO_TARGET_TMPDIR")).join("run-fault.s");
+    std::fs::write(&path, "main:\n    nop\n    ld [99999], %a\n    reset\n").unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_z33-cli"))
+        .args(["run", path.to_str().unwrap(), "main"])
+        .env("RUST_LOG", "warn")
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run z33-cli");
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("address 1001"), "{stdout}");
+    assert!(stdout.contains("invalid address 99999"), "{stdout}");
+}

--- a/crates/cli/tests/serial.rs
+++ b/crates/cli/tests/serial.rs
@@ -2,9 +2,8 @@
 //!
 //! These drive the compiled binary directly (via the `CARGO_BIN_EXE_*` env var
 //! cargo provides to integration tests), pipe bytes to its stdin, and assert on
-//! what the guest echoes back to stdout. The interactive (`-i`) path uses
-//! rustyline and reads the terminal device directly, so it cannot be driven
-//! from a pipe and is not covered here.
+//! what the guest echoes back to stdout. The interactive (`-i`) path is
+//! covered by `interactive.rs`.
 
 use std::io::Write;
 use std::path::PathBuf;

--- a/crates/emulator/src/diagnostic.rs
+++ b/crates/emulator/src/diagnostic.rs
@@ -71,6 +71,12 @@ impl FileDatabase {
     }
 }
 
+/// Whether any of `diagnostics` is severe enough to stop the compilation.
+#[must_use]
+pub fn has_errors(diagnostics: &[Diagnostic<FileId>]) -> bool {
+    diagnostics.iter().any(|d| d.severity >= Severity::Error)
+}
+
 // ---------------------------------------------------------------------------
 // Conversion: ParseDiagnostic → codespan Diagnostic
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Eleven fixes to `z33-cli run` and its interactive mode, with integration tests in `crates/cli/tests`. Revised after a review round.

Non-interactive run:
- A runtime fault names the faulting address and keeps the exception text (`while executing the instruction at address 1001: extract word: memory error: invalid address 99999`); `main` prints the whole error chain.
- Warning-level diagnostics no longer stop the run; only errors do, through a `has_errors` helper on the emulator's diagnostics.
- `NO_COLOR` is honoured when neither `--color` nor `--no-color` is given.
- `--json` can be combined with `--color` and `--no-color`; the test checks the JSON stream carries no escapes and parses line by line.

Interactive mode:
- `list` stays inside memory bounds (a large count overflowed in debug builds and walked billions of addresses in release) and says so once the cursor reaches the end of memory.
- `quit` and `q` leave the session, for students coming from gdb.
- Negative numbers are accepted where they mean something: the `set` value and the `memory` count (`set %a -1`, `memory 1000 -3`, and `memory 0 -3` stops at address 0). Other arguments keep rejecting them.
- A normal `reset` is told apart from a fault, faults are reported with their address and reason, and `run -i` exits non-zero when the program faulted. `Halt` replaces the boolean plumbing.
- Serial output is drained while `continue` runs, and flushed before the stop message so program output and log lines stay in order. One flush helper and batch size are shared with `run`; a failed write ends the session instead of spinning.
- `set` validates the address or register before announcing the write and resets the `list` cursor, so `list` after `set %pc` or `continue` shows current code.
- The README lists `set`, `input`, `info labels`, `info cycles`, the `quit`/`q` aliases and `list [n]`, and describes prefix matching accurately (`i` is ambiguous).

Verified: `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets`, `cargo test --workspace` (507 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
