### PR TITLE
Neovim, Vim and Zed: filetype detection, code lenses, Zed config and release grammar pinning

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -367,7 +367,28 @@ jobs:
             call writefile(['FAIL: expected syntax z33, got: ' . get(b:, 'current_syntax', '<unset>')], '/tmp/z33-vim-smoke-result.txt')
             cquit 1
           endif
-          call writefile(['OK: filetype=' . &filetype . ' syntax=' . b:current_syntax], '/tmp/z33-vim-smoke-result.txt')
+          " The content heuristic has a second hand-written copy in
+          " ftdetect/z33.vim; run it over the same fixture corpus the Neovim
+          " smoke test uses, so the two cannot drift apart silently. No
+          " third-party .s/.S claimant is installed on the runner, so
+          " fixtures/z33 must come out as z33 and fixtures/asm as the
+          " builtin's asm.
+          let checked = {'z33': 0, 'asm': 0}
+          for want in ['z33', 'asm']
+            for fixture in glob('editors/vim/tests/fixtures/' . want . '/*', 0, 1)
+              execute 'edit' fnameescape(fixture)
+              if &filetype !=# want
+                call writefile(['FAIL: ' . fixture . ': filetype ' . &filetype . ', expected ' . want], '/tmp/z33-vim-smoke-result.txt')
+                cquit 1
+              endif
+              let checked[want] += 1
+            endfor
+          endfor
+          if checked.z33 + checked.asm < 10
+            call writefile(['FAIL: fixture corpus not found, checked ' . (checked.z33 + checked.asm) . ' files'], '/tmp/z33-vim-smoke-result.txt')
+            cquit 1
+          endif
+          call writefile(['OK: samples/fact.s got filetype and syntax z33; ' . checked.z33 . ' z33 and ' . checked.asm . ' asm fixtures matched'], '/tmp/z33-vim-smoke-result.txt')
           qall!
           VIMSCRIPT
           vim -es -N -u NONE -S /tmp/z33-vim-smoke.vim

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -346,8 +346,18 @@ jobs:
           neovim: false
           version: stable
 
+      - name: Setup Rust build cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+
+      # The code lens test drives a real language server and a real run.
+      - name: Build z33-cli
+        run: cargo build -p z33-cli
+
       - name: Neovim smoke test
         run: nvim --headless -u NONE -N -l editors/vim/tests/smoke.lua
+
+      - name: Neovim code lens test
+        run: PATH="$PWD/target/debug:$PATH" nvim --headless -u NONE -N -l editors/vim/tests/lens.lua
 
       - name: Vim smoke test
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,15 +4,17 @@ name: Release
 # required, signed commits, required status checks):
 #
 #  1. `cut` (manual): bumps every manifest via scripts/set-version.sh, pushes
-#     a `release/vX.Y.Z` branch with a GitHub-signed commit (created through
-#     the GraphQL API, so it satisfies the signature requirement), opens a
-#     pull request, and dispatches the CI workflows on the branch — PRs
+#     a `release/vX.Y.Z` branch with two GitHub-signed commits (created
+#     through the GraphQL API, so they satisfy the signature requirement) —
+#     the bumps, then the Zed grammar rev pinned to that bump commit — opens
+#     a pull request, and dispatches the CI workflows on the branch: PRs
 #     opened by GITHUB_TOKEN don't trigger `pull_request` events, so the
 #     required checks have to be started explicitly.
 #
-#  2. `tag` (automatic): when the release PR merges, tags the merge commit
-#     and dispatches the Compile workflow on the tag, which builds all the
-#     artifacts and publishes the GitHub release.
+#  2. `tag` (automatic): when the release PR merges, checks the pinned Zed
+#     grammar rev, tags the merge commit and dispatches the Compile workflow
+#     on the tag, which builds all the artifacts and publishes the GitHub
+#     release.
 
 on:
   # Always dispatch `cut` on main: the release branch is created from the ref
@@ -81,49 +83,64 @@ jobs:
               -f sha="$GITHUB_SHA" -F force=true
           fi
 
-      - name: Commit the bumps on the release branch
+      - name: Commit the bumps and the grammar rev on the release branch
         # createCommitOnBranch produces a commit signed by GitHub, which the
         # required-signatures rule on main accepts once the PR merges.
         # File contents go through temp files (--rawfile / --slurpfile), not
         # command-line arguments: the base64 of the generated parser alone is
         # close to the kernel's 128 KiB per-argument limit.
+        #
+        # The grammar rev is pinned in a second commit; see
+        # scripts/set-grammar-rev.sh.
         run: |
-          ADDITIONS="$(mktemp)"
-          CONTENTS="$(mktemp)"
-          PAYLOAD="$(mktemp)"
-          echo '[]' >"$ADDITIONS"
-          for file in \
+          commit_on_branch() {
+            local expected_oid="$1" headline="$2"
+            shift 2
+            local additions contents payload file
+            additions="$(mktemp)"
+            contents="$(mktemp)"
+            payload="$(mktemp)"
+            echo '[]' >"$additions"
+            for file in "$@"; do
+              base64 -w0 "$file" >"$contents"
+              jq \
+                --arg path "$file" \
+                --rawfile contents "$contents" \
+                '. + [{path: $path, contents: $contents}]' \
+                "$additions" >"$additions.next"
+              mv "$additions.next" "$additions"
+            done
+            jq -n \
+              --arg repo "$GITHUB_REPOSITORY" \
+              --arg branch "release/v$VERSION" \
+              --arg headline "$headline" \
+              --arg oid "$expected_oid" \
+              --slurpfile additions "$additions" \
+              '{
+                query: "mutation ($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+                variables: {input: {
+                  branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+                  message: {headline: $headline},
+                  expectedHeadOid: $oid,
+                  fileChanges: {additions: $additions[0]}
+                }}
+              }' >"$payload"
+            gh api graphql --input "$payload" \
+              --jq .data.createCommitOnBranch.commit.oid
+          }
+
+          BUMP_OID="$(commit_on_branch "$GITHUB_SHA" "Release v$VERSION" \
             Cargo.toml \
             Cargo.lock \
             editors/vscode/package.json \
             editors/zed/extension.toml \
             tree-sitter-z33/package.json \
             tree-sitter-z33/tree-sitter.json \
-            tree-sitter-z33/src/parser.c; do
-            base64 -w0 "$file" >"$CONTENTS"
-            jq \
-              --arg path "$file" \
-              --rawfile contents "$CONTENTS" \
-              '. + [{path: $path, contents: $contents}]' \
-              "$ADDITIONS" >"$ADDITIONS.next"
-            mv "$ADDITIONS.next" "$ADDITIONS"
-          done
-          jq -n \
-            --arg repo "$GITHUB_REPOSITORY" \
-            --arg branch "release/v$VERSION" \
-            --arg headline "Release v$VERSION" \
-            --arg oid "$GITHUB_SHA" \
-            --slurpfile additions "$ADDITIONS" \
-            '{
-              query: "mutation ($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
-              variables: {input: {
-                branch: {repositoryNameWithOwner: $repo, branchName: $branch},
-                message: {headline: $headline},
-                expectedHeadOid: $oid,
-                fileChanges: {additions: $additions[0]}
-              }}
-            }' >"$PAYLOAD"
-          gh api graphql --input "$PAYLOAD"
+            tree-sitter-z33/src/parser.c)"
+
+          scripts/set-grammar-rev.sh "$BUMP_OID"
+          commit_on_branch "$BUMP_OID" "Pin the Zed grammar to the release commit" \
+            editors/zed/extension.toml
 
       - name: Open the release pull request
         run: |
@@ -160,6 +177,40 @@ jobs:
       MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
 
     steps:
+      - name: Check the pinned Zed grammar rev
+        # The published Zed extension compiles the grammar from that commit, so
+        # a merged release must not pin a rev whose tree-sitter-z33/ differs
+        # from the one it ships.
+        run: |
+          set -o pipefail
+          grammar_tree() {
+            gh api "repos/$GH_REPO/git/trees/$1" \
+              --jq '.tree[] | select(.path == "tree-sitter-z33") | .sha'
+          }
+          REV="$(gh api "repos/$GH_REPO/contents/editors/zed/extension.toml?ref=$MERGE_SHA" \
+            -H "Accept: application/vnd.github.raw" |
+            sed -n 's/^rev = "\(.*\)"$/\1/p')"
+          if [ -z "$REV" ]; then
+            echo "::error::no grammar rev found in editors/zed/extension.toml"
+            exit 1
+          fi
+          # A command substitution inside `[ ... ]` does not abort under
+          # `set -e`, so each tree is read and checked before the comparison.
+          PINNED_TREE="$(grammar_tree "$REV" || true)"
+          MERGED_TREE="$(grammar_tree "$MERGE_SHA" || true)"
+          if [ -z "$PINNED_TREE" ]; then
+            echo "::error::could not read tree-sitter-z33/ at the pinned grammar rev $REV"
+            exit 1
+          fi
+          if [ -z "$MERGED_TREE" ]; then
+            echo "::error::could not read tree-sitter-z33/ at the merge commit $MERGE_SHA"
+            exit 1
+          fi
+          if [ "$PINNED_TREE" != "$MERGED_TREE" ]; then
+            echo "::error::the pinned Zed grammar rev $REV does not carry the grammar being released ($MERGE_SHA); the release pull request is already merged, so recover by cutting a new release"
+            exit 1
+          fi
+
       - name: Create the tag
         # Tolerates a tag left behind by a previously failed run (as long as
         # it points at the same commit), so the job can simply be re-run.

--- a/editors/vim/README.md
+++ b/editors/vim/README.md
@@ -222,10 +222,11 @@ Standard nvim-dap keymaps work as usual.
 ## Health check (Neovim)
 
 Run **`:checkhealth z33`** to verify your setup: Neovim version, whether
-`z33-cli` is on `PATH`/cached, platform download support, nvim-treesitter (+ the
-`z33` parser) and nvim-dap availability, and which highlighting mode
-(tree-sitter vs. regex fallback) is in effect. If highlighting looks basic when
-you wanted tree-sitter, run `:TSInstall z33`.
+`z33-cli` is on `PATH`/cached and what it prints when actually run
+(`z33-cli --version`), platform download support, nvim-treesitter (+ the `z33`
+parser) and nvim-dap availability, and which highlighting mode (tree-sitter vs.
+regex fallback) is in effect. If highlighting looks basic when you wanted
+tree-sitter, run `:TSInstall z33`.
 
 ## Troubleshooting
 

--- a/editors/vim/README.md
+++ b/editors/vim/README.md
@@ -122,6 +122,7 @@ the same variables.
 | `z33_no_indent` | Disable the indent script (Vim / regex path). |
 | `z33_no_lsp` | Disable the vim-lsp registration (classic Vim only). |
 | `z33_no_treesitter_start` | Neovim: don't auto-start tree-sitter highlighting (stay on the regex fallback). |
+| `z33_no_codelens` | Neovim: don't show the LSP code lenses (label address / reference count, and the run lens). |
 | `z33_auto_download` | Neovim: `z33-cli` download consent — unset = prompt once, `true` = download silently, `false` = never download (PATH/cache only). |
 
 ### lazy.nvim `opts`
@@ -153,10 +154,11 @@ The server (`z33-cli lsp`) provides diagnostics, completion, hover,
 go-to-definition, references, rename, document symbols and code lens.
 
 - **Neovim 0.11+** — enabled automatically for `z33` buffers via the native
-  `vim.lsp.enable` mechanism (config in `lsp/z33.lua`). Nothing to wire. The
-  server offers an informational `▶ Run <label>` code lens; this plugin does not
-  advertise the `experimental.commands` capability, so use nvim-dap (below) to
-  actually run/debug.
+  `vim.lsp.enable` mechanism (config in `lsp/z33.lua`). Nothing to wire. Code
+  lenses show each label's address and reference count, plus a `▶ Run <label>`
+  lens on executable labels: `:lua vim.lsp.codelens.run()` on that line starts a
+  debug session stopped on the label with nvim-dap (below), or runs the program
+  in a terminal split when nvim-dap is not installed.
 - **Classic Vim** — zero-config [vim-lsp](https://github.com/prabirshrestha/vim-lsp)
   registration, active only when both vim-lsp and the `z33-cli` binary are
   present. Opt out with `g:z33_no_lsp = 1`.

--- a/editors/vim/README.md
+++ b/editors/vim/README.md
@@ -241,10 +241,25 @@ silently no-ops once a filetype has been set during detection, so depending on
 load order they can win over this plugin.
 
 To reclaim only genuine Z33 files without stealing real GNU-asm ones, the plugin
-scans each `.s`/`.S` buffer for Z33-specific markers (registers, the `.addr`
-directive, the preprocessor) that effectively never appear in GNU asm, acting
-only when no confident filetype is already set — so a GNU-asm `.s` keeps its
-filetype (the exact signal list and its rationale live in one place, the header
-comment of `ftdetect/z33.vim`). If you'd rather stop polyglot from claiming
-`.s`/`.S` at the source, set `let g:polyglot_disabled = ['r-lang']` before it
-loads.
+scans the first 64 lines of each `.s`/`.S` buffer, acting only when no confident
+filetype is already set — so a GNU-asm `.s` keeps its filetype. It claims the
+buffer on a Z33 marker: the `%pc`/`%sr`/`%a`/`%b` registers, `.addr`, a mnemonic
+that is rare in GNU asm such as `reset`/`rti`/`fas`, or a preprocessor directive
+spelled the way Z33's parser wants it — `#` in column 0, lower case — among
+`#undefine`, `#include "…"` and the keywords Z33 shares with C.
+
+A foreign marker anywhere in that window vetoes detection outright:
+
+- GNU cpp spellings Z33 has no equivalent for: `#ifdef`, `#ifndef`, `#undef`,
+  `#pragma`, `#include <…>`.
+- GNU `as` directives: `.globl`, `.global`, `.section`, `.type`, `.size`,
+  `.text`, `.data`, `.macro`, `.endm`.
+- Plan 9 / Go assembly: `TEXT`, `DATA`, `GLOBL`, `FUNCDATA` or `PCDATA` opening
+  a line, or `(SB)` anywhere.
+
+So preprocessed GNU `.S` files, m68k sources (which spell `reset`/`rti`/`swap`
+the way Z33 does) and Go's assembly are all left alone. The exact lists are in
+the two heuristic copies (`ftdetect/z33.vim` for Vim, `lua/z33/ftdetect.lua` for
+Neovim); CI runs both over the same corpus, `tests/fixtures/`. If you'd rather
+stop polyglot from claiming `.s`/`.S` at the source, set
+`let g:polyglot_disabled = ['r-lang']` before it loads.

--- a/editors/vim/ftdetect/z33.vim
+++ b/editors/vim/ftdetect/z33.vim
@@ -25,19 +25,53 @@ if get(g:, 'z33_no_ftdetect', 0)
   finish
 endif
 
-" We use `setlocal filetype=z33` rather than `:setf z33` on purpose: our
-" autocommand runs *after* the builtin `.s`/`.S` detection has already set
-" `asm`, and `:setf` is defined to do nothing once a filetype has been set in
-" the current autocommand sequence — it could never override `asm`. A plain
-" `setlocal filetype=` forces it. (A trailing `// vim: ft=…` modeline still
-" wins, since modelines are applied after ftdetect.)
+" Content heuristic, kept in lockstep with the Lua copy in
+" lua/z33/ftdetect.lua (same window, same signal lists). Two of the four
+" patterns are matched case-sensitively (=~#) below.
+"
+" Anti-signals: GNU spellings Z33 does not have. Z33 has `#if` and `#undefine`
+" but no `#ifdef`/`#ifndef`/`#undef`/`#pragma`, its `#include` takes a quoted
+" string only, and its four directives are `.addr`/`.space`/`.string`/`.word`.
+let s:anti =
+      \   '^\s*#\s*\%(ifdef\|ifndef\|undef\|pragma\)\>'
+      \ . '\|^\s*#\s*include\s*<'
+      \ . '\|^\s*\.\%(globl\|global\|section\|type\|size\|text\|data\|macro\|endm\)\>'
+
+" Plan 9 / Go assembly, which spells these in upper case. Go's `.s` files are
+" otherwise mistaken for Z33: `#include "textflag.h"` is a positive below and
+" JEQ/JLT/JGT are Plan 9 mnemonics too. `(SB)` is the dialect's static-base
+" pseudo-register, on every symbol reference.
+let s:plan9 = '^\%(TEXT\|DATA\|GLOBL\|FUNCDATA\|PCDATA\)\%([ \t]\|·\)\|(SB)'
+
+" Positives, part one: the preprocessor. `#` in column 0 and a lower-case
+" keyword is the only spelling parser/preprocessor.rs accepts. These keywords
+" are shared with C, hence only trusted because an anti-signal anywhere in the
+" window vetoes the file.
+let s:preproc =
+      \   '^#\s*\%(undefine\|define\|if\|elif\|endif\|error\)\>'
+      \ . '\|^#\s*include\s*"'
+
+" Positives, part two: directives, registers and mnemonics, all
+" case-insensitive to the parser. The %pc/%sr/%a/%b registers (GNU asm uses
+" %eax, %rdi, … never %pc; %sp is excluded, it is a real x86 AT&T register,
+" and the word boundary keeps %a off m68k's %a0-%a7), the .addr directive, and
+" mnemonics rare in GNU asm — push/pop/call/jmp/add/… are excluded, and of the
+" conditional jumps only the jeq/jlt/jgt spellings (x86 has jle/jge/jne).
+" m68k does spell reset/rti/swap/trap this way, but a real m68k file also
+" carries a .text/.globl/.section veto.
+let s:positive =
+      \   '^\s*\.addr\>'
+      \ . '\|%\%(pc\|sr\|a\|b\)\>'
+      \ . '\|^\s*\%(\w\+\s*:\s*\)\=\%(fas\|rti\|rtn\|swap\|reset\|trap\|jeq\|jlt\|jgt\)\>'
+
+" `setlocal filetype=z33` rather than `:setf z33`: this autocommand runs after
+" the builtin `.s`/`.S` detection has set `asm`, and `:setf` does nothing once
+" a filetype has been set in the current autocommand sequence. (A trailing
+" `// vim: ft=…` modeline still wins — modelines are applied after ftdetect.)
 func! s:DetectZ33() abort
   " Never clobber a filetype another (more confident) detector already set;
   " only act on a fresh buffer, one the builtin fell back to `asm`, or one
-  " vim-polyglot's r-lang detector claimed as `r` (see header comment above
-  " — that's the S-PLUS `.s` collision, not a hypothetical). The content
-  " heuristic below only fires on unmistakably-Z33 markers, so it's safe to
-  " override an `r` guess the same way we override `asm`.
+  " vim-polyglot's r-lang detector claimed as `r` (see header comment).
   if &filetype !=# '' && &filetype !=# 'asm' && &filetype !=# 'r'
     return
   endif
@@ -48,27 +82,19 @@ func! s:DetectZ33() abort
     return
   endif
 
-  " Content heuristic. Scan the head of the buffer for signals that are
-  " specific to Z33 and effectively never appear in GNU/other asm:
-  "   - the %pc/%sr/%a/%b registers (GNU asm uses %eax, %rdi, … never %pc;
-  "     %sp was dropped — it's a real x86 AT&T register, so it caused false
-  "     positives on GNU asm. Bare %a/%b are safe: GNU asm has no such
-  "     registers, and the `\>` word-boundary keeps them from matching inside
-  "     %ax/%bp/etc.);
-  "   - the Z33 .addr directive (.word/.space/.string were dropped — they're
-  "     standard GNU `as` directives too, not Z33-specific);
-  "   - the Z33 preprocessor (#include/#define/#undefine/#if/#elif/#endif/#error
-  "     — note `#undefine`, not the C-style `#undef`, and `#` may be spaced).
-  " A bare `//` comment is deliberately NOT a signal (GNU asm allows it too).
-  let l:lines = getline(1, 64)
-  for l:line in l:lines
-    if l:line =~? '^\s*#\s*\%(include\|define\|undefine\|if\|elif\|endif\|error\)\>'
-          \ || l:line =~? '^\s*\.addr\>'
-          \ || l:line =~? '%\%(pc\|sr\|a\|b\)\>'
-      setlocal filetype=z33
+  let l:found = 0
+  for l:line in getline(1, 64)
+    if l:line =~? s:anti || l:line =~# s:plan9
       return
     endif
+    if l:line =~# s:preproc || l:line =~? s:positive
+      let l:found = 1
+    endif
   endfor
+
+  if l:found
+    setlocal filetype=z33
+  endif
 endfunc
 
 augroup z33_ftdetect

--- a/editors/vim/indent/z33.vim
+++ b/editors/vim/indent/z33.vim
@@ -33,5 +33,9 @@ func! Z33Indent() abort
   if getline(v:lnum) =~# '^\s*\h\w*\s*:'
     return 0
   endif
+  " The body of a label is indented one level below it.
+  if getline(l:prev) =~# '^\s*\h\w*\s*:\s*\(//.*\)\=$'
+    return shiftwidth()
+  endif
   return indent(l:prev)
 endfunc

--- a/editors/vim/lsp/z33.lua
+++ b/editors/vim/lsp/z33.lua
@@ -22,6 +22,10 @@ return {
     return vim.lsp.rpc.start({ path, "lsp" }, dispatchers)
   end,
   filetypes = { "z33" },
+  capabilities = require("z33.lens").capabilities(),
+  on_attach = function(_client, bufnr)
+    require("z33.lens").attach(bufnr)
+  end,
   -- Prefer a `.git` root; with no marker, nvim core attaches to the buffer's
   -- own directory (single-file mode), so a lone scratch file still works.
   root_markers = { ".git" },

--- a/editors/vim/lua/z33/dap.lua
+++ b/editors/vim/lua/z33/dap.lua
@@ -37,7 +37,9 @@ function M.setup()
       name = "Launch Z33 program",
       program = "${file}",
       entrypoint = function()
-        return vim.fn.input("Entrypoint: ", "main")
+        local answer = vim.fn.input("Entrypoint: ", "main")
+        -- An omitted entrypoint lets the adapter pick main/start/run/entry.
+        return answer ~= "" and answer or nil
       end,
       stopOnEntry = true,
     },

--- a/editors/vim/lua/z33/download.lua
+++ b/editors/vim/lua/z33/download.lua
@@ -15,6 +15,17 @@ local M = {}
 
 local REPO = "sandhose/z33-emulator"
 
+--- Wraps `vim.system`, which throws when the command is missing from PATH, so
+--- that failure reaches `on_exit` as exit code 127 like any other.
+local function spawn(cmd, opts, on_exit)
+  local ok, err = pcall(vim.system, cmd, opts, on_exit)
+  if not ok then
+    vim.schedule(function()
+      on_exit({ code = 127, stderr = tostring(err) })
+    end)
+  end
+end
+
 --- Base cache directory: `stdpath('data')/z33/`.
 local function base_dir()
   return vim.fs.joinpath(vim.fn.stdpath("data"), "z33")
@@ -157,7 +168,7 @@ local function run_download(url, version_dir, platform, done)
 
   -- Bare .exe: download straight to the final binary path.
   if platform.archive == "exe" then
-    vim.system(
+    spawn(
       { "curl", "-fSL", "-o", binary_path, url },
       { text = true },
       vim.schedule_wrap(function(out)
@@ -175,14 +186,14 @@ local function run_download(url, version_dir, platform, done)
 
   -- tar.gz: download to a temp file, then extract into version_dir.
   local tmp = vim.fs.joinpath(version_dir, platform.asset)
-  vim.system(
+  spawn(
     { "curl", "-fSL", "-o", tmp, url },
     { text = true },
     vim.schedule_wrap(function(out)
       if out.code ~= 0 then
         return fail("curl failed: " .. (out.stderr or ("exit " .. out.code)))
       end
-      vim.system(
+      spawn(
         { "tar", "-xzf", tmp, "-C", version_dir },
         { text = true },
         vim.schedule_wrap(function(tout)
@@ -198,7 +209,7 @@ local function run_download(url, version_dir, platform, done)
           pcall(vim.uv.fs_chmod, binary_path, 493) -- 0755
           -- macOS: strip the quarantine xattr, best effort.
           if vim.uv.os_uname().sysname == "Darwin" then
-            vim.system({ "xattr", "-d", "com.apple.quarantine", binary_path }, { text = true }, function() end)
+            spawn({ "xattr", "-d", "com.apple.quarantine", binary_path }, { text = true }, function() end)
           end
           done(binary_path)
         end)
@@ -226,7 +237,7 @@ end
 --- API is unreachable but a platform is known. Calls `done(path, err)`.
 local function fetch_and_install(platform, done)
   local api = ("https://api.github.com/repos/%s/releases/latest"):format(REPO)
-  vim.system(
+  spawn(
     { "curl", "-fSL", "-H", "Accept: application/vnd.github+json", api },
     { text = true },
     vim.schedule_wrap(function(out)

--- a/editors/vim/lua/z33/ftdetect.lua
+++ b/editors/vim/lua/z33/ftdetect.lua
@@ -1,6 +1,8 @@
--- Shared `.s` / `.S` filetype heuristic for the Z33 vs GNU-asm collision.
+-- The `.s` / `.S` filetype heuristic for the Z33 vs GNU-asm collision.
 --
--- This is the ONE copy of the content heuristic. It backs two mechanisms:
+-- The Neovim copy of the heuristic (classic Vim has its own in
+-- `ftdetect/z33.vim`; CI runs both over `tests/fixtures/`). It backs two
+-- mechanisms:
 --   1. `vim.filetype.add` (wired in `z33/init.lua`) — the idiomatic matcher,
 --      which also feeds `vim.filetype.match` consumers and works under
 --      `nvim --clean` where no third-party rule fights over `.s`/`.S`.
@@ -11,67 +13,139 @@
 --      shadow our matcher; a forced `setlocal`-equivalent wins regardless of
 --      ordering.
 --
--- Signals are deliberately narrowed to ones that effectively never appear in
--- GNU/other asm sharing the `.s`/`.S` extension, so a real GNU file is not
--- misdetected as Z33.
+-- A GNU or Plan 9 marker anywhere in the scanned window vetoes detection, so
+-- the positives below need only be things those assemblers do not routinely
+-- write.
 
 local M = {}
 
--- Preprocessor keywords whose presence strongly implies Z33 (note `#undefine`,
--- not the C-style `#undef`; `#` may be followed by spaces).
-local PREPROC = { "include", "define", "undefine", "if", "elif", "endif", "error" }
--- Z33-specific assembler directives. Only `.addr` — `.word`/`.space`/`.string`
--- are standard GNU `as` directives too, so they were dropped to avoid
--- misdetecting GNU sources (a bare `.word 5` file is not Z33).
-local DIRECTIVES = { "addr" }
--- Z33 registers — a strong discriminator: GNU asm uses `%eax`/`%rdi`/… and
--- never `%pc`/`%sr`. `%sp` is excluded because it is a real x86 AT&T register.
--- The greedy `%a+` capture below word-bounds these, so `%a`/`%b` cannot fire
--- inside `%ax`/`%bp`.
-local REGISTERS = { "a", "b", "pc", "sr" }
+-- Anti-signals. Indentation and case are tolerated on all of them: they
+-- describe foreign files, not what the Z33 parser accepts.
+--
+-- C-preprocessor directives GNU uses and Z33 does not: Z33 has `#if` and
+-- `#undefine`, no `#ifdef`/`#ifndef`/`#undef`/`#pragma`, and its `#include`
+-- takes a quoted string (parser/preprocessor.rs), never `<...>`.
+local ANTI_PREPROC = { ifdef = true, ifndef = true, undef = true, pragma = true }
+-- GNU `as` directives; Z33 only has `.addr`, `.space`, `.string` and `.word`.
+local ANTI_DIRECTIVES = {
+  globl = true,
+  global = true,
+  section = true,
+  type = true,
+  size = true,
+  text = true,
+  data = true,
+  macro = true,
+  endm = true,
+}
+-- Plan 9 / Go assembly openers, matched case-sensitively because that dialect
+-- spells them in upper case. Go's `.s` files are otherwise mistaken for Z33:
+-- `#include "textflag.h"` is a Z33 positive and `JEQ`/`JLT`/`JGT` are Plan 9
+-- mnemonics.
+local ANTI_PLAN9 = { TEXT = true, DATA = true, GLOBL = true, FUNCDATA = true, PCDATA = true }
 
---- Returns true when a single source line looks distinctively like Z33.
-function M.line_is_z33(line)
-  -- `#<spaces>keyword` preprocessor directive.
-  local kw = line:match("^%s*#%s*(%a+)")
+-- Preprocessor keywords Z33 shares with C, hence only trusted because any
+-- anti-signal vetoes the whole file. `#include` counts only with a quoted
+-- argument. Matched at column 0 and in lower case, the only spelling
+-- parser/preprocessor.rs accepts.
+local WEAK_PREPROC = { define = true, ["if"] = true, elif = true, endif = true, error = true }
+-- Z33-only spellings and directives.
+local STRONG_PREPROC = { undefine = true }
+local DIRECTIVES = { addr = true }
+-- Z33 registers: GNU asm uses `%eax`/`%rdi`/… and never `%pc`/`%sr`. `%sp` is
+-- excluded — it is a real x86 AT&T register. `%a0`…`%a7` (m68k) are not
+-- registers to the parser either, so the captures below take a whole
+-- identifier and look it up, rather than matching a prefix.
+local REGISTERS = { a = true, b = true, pc = true, sr = true }
+-- Z33 mnemonics rare enough in GNU asm to carry weight. m68k spells
+-- `reset`/`rti`/`swap`/`trap` the same way, but a real m68k file also carries
+-- a `.text`/`.globl`/`.section` veto.
+local MNEMONICS = {
+  fas = true,
+  rti = true,
+  rtn = true,
+  swap = true,
+  reset = true,
+  trap = true,
+  jeq = true,
+  jlt = true,
+  jgt = true,
+}
+
+--- Classifies one source line: "z33" for a Z33 signal, "gnu" for a marker that
+--- rules Z33 out, nil for neither. Every capture takes a whole `[0-9A-Za-z_]`
+--- word, so the Vimscript copy's `\>` word boundaries mean the same thing here.
+--- @param line string
+--- @return string|nil
+function M.line_signal(line)
+  -- Anti-signals first: one of them on a line outweighs anything else on it.
+  local anti_kw, anti_rest = line:match("^%s*#%s*([%w_]+)(.*)$")
+  if anti_kw then
+    anti_kw = anti_kw:lower()
+    if ANTI_PREPROC[anti_kw] then
+      return "gnu"
+    end
+    if anti_kw == "include" and anti_rest:match("^%s*<") then
+      return "gnu"
+    end
+  end
+  local anti_dir = line:match("^%s*%.([%w_]+)")
+  if anti_dir and ANTI_DIRECTIVES[anti_dir:lower()] then
+    return "gnu"
+  end
+  -- Plan 9: `TEXT ·name(SB)`, `GLOBL sym(SB)`, `PCDATA $0, $1`. `(SB)` is the
+  -- dialect's static-base pseudo-register and appears on every symbol
+  -- reference.
+  local plan9 = line:match("^(%u+)[ \t]") or line:match("^(%u+)·")
+  if (plan9 and ANTI_PLAN9[plan9]) or line:find("(SB)", 1, true) then
+    return "gnu"
+  end
+
+  -- Z33 preprocessor: `#` in column 0, lower-case keyword.
+  local kw, rest = line:match("^#%s*([%w_]+)(.*)$")
   if kw then
-    for _, k in ipairs(PREPROC) do
-      if kw == k then
-        return true
-      end
+    if kw == "include" then
+      return rest:match('^%s*"') and "z33" or nil
+    end
+    if STRONG_PREPROC[kw] or WEAK_PREPROC[kw] then
+      return "z33"
     end
   end
-  -- `.directive` at line start.
-  local dir = line:match("^%s*%.(%a+)")
-  if dir then
-    for _, d in ipairs(DIRECTIVES) do
-      if dir == d then
-        return true
-      end
+  -- `.directive` at line start. Directives, mnemonics and registers are all
+  -- case-insensitive to the parser.
+  local dir = line:match("^%s*%.([%w_]+)")
+  if dir and DIRECTIVES[dir:lower()] then
+    return "z33"
+  end
+  -- A mnemonic opening an instruction, with or without a leading `label:`.
+  local labelled = line:match("^%s*[%w_]+%s*:%s*([%w_]+)")
+  local bare = line:match("^%s*([%w_]+)")
+  if (labelled and MNEMONICS[labelled:lower()]) or (bare and MNEMONICS[bare:lower()]) then
+    return "z33"
+  end
+  -- A `%reg` register anywhere.
+  for reg in line:gmatch("%%([%w_]+)") do
+    if REGISTERS[reg:lower()] then
+      return "z33"
     end
   end
-  -- A `%reg` register anywhere (word-bounded so `%pc` matches but `%pcx`
-  -- does not). Matched case-insensitively.
-  for reg in line:gmatch("%%(%a+)") do
-    local lreg = reg:lower()
-    for _, r in ipairs(REGISTERS) do
-      if lreg == r then
-        return true
-      end
-    end
-  end
-  return false
+  return nil
 end
 
---- Scans the head of a buffer and returns true if it looks like Z33.
+--- Scans the head of a buffer and returns true if it looks like Z33. One
+--- anti-signal vetoes the whole buffer, whatever was found before it.
 function M.buf_is_z33(bufnr)
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, 64, false)
+  local found = false
   for _, line in ipairs(lines) do
-    if M.line_is_z33(line) then
-      return true
+    local signal = M.line_signal(line)
+    if signal == "gnu" then
+      return false
+    elseif signal == "z33" then
+      found = true
     end
   end
-  return false
+  return found
 end
 
 --- Decides the filetype for a `.s` / `.S` buffer. Returns "z33" or nil (fall

--- a/editors/vim/lua/z33/health.lua
+++ b/editors/vim/lua/z33/health.lua
@@ -14,17 +14,31 @@ function M.check()
     health.warn("Neovim < 0.11: native LSP unavailable; use the nvim-lspconfig fallback (see README)")
   end
 
-  -- z33-cli availability.
+  -- z33-cli availability, and whether the file actually runs (a download
+  -- for the wrong platform or a quarantined binary is found but fails here).
   local on_path = vim.fn.exepath("z33-cli")
   local download = require("z33.download")
+  local bin
   if on_path ~= "" then
+    bin = on_path
     health.ok("z33-cli found on PATH: " .. on_path)
   else
-    local cached = download.cached_binary()
-    if cached then
-      health.ok("z33-cli found in cache: " .. cached)
+    bin = download.cached_binary()
+    if bin then
+      health.ok("z33-cli found in cache: " .. bin)
     else
       health.warn("z33-cli not found on PATH or in cache; run :Z33Download or add it to PATH")
+    end
+  end
+  if bin then
+    local ok, result = pcall(function()
+      return vim.system({ bin, "--version" }, { text = true, timeout = 5000 }):wait()
+    end)
+    if ok and result.code == 0 then
+      health.ok("z33-cli runs: " .. vim.trim(result.stdout or ""))
+    else
+      local detail = ok and vim.trim((result.stderr or "") .. (result.stdout or "")) or tostring(result)
+      health.error("z33-cli does not run: " .. (detail ~= "" and detail or ("exit code " .. tostring(ok and result.code))))
     end
   end
 

--- a/editors/vim/lua/z33/init.lua
+++ b/editors/vim/lua/z33/init.lua
@@ -153,6 +153,7 @@ function M.setup(opts)
   --    now; otherwise arm a lazy fetch-then-enable so we never hand the LSP
   --    core a `cmd` that has no binary (which crashes it and poisons retries).
   if vim.lsp and vim.lsp.enable then
+    vim.lsp.commands[require("z33.lens").RUN_COMMAND] = require("z33.lens").run
     if M.cli_path() then
       enable_lsp()
     else

--- a/editors/vim/lua/z33/init.lua
+++ b/editors/vim/lua/z33/init.lua
@@ -32,8 +32,21 @@ end
 -- passed `(path, bufnr)`.
 local function register_ftdetect()
   local ftdetect = require("z33.ftdetect")
-  local function matcher(_, bufnr)
-    return ftdetect.detect(bufnr)
+  -- Registering an extension callback replaces Neovim's builtin entry for
+  -- it, so a non-Z33 file must be handed back to the builtin asm detection.
+  local function matcher(path, bufnr)
+    local ft = ftdetect.detect(bufnr)
+    if ft then
+      return ft
+    end
+    -- `vim.filetype.detect` is not a documented API, and its `asm` returns a
+    -- second value (an `on_detect` callback setting `b:asmsyntax`) that `or`
+    -- would truncate away.
+    local ok, detect = pcall(require, "vim.filetype.detect")
+    if ok and detect.asm then
+      return detect.asm(path, bufnr)
+    end
+    return "asm"
   end
   vim.filetype.add({
     extension = {

--- a/editors/vim/lua/z33/lens.lua
+++ b/editors/vim/lua/z33/lens.lua
@@ -1,0 +1,102 @@
+-- Code lens support for the Z33 LSP.
+--
+-- The server puts an informational lens (address, reference count) on every
+-- label and, when the client advertises the `zorglub33.run` command, a
+-- "Run <label>" lens on executable labels. Neovim requests lenses only when
+-- asked, so `attach` schedules refreshes, and `run` executes the run lens.
+
+local M = {}
+
+M.RUN_COMMAND = "zorglub33.run"
+
+--- Client capabilities merged into the LSP client config: the server emits
+--- the run lens only for clients listing the command here.
+function M.capabilities()
+  return { experimental = { commands = { M.RUN_COMMAND } } }
+end
+
+--- Show the lenses of `bufnr` and keep them fresh. Neovim 0.12 tracks the
+--- refresh events itself; 0.11 only exposes a one-shot refresh.
+--- `vim.g.z33_no_codelens` opts out (documented in the README).
+function M.attach(bufnr)
+  if vim.g.z33_no_codelens then
+    return
+  end
+  local codelens = vim.lsp.codelens
+  if not codelens then
+    return
+  end
+  if codelens.enable then
+    codelens.enable(true, { bufnr = bufnr })
+    return
+  end
+  local name = "z33_codelens_" .. bufnr
+  local group = vim.api.nvim_create_augroup(name, { clear = true })
+  vim.api.nvim_create_autocmd({ "BufEnter", "CursorHold", "InsertLeave", "BufWritePost" }, {
+    group = group,
+    buffer = bufnr,
+    desc = "z33: refresh LSP code lenses",
+    callback = function()
+      codelens.refresh({ bufnr = bufnr })
+    end,
+  })
+  -- The group name embeds a buffer number, which Neovim reuses for later
+  -- buffers, so it has to go when this one does.
+  vim.api.nvim_create_autocmd("BufWipeout", {
+    group = group,
+    buffer = bufnr,
+    desc = "z33: drop the code lens refresh group with the buffer",
+    callback = function()
+      pcall(vim.api.nvim_del_augroup_by_name, name)
+    end,
+  })
+  codelens.refresh({ bufnr = bufnr })
+end
+
+local function program_path(args, ctx)
+  local name = vim.api.nvim_buf_get_name(ctx.bufnr)
+  if name ~= "" then
+    return name
+  end
+  -- The lens path is relative to the server's root; join it back.
+  local client = vim.lsp.get_client_by_id(ctx.client_id)
+  local root = client and client.root_dir or vim.fn.getcwd()
+  return vim.fs.joinpath(root, args.path)
+end
+
+--- Executes the run lens: with nvim-dap installed it starts a debug session
+--- stopped on the label's first instruction, otherwise it runs the program in
+--- a terminal split.
+function M.run(command, ctx)
+  local args = (command.arguments or {})[1] or {}
+  local label = args.label or "main"
+  local program = program_path(args, ctx)
+
+  local has_dap, dap = pcall(require, "dap")
+  if has_dap then
+    dap.run({
+      type = "z33",
+      request = "launch",
+      name = "Run " .. label,
+      program = program,
+      entrypoint = label,
+      stopOnEntry = true,
+    })
+    return
+  end
+
+  require("z33.download").ensure(function(bin)
+    if not bin then
+      return
+    end
+    vim.cmd.split()
+    vim.cmd.enew()
+    -- A list argument, not `:terminal`: that builds a command line, where
+    -- spaces in `program` split it into extra arguments and `%`/`#` expand to
+    -- file names. `jobstart`'s `term` needs 0.11, the floor for the native LSP
+    -- that carries this command.
+    vim.fn.jobstart({ bin, "run", program, label }, { term = true })
+  end)
+end
+
+return M

--- a/editors/vim/tests/fixtures/asm/cfile.S
+++ b/editors/vim/tests/fixtures/asm/cfile.S
@@ -1,0 +1,1 @@
+#include <stdio.h>

--- a/editors/vim/tests/fixtures/asm/cond.S
+++ b/editors/vim/tests/fixtures/asm/cond.S
@@ -1,0 +1,5 @@
+#ifdef CONFIG_64BIT
+	.quad 0
+#else
+	.long 0
+#endif

--- a/editors/vim/tests/fixtures/asm/cortex_m.S
+++ b/editors/vim/tests/fixtures/asm/cortex_m.S
@@ -1,0 +1,11 @@
+// ARM Cortex-M startup: `Reset_Handler` is not the `reset` mnemonic.
+	.syntax unified
+	.thumb
+	.section .isr_vector,"a",%progbits
+	.word _estack
+	.word Reset_Handler
+	.text
+	.thumb_func
+Reset_Handler:
+	bl main
+	b .

--- a/editors/vim/tests/fixtures/asm/gnu_globl.s
+++ b/editors/vim/tests/fixtures/asm/gnu_globl.s
@@ -1,0 +1,6 @@
+	.text
+	.globl main
+	.type main, @function
+main:
+	.word 1
+	ret

--- a/editors/vim/tests/fixtures/asm/go_plan9.s
+++ b/editors/vim/tests/fixtures/asm/go_plan9.s
@@ -1,0 +1,11 @@
+#include "textflag.h"
+
+// func add(a, b int64) int64
+TEXT ·add(SB),NOSPLIT,$0-24
+	MOVQ a+0(FP), AX
+	MOVQ b+8(FP), BX
+	ADDQ BX, AX
+	JEQ done
+done:
+	MOVQ AX, ret+16(FP)
+	RET

--- a/editors/vim/tests/fixtures/asm/kernel.S
+++ b/editors/vim/tests/fixtures/asm/kernel.S
@@ -1,0 +1,4 @@
+#include <asm/unistd.h>
+#define SYS_write 1
+	movq $SYS_write, %rax
+	syscall

--- a/editors/vim/tests/fixtures/asm/m68k.s
+++ b/editors/vim/tests/fixtures/asm/m68k.s
@@ -1,0 +1,6 @@
+	.text
+	.globl _start
+_start:
+	move.l %a0,%d0
+	swap %d0
+	reset

--- a/editors/vim/tests/fixtures/asm/undef.S
+++ b/editors/vim/tests/fixtures/asm/undef.S
@@ -1,0 +1,2 @@
+#define HAVE_CPUID 1
+#undef HAVE_CPUID

--- a/editors/vim/tests/fixtures/asm/x86_att.s
+++ b/editors/vim/tests/fixtures/asm/x86_att.s
@@ -1,0 +1,3 @@
+	movl %eax, %ebx
+	xorl %ecx, %ecx
+	ret

--- a/editors/vim/tests/fixtures/asm/x86_frame.s
+++ b/editors/vim/tests/fixtures/asm/x86_frame.s
@@ -1,0 +1,4 @@
+	pushq %rbp
+	movq %rsp, %rbp
+	popq %rbp
+	ret

--- a/editors/vim/tests/fixtures/z33/data_only.s
+++ b/editors/vim/tests/fixtures/z33/data_only.s
@@ -1,0 +1,5 @@
+// Data-only program: no register, no .addr, no preprocessor.
+main:
+    .word 1
+    .word 2
+    reset

--- a/editors/vim/tests/fixtures/z33/defines_only.s
+++ b/editors/vim/tests/fixtures/z33/defines_only.s
@@ -1,0 +1,6 @@
+// Z33 header meant to be #include'd: only shared-with-C preprocessor keywords.
+#define WIDTH 4
+#define HEIGHT 8
+#if WIDTH > 2
+#  define WIDE 1
+#endif

--- a/editors/vim/tests/fixtures/z33/inline_label.s
+++ b/editors/vim/tests/fixtures/z33/inline_label.s
@@ -1,0 +1,2 @@
+// Label and instruction on one line.
+main: rtn

--- a/editors/vim/tests/fixtures/z33/no_registers.s
+++ b/editors/vim/tests/fixtures/z33/no_registers.s
@@ -1,0 +1,5 @@
+// Stack-only program: `reset` is the single Z33-specific token.
+main:
+    push 1
+    pop
+    reset

--- a/editors/vim/tests/fixtures/z33/quoted_include.S
+++ b/editors/vim/tests/fixtures/z33/quoted_include.S
@@ -1,0 +1,5 @@
+// Z33 #include only takes a quoted string.
+#include "defines_only.s"
+#undefine WIDE
+main:
+    reset

--- a/editors/vim/tests/lens.lua
+++ b/editors/vim/tests/lens.lua
@@ -1,0 +1,96 @@
+-- Code lens check for the Neovim plugin. Needs `z33-cli` on PATH.
+--
+-- Run from the repository root with:
+--   nvim --headless -u NONE -N -l editors/vim/tests/lens.lua
+
+vim.opt.rtp:prepend(vim.fn.getcwd() .. "/editors/vim")
+
+local z33 = require("z33")
+z33.setup()
+assert(z33.cli_path(), "z33-cli must be on PATH for this test")
+
+vim.cmd.edit("samples/fact.s")
+local bufnr = vim.api.nvim_get_current_buf()
+
+-- 0.12 returns `{ client_id, lens }` pairs; 0.11 returns the lenses directly.
+local function lenses()
+  if vim.fn.has("nvim-0.12") == 0 then
+    return vim.lsp.codelens.get(bufnr)
+  end
+  return vim.tbl_map(function(entry)
+    return entry.lens
+  end, vim.lsp.codelens.get({ bufnr = bufnr }))
+end
+
+local attached = vim.wait(10000, function()
+  return #vim.lsp.get_clients({ bufnr = bufnr, name = "z33" }) > 0
+end, 50)
+assert(attached, "the z33 LSP client did not attach")
+
+local ok = vim.wait(10000, function()
+  return #lenses() > 0
+end, 100)
+assert(ok, "no code lenses were received for samples/fact.s")
+
+local titles = {}
+local run_lenses = 0
+for _, lens in ipairs(lenses()) do
+  titles[#titles + 1] = lens.command.title
+  if lens.command.command == require("z33.lens").RUN_COMMAND then
+    run_lenses = run_lenses + 1
+  end
+end
+assert(run_lenses > 0, "no run lens; the client capability was not advertised: " .. vim.inspect(titles))
+
+local run
+for _, lens in ipairs(lenses()) do
+  if lens.command.command == require("z33.lens").RUN_COMMAND and lens.command.arguments[1].label == "main" then
+    run = lens
+  end
+end
+assert(run, "no run lens for main")
+local client = vim.lsp.get_clients({ bufnr = bufnr, name = "z33" })[1]
+local ctx = { bufnr = bufnr, client_id = client.id }
+
+-- With nvim-dap present (stubbed here) the lens starts a debug session on the
+-- label, stopped on entry.
+local launched
+package.loaded["dap"] = {
+  run = function(config)
+    launched = config
+  end,
+}
+vim.lsp.commands[run.command.command](run.command, ctx)
+assert(launched, "the run lens did not start a debug session")
+assert(launched.type == "z33" and launched.entrypoint == "main" and launched.stopOnEntry == true, vim.inspect(launched))
+assert(launched.program == vim.api.nvim_buf_get_name(bufnr), "program should be the buffer path: " .. launched.program)
+
+-- Without nvim-dap the lens runs the program in a terminal split. The copy
+-- sits under a directory with a space in its name: the path has to reach the
+-- process as one argument, so a run that finishes proves it was not split.
+package.loaded["dap"] = nil
+package.preload["dap"] = function()
+  error("nvim-dap is not installed")
+end
+
+local dir = vim.fn.tempname() .. "/my dir"
+assert(vim.fn.mkdir(dir, "p") == 1, "could not create " .. dir)
+local spaced = dir .. "/fact.s"
+assert(vim.uv.fs_copyfile("samples/fact.s", spaced), "could not copy samples/fact.s")
+local spaced_buf = vim.fn.bufadd(spaced)
+vim.fn.bufload(spaced_buf)
+vim.lsp.commands[run.command.command](run.command, { bufnr = spaced_buf, client_id = client.id })
+
+local output = ""
+local finished = vim.wait(10000, function()
+  if vim.bo.buftype ~= "terminal" then
+    return false
+  end
+  output = table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n")
+  -- The CLI's end-of-run line differs between the info log ("End of program")
+  -- and the quiet summary ("Program ended"); either means the run succeeded.
+  return output:find("End of program", 1, true) ~= nil or output:find("Program ended", 1, true) ~= nil
+end, 100)
+assert(finished, "the terminal run did not finish; buftype " .. vim.bo.buftype .. ", output:\n" .. output)
+
+print("lens.lua: ok (" .. #titles .. " lenses, " .. run_lenses .. " run lenses)")

--- a/editors/vim/tests/smoke.lua
+++ b/editors/vim/tests/smoke.lua
@@ -2,9 +2,11 @@
 -- (.github/workflows/check.yaml, job `editors-vim-nvim`). Not a real test suite
 -- (no plugin-manager/CI Lua-test framework is set up for this small plugin) —
 -- just enough to catch "plugin doesn't even load" regressions: `setup()` must
--- be idempotent and must not error, the `.s`/`.S` filetype heuristic must
--- actually detect a real Z33 sample, and — with no tree-sitter parser present
--- (the CI case) — a z33 buffer must fall back to the bundled Vimscript syntax
+-- be idempotent and must not error, the `.s`/`.S` content heuristic must agree
+-- with the fixture corpus in `tests/fixtures/` (`z33/` claimed, `asm/` left to
+-- the builtin asm detection — the classic-Vim copy of the heuristic is run
+-- over the same corpus in CI), and — with no tree-sitter parser present (the
+-- CI case) — a z33 buffer must fall back to the bundled Vimscript syntax
 -- (syntax/z33.vim, shared with classic Vim).
 --
 -- Run from the repository root with:
@@ -24,23 +26,91 @@ local z33 = require("z33")
 z33.setup()
 z33.setup()
 
-local bufnr = vim.fn.bufadd("samples/fact.s")
-vim.fn.bufload(bufnr)
+-- Line-level cases the fixture corpus does not spell out: the Z33 vs GNU
+-- spellings that are one character apart, and the GNU mnemonics/registers that
+-- must not count as positives.
+local ftdetect = require("z33.ftdetect")
+for _, case in ipairs({
+  { "#undefine FOO", "z33" },
+  { "#undef FOO", "gnu" },
+  { "#  ifdef X", "gnu" },
+  { '#include "lib.s"', "z33" },
+  { "#include <stdio.h>", "gnu" },
+  { "  .text", "gnu" },
+  { ".addr 100", "z33" },
+  { ".word 1", nil },
+  { "    push %a", "z33" },
+  { "    movl %ax, %bx", nil },
+  { "    pushq %rbp", nil },
+  { "main: reset", "z33" },
+  { "  RESET", "z33" },
+  { "  resetting", nil },
+  { "    jle done", nil },
+  { "    jeq done", "z33" },
+  { "    call foo", nil },
+}) do
+  local got = ftdetect.line_signal(case[1])
+  assert(
+    got == case[2],
+    ("line_signal(%q) = %s, expected %s"):format(case[1], tostring(got), tostring(case[2]))
+  )
+end
 
-local ft = vim.filetype.match({ buf = bufnr, filename = "fact.s" })
-assert(ft == "z33", "expected filetype z33 for samples/fact.s, got: " .. tostring(ft))
+-- End to end through a real `:edit`, where the `vim.filetype.add` matcher and
+-- the force-override autocmd run on a buffer load instead of being called
+-- directly. (`filetype on` is a no-op under `nvim -l`, which has already
+-- loaded the filetype machinery; it is here for other harnesses.) The negative
+-- case only asserts "not z33" — a third-party `.s` claimant installed on the
+-- host (vim-polyglot's r-lang) can legitimately win there; the exact builtin
+-- answer is asserted below.
+pcall(vim.cmd, "filetype on")
+for _, case in ipairs({
+  { "editors/vim/tests/fixtures/z33/no_registers.s", true },
+  { "editors/vim/tests/fixtures/asm/kernel.S", false },
+}) do
+  local path, want_z33 = case[1], case[2]
+  vim.cmd.edit(path)
+  local ft = vim.bo.filetype
+  assert(
+    (ft == "z33") == want_z33,
+    ("%s: filetype %s after :edit, expected %sz33"):format(path, ft, want_z33 and "" or "not ")
+  )
+end
 
--- A GNU assembly file must keep Neovim's builtin detection.
-local gnu = vim.api.nvim_create_buf(false, true)
-vim.api.nvim_buf_set_lines(gnu, 0, -1, false, {
-  "\t.text",
-  "\t.globl main",
-  "main:",
-  "\tmovq $1, %rax",
-  "\tret",
-})
-local gnu_ft = vim.filetype.match({ buf = gnu, filename = "gnu.s" })
-assert(gnu_ft == "asm", "expected filetype asm for a GNU file, got: " .. tostring(gnu_ft))
+-- Filetype heuristic. Every file under `tests/fixtures/<ft>/` must come out as
+-- `<ft>`, and every sample must be z33. Checked twice: through the module (what
+-- the force-override autocmd calls) and end to end through `vim.filetype.match`
+-- (Neovim's own detection, which must hand non-Z33 files back to the builtin
+-- asm detection rather than leaving them filetype-less).
+local function check(path, expected)
+  local buf = vim.fn.bufadd(path)
+  vim.fn.bufload(buf)
+  local direct = ftdetect.detect(buf)
+  local want_direct = expected == "z33" and "z33" or nil
+  assert(
+    direct == want_direct,
+    ("%s: ftdetect.detect returned %s, expected %s"):format(path, tostring(direct), tostring(want_direct))
+  )
+  local ft = vim.filetype.match({ buf = buf, filename = path })
+  assert(ft == expected, ("%s: filetype %s, expected %s"):format(path, tostring(ft), expected))
+end
+
+local files = {}
+for _, expected in ipairs({ "z33", "asm" }) do
+  for _, path in ipairs(vim.fn.glob("editors/vim/tests/fixtures/" .. expected .. "/*", false, true)) do
+    files[path] = expected
+  end
+end
+for _, path in ipairs(vim.fn.glob("samples/*.s", false, true)) do
+  files[path] = "z33"
+end
+
+local checked = 0
+for path, expected in pairs(files) do
+  check(path, expected)
+  checked = checked + 1
+end
+assert(checked >= 10, "expected the fixture corpus to be found, only checked " .. checked .. " files")
 
 -- Highlighting: with no tree-sitter parser installed (the CI case), a z33
 -- buffer must fall back to the bundled Vimscript syntax (syntax/z33.vim, shared
@@ -78,4 +148,4 @@ else
   mode = "regex fallback (b:current_syntax=z33)"
 end
 
-print("OK: nvim smoke test passed (filetype=" .. tostring(ft) .. ", highlighting=" .. mode .. ")")
+print("OK: nvim smoke test passed (" .. checked .. " filetype cases, highlighting=" .. mode .. ")")

--- a/editors/vim/tests/smoke.lua
+++ b/editors/vim/tests/smoke.lua
@@ -30,6 +30,18 @@ vim.fn.bufload(bufnr)
 local ft = vim.filetype.match({ buf = bufnr, filename = "fact.s" })
 assert(ft == "z33", "expected filetype z33 for samples/fact.s, got: " .. tostring(ft))
 
+-- A GNU assembly file must keep Neovim's builtin detection.
+local gnu = vim.api.nvim_create_buf(false, true)
+vim.api.nvim_buf_set_lines(gnu, 0, -1, false, {
+  "\t.text",
+  "\t.globl main",
+  "main:",
+  "\tmovq $1, %rax",
+  "\tret",
+})
+local gnu_ft = vim.filetype.match({ buf = gnu, filename = "gnu.s" })
+assert(gnu_ft == "asm", "expected filetype asm for a GNU file, got: " .. tostring(gnu_ft))
+
 -- Highlighting: with no tree-sitter parser installed (the CI case), a z33
 -- buffer must fall back to the bundled Vimscript syntax (syntax/z33.vim, shared
 -- with classic Vim), i.e. b:current_syntax == "z33". With a parser present,

--- a/editors/vim/tests/smoke.lua
+++ b/editors/vim/tests/smoke.lua
@@ -12,6 +12,11 @@
 
 vim.opt.rtp:prepend(vim.fn.getcwd() .. "/editors/vim")
 
+-- The first z33 buffer triggers the z33-cli download consent prompt when no
+-- binary is on PATH. Headless with stdin at EOF, that prompt makes Neovim exit
+-- with status 0 before any assertion below runs, so forbid downloads up front.
+vim.g.z33_auto_download = false
+
 local z33 = require("z33")
 
 -- setup() is documented as idempotent and safe to call more than once (see

--- a/editors/zed/LICENSE
+++ b/editors/zed/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Quentin Gliech
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -33,6 +33,28 @@ Add a `zorglub33` entry to the project's `.zed/debug.json`, or fill the
 `entrypoint` defaults to whichever of `main`, `start`, `run` or `entry` the
 program defines.
 
+## Running a label from the gutter
+
+The extension marks every label as a runnable and exposes its name to tasks
+as `$ZED_CUSTOM_label`. Zed only shows the run button once a task carries the
+`zorglub33-label` tag, so add one to your `tasks.json`
+(`zed: open tasks` in the command palette):
+
+```json
+[
+  {
+    "label": "z33: run $ZED_CUSTOM_label",
+    "command": "z33-cli",
+    "args": ["run", "$ZED_FILE", "$ZED_CUSTOM_label"],
+    "tags": ["zorglub33-label"]
+  }
+]
+```
+
+This runs `z33-cli` from your `PATH`; the copy the extension downloads for
+the language server is not on it. Data labels get a button too, since the
+syntax query cannot tell them from code labels.
+
 ## Development
 
 The extension lives in `editors/zed/` of the main repository. Install it as a

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -1,0 +1,41 @@
+# Zorglub33 for Zed
+
+Language support and debugging for Zorglub-33 (Z33) assembly, the teaching
+architecture of the *Architecture des Systèmes d'Exploitation* course at the
+University of Strasbourg.
+
+- Syntax highlighting, outline and brackets through the `tree-sitter-z33`
+  grammar.
+- Diagnostics, completion, hover documentation, go to definition, references
+  and rename through the `z33-cli lsp` language server.
+- Debugging (breakpoints, stepping, registers, stack, memory) through the
+  `z33-cli dap` debug adapter.
+
+The extension uses `z33-cli` from your `PATH` when present and otherwise
+downloads the prebuilt binary for your platform from the GitHub releases of
+<https://github.com/sandhose/z33-emulator>.
+
+## Debugging
+
+Add a `zorglub33` entry to the project's `.zed/debug.json`, or fill the
+`debugger: new process` modal, with the program to run:
+
+```json
+{
+  "label": "Run fact.s",
+  "adapter": "zorglub33",
+  "request": "launch",
+  "program": "$ZED_WORKTREE_ROOT/fact.s",
+  "entrypoint": "main"
+}
+```
+
+`entrypoint` defaults to whichever of `main`, `start`, `run` or `entry` the
+program defines.
+
+## Development
+
+The extension lives in `editors/zed/` of the main repository. Install it as a
+dev extension from Zed's command palette (`zed: install dev extension`) and
+point it at that directory; a Rust toolchain with the `wasm32-wasip1` target
+is required.

--- a/editors/zed/debug_adapter_schemas/zorglub33.json
+++ b/editors/zed/debug_adapter_schemas/zorglub33.json
@@ -10,6 +10,16 @@
         "Debug main.s"
       ]
     },
+    "adapter": {
+      "type": "string",
+      "const": "zorglub33",
+      "description": "Debug adapter this configuration runs with."
+    },
+    "request": {
+      "type": "string",
+      "const": "launch",
+      "description": "The adapter launches a program; it cannot attach to a running one."
+    },
     "program": {
       "type": "string",
       "description": "Path to the Zorglub33 assembly file to debug",
@@ -34,6 +44,5 @@
   },
   "required": [
     "program"
-  ],
-  "additionalProperties": false
+  ]
 }

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -15,8 +15,8 @@ languages = ["Zorglub33 Assembly"]
 
 # The tree-sitter grammar lives in this same repository under `tree-sitter-z33/`.
 # Zed fetches the grammar from the repository at `rev` and compiles the
-# `parser.c` found at `path`. `rev` is refreshed by scripts/set-version.sh on
-# each release.
+# `parser.c` found at `path`. The release workflow points `rev` at the commit
+# that bumps the version, through scripts/set-grammar-rev.sh.
 [grammars.z33]
 repository = "https://github.com/sandhose/z33-emulator"
 rev = "53c8d1ccd133c0bdb80d150504a7cec8227670cf"

--- a/editors/zed/languages/zorglub33/config.toml
+++ b/editors/zed/languages/zorglub33/config.toml
@@ -3,3 +3,13 @@ grammar = "z33"
 path_suffixes = ["s", "S"]
 line_comments = ["// "]
 tab_size = 4
+word_characters = ["%"]
+# Zed autocloses a pair only before whitespace or one of these characters, and
+# `ld [%sp+2],%b` closes a bracket right before a comma.
+autoclose_before = ",]"
+debuggers = ["zorglub33"]
+brackets = [
+  { start = "[", end = "]", close = true, newline = false },
+  { start = "(", end = ")", close = true, newline = false },
+  { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
+]

--- a/editors/zed/languages/zorglub33/overrides.scm
+++ b/editors/zed/languages/zorglub33/overrides.scm
@@ -1,0 +1,3 @@
+; Names the scopes `not_in` refers to in config.toml.
+(comment) @comment.inclusive
+(string) @string

--- a/editors/zed/languages/zorglub33/runnables.scm
+++ b/editors/zed/languages/zorglub33/runnables.scm
@@ -1,0 +1,7 @@
+; A run button on every label definition; the label name reaches tasks as
+; $ZED_CUSTOM_label (see editors/zed/README.md for the tasks.json binding).
+; Data labels get a button too: a syntax query cannot tell them from code
+; labels.
+((label
+   name: (identifier) @run @label)
+ (#set! tag zorglub33-label))

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Asserts that every manifest scripts/set-version.sh writes still agrees on
-# one version, so a hand-edit can't silently desync them between releases.
+# one version, so a hand-edit can't silently desync them between releases, and
+# that the Zed extension still pins its grammar at a commit SHA.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -24,6 +25,14 @@ for pair in \
     status=1
   fi
 done
+
+# Zed resolves the grammar `rev` with `git fetch --depth 1 origin <rev>`
+# followed by `git checkout <rev>`, which a tag or branch name does not survive.
+rev="$(perl -ne 'if (/^rev = "([^"]+)"/) { print $1; exit }' editors/zed/extension.toml)"
+if ! [[ "$rev" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "::error::editors/zed/extension.toml pins the grammar at '$rev', not a full commit SHA" >&2
+  status=1
+fi
 
 if [[ "$status" -eq 0 ]]; then
   echo "All manifests agree on version $workspace"

--- a/scripts/set-grammar-rev.sh
+++ b/scripts/set-grammar-rev.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Pins the commit the Zed extension compiles the tree-sitter grammar from
+# (`rev` in editors/zed/extension.toml).
+#
+# The release workflow calls this with the SHA of the version-bump commit, so
+# the published extension builds the grammar exactly as the release ships it.
+# A commit cannot name itself, which is why this runs as a separate step and
+# lands in its own commit on the release branch.
+#
+# Usage: scripts/set-grammar-rev.sh <commit-sha>
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <commit-sha>" >&2
+  exit 1
+fi
+
+GRAMMAR_REV="$1"
+if ! [[ "$GRAMMAR_REV" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "error: expected a full 40-character commit SHA (got '$GRAMMAR_REV')" >&2
+  exit 1
+fi
+
+cd "$(dirname "$0")/.."
+
+export GRAMMAR_REV
+perl -0777 -pi -e 's/^rev = "[0-9a-f]+"/rev = "$ENV{GRAMMAR_REV}"/m' \
+  editors/zed/extension.toml
+
+if ! grep -q "^rev = \"$GRAMMAR_REV\"\$" editors/zed/extension.toml; then
+  echo "error: no grammar rev line was rewritten in editors/zed/extension.toml" >&2
+  exit 1
+fi
+
+echo "Pinned the Zed grammar rev to $GRAMMAR_REV"

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -2,8 +2,9 @@
 # Sets the project version across every shipped manifest:
 #   - Cargo.toml [workspace.package] (inherited by all crates) + Cargo.lock
 #   - editors/vscode/package.json (the VS Code extension)
-#   - editors/zed/extension.toml (the Zed extension), whose pinned tree-sitter
-#     grammar `rev` is also refreshed to the current HEAD
+#   - editors/zed/extension.toml (the Zed extension); its pinned tree-sitter
+#     grammar `rev` is set separately by scripts/set-grammar-rev.sh, which the
+#     release workflow runs once the commit holding the released grammar exists
 #   - tree-sitter-z33/package.json and tree-sitter.json (the grammar),
 #     plus the committed generated parser, which embeds that version
 #
@@ -23,16 +24,13 @@ fi
 
 cd "$(dirname "$0")/.."
 
-GRAMMAR_REV="$(git rev-parse HEAD)"
-export VERSION GRAMMAR_REV
+export VERSION
 
 # The first `version = "…"` line is the [workspace.package] one.
 perl -0777 -pi -e 's/^version = "[^"]+"/version = "$ENV{VERSION}"/m' Cargo.toml
 
-perl -0777 -pi -e '
-  s/^version = "[^"]+"/version = "$ENV{VERSION}"/m;
-  s/^rev = "[0-9a-f]+"/rev = "$ENV{GRAMMAR_REV}"/m;
-' editors/zed/extension.toml
+perl -0777 -pi -e 's/^version = "[^"]+"/version = "$ENV{VERSION}"/m' \
+  editors/zed/extension.toml
 
 (cd editors/vscode && npm pkg set version="$VERSION")
 (cd tree-sitter-z33 && npm pkg set version="$VERSION")
@@ -48,4 +46,4 @@ pnpm --filter tree-sitter-z33 run generate
 
 cargo update --workspace --quiet
 
-echo "Set version $VERSION (grammar rev $GRAMMAR_REV)"
+echo "Set version $VERSION"


### PR DESCRIPTION
Neovim, classic Vim and Zed improvements from the 2026-09-04 exploration (notes: "Zed, Vim/Neovim, tree-sitter"), plus the follow-ups it ranked: the `.s`/`.S` detection heuristic, the Zed grammar rev pinned at release time, and a Zed runnables query.

## Neovim / Vim

- Filetype detection: a `.s` file that is not Z33 falls back to Neovim's own `asm` detection instead of ending with no filetype (the `vim.filetype.add` entry replaced the builtin one).
- The heuristic now vetoes files carrying GNU cpp (`#ifdef`, `#undef`, `#include <…>`, `#pragma`), GNU `as` (`.globl`, `.section`, `.text`, `.data`, `.type`, `.size`, `.macro`) and Plan 9 / Go (`TEXT`/`DATA`/`GLOBL`…, `(SB)`) markers, and accepts Z33-only mnemonics (`fas`, `rti`, `rtn`, `swap`, `reset`, `trap`, `jeq`, `jlt`, `jgt`) as positives, so data-only or register-free programs are detected. Both the Lua and the Vimscript copies implement the same rule and are checked in CI against one fixture corpus (`editors/vim/tests/fixtures/`). Measured over Go's `GOROOT/src`: 600 `.s` files, 17 still claimed (all have their first `TEXT` past the 64-line window); GNU asm from `rust-src`: 4 of 2308.
- LSP code lenses are shown (`codelens.enable` on 0.12, refresh autocmds on 0.11) and the run lens starts the program through nvim-dap or a terminal split. `g:z33_no_codelens` turns it off. The lens test now runs in CI.
- `download.lua` reports a missing `curl`/`tar` instead of wedging the module for the session (and hanging nvim-dap).
- An empty entrypoint answer in the nvim-dap prompt means the default.
- `:checkhealth z33` runs `z33-cli --version` instead of only locating the binary.
- `gg=G` no longer flattens the first line after a label.
- The smoke test forbids the download prompt (it used to pass with zero assertions when the prompt appeared).

## Zed

- `config.toml`: brackets with autoclose, `autoclose_before`, `word_characters = ["%"]`, `debuggers`, and an `overrides.scm` so the `"` pair's `not_in` applies.
- `runnables.scm` marks every label as a runnable and exposes it as `$ZED_CUSTOM_label`; Zed shows the button once a task carries the `zorglub33-label` tag (snippet in the README).
- LICENSE and README for the extension directory (no registry submission in this PR).
- The debug adapter schema accepts the `adapter`/`request` keys Zed validates on the whole `debug.json` entry.

## Release tooling

- `set-version.sh` used to pin the Zed grammar `rev` to `HEAD` before creating the bump commit, so the published extension compiled the grammar from the commit before the release. The `cut` job now creates a second signed commit pinning the rev to the bump commit (`scripts/set-grammar-rev.sh`), and the `tag` job refuses to tag when the pinned rev's `tree-sitter-z33/` tree differs from the merge commit's. `check-version-sync.sh` requires a full SHA (Zed's `git fetch --depth 1` + `checkout` does not resolve tag names).

## Not verified here

- The classic Vim CI step (fixture loop asserting `asm`/`z33`): this machine has no real Vim, only Neovim. The Vimscript regexes were evaluated through Neovim's `match()` and agree with the Lua copy on 174 lines.
- The two-mutation `createCommitOnBranch` flow and the `tag` job check against a live release; the API shapes were exercised read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
