### PR TITLE
Shared editor package: one wasm build and one serial input translation for the web IDE and VS Code

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -100,6 +100,11 @@ jobs:
           runtime: node@24
           require-lockfile: true
 
+      # Ahead of the Rust cache and the wasm build: these need neither, and a
+      # failure here should not wait on them.
+      - name: Run the shared package unit tests
+        run: pnpm --filter z33-editor-shared run test
+
       - name: Setup Rust build cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -108,17 +108,8 @@ jobs:
       - name: Setup Rust build cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
-      # Build the wasm once and reuse it for the vscode check: the web and
-      # vscode `build:wasm` scripts differ only in `--out-dir`, so the output is
-      # byte-identical. The copy also satisfies the vscode check's dist/pkg
-      # exists-guard, avoiding a second wasm-pack build.
       - name: Build the wasm bindings
-        run: pnpm --filter z33-web run build:wasm
-
-      - name: Reuse the wasm bindings for the vscode extension
-        run: |
-          mkdir -p editors/vscode/dist
-          cp -r editors/web/pkg editors/vscode/dist/pkg
+        run: pnpm --filter z33-editor-shared run build:wasm
 
       - name: Run lint and format check
         run: pnpm -r run check
@@ -192,12 +183,7 @@ jobs:
       # Jobs share no filesystem, so the wasm build of the lint job is
       # repeated here.
       - name: Build the wasm bindings
-        run: pnpm --filter z33-web run build:wasm
-
-      - name: Reuse the wasm bindings for the vscode extension
-        run: |
-          mkdir -p editors/vscode/dist
-          cp -r editors/web/pkg editors/vscode/dist/pkg
+        run: pnpm --filter z33-editor-shared run build:wasm
 
       - name: Build the extension bundle
         run: pnpm --filter z33-assembly run build:bundle
@@ -298,7 +284,7 @@ jobs:
       # file. No story instantiates the binary, so the dev build is enough. The
       # unit project mocks that module and runs without it.
       - name: Build the wasm bindings
-        run: pnpm run build:wasm:dev
+        run: pnpm --filter z33-editor-shared run build:wasm:dev
 
       # Only the storybook project needs a browser; the unit project runs in node.
       - name: Install Playwright browsers

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -183,9 +183,9 @@ jobs:
           runtime: node@24
           require-lockfile: true
 
-      # wasm-pack comes from the `z33-assembly` (vscode) package's devDependency
-      # — that is the one `pnpm --filter z33-assembly run build` resolves via its
-      # `build:wasm` script — so no separate install action is needed.
+      # `pnpm --filter z33-assembly run build` shells out to z33-editor-shared's
+      # `build:wasm`, which brings wasm-pack from that package's
+      # devDependencies, so no separate install action is needed.
       - name: Build the extension
         run: pnpm --filter z33-assembly run build
 

--- a/editors/shared/.gitignore
+++ b/editors/shared/.gitignore
@@ -1,0 +1,2 @@
+/pkg/
+/node_modules/

--- a/editors/shared/package.json
+++ b/editors/shared/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "z33-editor-shared",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./serial-input": "./src/serial-input.ts",
+    "./wasm": {
+      "types": "./pkg/z33_web.d.ts",
+      "default": "./pkg/z33_web.js"
+    },
+    "./wasm-binary": "./pkg/z33_web_bg.wasm"
+  },
+  "scripts": {
+    "build:wasm": "wasm-pack build ../../crates/wasm --target web --out-dir ../../editors/shared/pkg --out-name z33_web",
+    "build:wasm:dev": "wasm-pack build ../../crates/wasm --dev --target web --out-dir ../../editors/shared/pkg --out-name z33_web",
+    "check": "tsc --noEmit && pnpm run lint && oxfmt --check src/",
+    "lint": "oxlint src/",
+    "fmt": "oxfmt src/",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "^4.1.11",
+    "wasm-pack": "catalog:"
+  }
+}

--- a/editors/shared/src/serial-input.test.ts
+++ b/editors/shared/src/serial-input.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { translateSerialInput } from "./serial-input";
+
+const ESC = "\u001B";
+const DEL = "\u007F";
+const BS = "\u0008";
+const EOT = "\u0004";
+
+describe("translateSerialInput", () => {
+  it("passes plain text through", () => {
+    expect(translateSerialInput("hello")).toBe("hello");
+  });
+
+  it("turns a typed Enter into LF", () => {
+    expect(translateSerialInput("\r")).toBe("\n");
+  });
+
+  it("turns a CRLF into a single LF", () => {
+    expect(translateSerialInput("a\r\nb")).toBe("a\nb");
+  });
+
+  it("normalizes every newline of a multi-line paste", () => {
+    expect(translateSerialInput("one\rtwo\r\nthree\n")).toBe("one\ntwo\nthree\n");
+  });
+
+  it("turns DEL into BS", () => {
+    expect(translateSerialInput(DEL)).toBe(BS);
+    expect(translateSerialInput(`a${DEL}b${DEL}`)).toBe(`a${BS}b${BS}`);
+  });
+
+  it("drops a chunk that starts with an escape sequence", () => {
+    expect(translateSerialInput(`${ESC}[A`)).toBeNull();
+    expect(translateSerialInput(`${ESC}OP`)).toBeNull();
+  });
+
+  it("drops a bare ESC chunk", () => {
+    expect(translateSerialInput(ESC)).toBeNull();
+  });
+
+  it("passes an ESC that is not at the start through", () => {
+    expect(translateSerialInput(`a${ESC}[Ab`)).toBe(`a${ESC}[Ab`);
+  });
+
+  it("keeps control characters the program reads", () => {
+    expect(translateSerialInput(EOT)).toBe(EOT);
+  });
+
+  it("drops an empty chunk", () => {
+    expect(translateSerialInput("")).toBeNull();
+  });
+});

--- a/editors/shared/src/serial-input.ts
+++ b/editors/shared/src/serial-input.ts
@@ -1,0 +1,27 @@
+// One translation from terminal input to serial input, shared by the web IDE
+// and the VS Code extension so both consoles behave the same on the same
+// program.
+
+const ESCAPE = "\u001B";
+const DELETE = "\u007F";
+const BACKSPACE = "\u0008";
+
+/**
+ * Translate one terminal input chunk into what the serial port should receive,
+ * as a string the caller sends or encodes. Returns `null` when the chunk
+ * carries nothing for the emulator, so a caller never sends an empty edge.
+ *
+ * The conventions:
+ *   * Enter arrives as CR, or, on the VS Code pty, as CRLF, and becomes a
+ *     single LF, the host line convention. Matching `\r\n?` rather than `\r`
+ *     keeps one CRLF from becoming two host newlines.
+ *   * Backspace arrives as DEL and becomes BS.
+ *   * A chunk starting with ESC is an arrow or function key, which carries no
+ *     serial meaning.
+ *   * Everything else, control characters included, passes through: the
+ *     program decides what to do with Ctrl-D and friends.
+ */
+export function translateSerialInput(data: string): string | null {
+  if (data === "" || data.startsWith(ESCAPE)) return null;
+  return data.replaceAll(/\r\n?/gu, "\n").replaceAll(DELETE, BACKSPACE);
+}

--- a/editors/shared/tsconfig.json
+++ b/editors/shared/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "lib": ["es2022"],
+    "types": [],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,18 +1,15 @@
 .vscode/**
 src/**
 node_modules/**
-# Stale pre-WASM build output; never ship it even if a working copy has one
+# Stale build output; never ship it even if a working copy has one
 out/**
+dist/pkg/**
 tsconfig.json
 tsconfig.tsbuildinfo
 build.mjs
 .gitignore
 **/*.map
 **/*.ts
-# Only the wasm binary is needed at runtime; the glue is bundled into the
-# extension and worker output.
-dist/pkg/**
-!dist/pkg/z33_web_bg.wasm
 e2e/**
 playwright.config.ts
 playwright-report/**

--- a/editors/vscode/build.mjs
+++ b/editors/vscode/build.mjs
@@ -4,15 +4,35 @@
 //   * dist/extension.js         — the extension host entry (CJS, `vscode` external)
 //   * dist/lsp-server.worker.js — the LSP web worker (classic IIFE worker)
 //
-// Both bundle the wasm-pack glue (dist/pkg/z33_web.js). The `import.meta.url`
+// Both bundle the wasm-pack glue from `z33-editor-shared`. The `import.meta.url`
 // fallback in that glue (used only to locate the .wasm by URL) is dead code
 // here — we always instantiate from bytes — so we define it to a harmless
 // literal to keep esbuild happy in CJS/IIFE output.
+//
+// The binary itself is read at run time from the extension directory, so it is
+// copied into dist/ rather than bundled.
 
+import { copyFile, mkdir } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import * as esbuild from "esbuild";
 
 const production = process.argv.includes("--production");
 const watch = process.argv.includes("--watch");
+
+// wasm-pack rewrites the glue on every build, so a wasm rebuild is also an
+// esbuild rebuild and this keeps the copy in dist/ in step under `--watch`. One
+// config carries it: two would race for the same output file.
+/** @type {import("esbuild").Plugin} */
+const copyWasmPlugin = {
+  name: "copy-wasm",
+  setup(build) {
+    build.onEnd(async () => {
+      const source = fileURLToPath(import.meta.resolve("z33-editor-shared/wasm-binary"));
+      await mkdir("dist", { recursive: true });
+      await copyFile(source, "dist/z33_web_bg.wasm");
+    });
+  },
+};
 
 /** @type {import("esbuild").BuildOptions} */
 const shared = {
@@ -34,6 +54,7 @@ const extensionConfig = {
   outfile: "dist/extension.js",
   format: "cjs",
   external: ["vscode"],
+  plugins: [copyWasmPlugin],
 };
 
 /** @type {import("esbuild").BuildOptions} */

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -152,11 +152,10 @@
   },
   "scripts": {
     "vscode:prepublish": "pnpm run build",
-    "build:wasm": "wasm-pack build ../../crates/wasm --target web --out-dir ../../editors/vscode/dist/pkg --out-name z33_web",
     "build:bundle": "node build.mjs --production",
-    "build": "pnpm run build:wasm && pnpm run build:bundle",
+    "build": "pnpm --filter z33-editor-shared run build:wasm && pnpm run build:bundle",
     "watch": "node build.mjs --watch",
-    "check": "node -e \"require('fs').existsSync('dist/pkg')||process.exit(1)\" || pnpm run build:wasm && tsc --noEmit && pnpm run lint && oxfmt --check src/ e2e/ playwright.config.ts",
+    "check": "node -e \"try{require.resolve('z33-editor-shared/wasm')}catch{process.exit(1)}\" || pnpm --filter z33-editor-shared run build:wasm && tsc --noEmit && pnpm run lint && oxfmt --check src/ e2e/ playwright.config.ts",
     "lint": "oxlint src/ e2e/ playwright.config.ts",
     "fmt": "oxfmt src/ e2e/ playwright.config.ts",
     "package": "vsce package --no-dependencies",
@@ -176,6 +175,6 @@
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "typescript": "catalog:",
-    "wasm-pack": "catalog:"
+    "z33-editor-shared": "workspace:*"
   }
 }

--- a/editors/vscode/src/debug-adapter.ts
+++ b/editors/vscode/src/debug-adapter.ts
@@ -10,7 +10,7 @@
 // calls (pause / disconnect / etc.) can interleave with execution.
 
 import * as vscode from "vscode";
-import type { WasmDapServer } from "../dist/pkg/z33_web.js";
+import type { WasmDapServer } from "z33-editor-shared/wasm";
 import { collectWorkspaceFiles } from "./workspace-paths.js";
 
 /** A launch configuration as sent by VS Code, before we inject the file map. */

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -15,7 +15,7 @@
 import * as vscode from "vscode";
 import { LanguageClient, type LanguageClientOptions } from "vscode-languageclient/browser";
 
-import initDapWasm, { WasmDapServer } from "../dist/pkg/z33_web.js";
+import initDapWasm, { WasmDapServer } from "z33-editor-shared/wasm";
 import { Z33DebugAdapter } from "./debug-adapter.js";
 import { SerialTerminalManager } from "./serial-terminal.js";
 import {
@@ -44,7 +44,7 @@ let client: LanguageClient | undefined;
 
 /** Read the wasm binary shipped in the extension as raw bytes. */
 async function readWasmBytes(context: vscode.ExtensionContext): Promise<Uint8Array> {
-  const uri = vscode.Uri.joinPath(context.extensionUri, "dist/pkg/z33_web_bg.wasm");
+  const uri = vscode.Uri.joinPath(context.extensionUri, "dist/z33_web_bg.wasm");
   return vscode.workspace.fs.readFile(uri);
 }
 

--- a/editors/vscode/src/lsp-server.worker.ts
+++ b/editors/vscode/src/lsp-server.worker.ts
@@ -15,7 +15,7 @@
 // `WasmLspServer` speaks *unframed JSON strings*, whereas the browser transport
 // exchanges JSON-RPC *objects*, so we JSON.stringify/parse at the boundary.
 
-import initWasm, { WasmLspServer } from "../dist/pkg/z33_web.js";
+import initWasm, { WasmLspServer } from "z33-editor-shared/wasm";
 
 interface InitMessage {
   type: "init";

--- a/editors/vscode/src/serial-terminal.ts
+++ b/editors/vscode/src/serial-terminal.ts
@@ -13,6 +13,7 @@
 // two are connected through the session-id-keyed `SerialTerminalManager`.
 
 import * as vscode from "vscode";
+import { translateSerialInput } from "z33-editor-shared/serial-input";
 
 const TERMINAL_NAME = "Zorglub33 Serial";
 const SERIAL_INPUT_REQUEST = "zorglub33/serialInput";
@@ -101,17 +102,10 @@ class SerialPty implements vscode.Pseudoterminal {
     if (!this.accepting) {
       return;
     }
-    // Translate terminal conventions to the host's serial convention:
-    //   * Enter arrives as CR (\r), possibly followed by LF (\r\n on a
-    //     Windows-style paste or other CRLF-delivering path) → send a single
-    //     LF (\n), the host line convention. Matching `\r\n?` (not just `\r`)
-    //     avoids turning one CRLF into two host newlines.
-    //   * Backspace arrives as DEL (\x7f) → send BS (\x08), matching the web
-    //     console.
-    // Everything else (including control chars like Ctrl-D = EOT \x04) passes
-    // through untouched — that is the whole point: the program decides what to
-    // do with them (echo.s exits on EOT).
-    const translated = data.replace(/\r\n?/g, "\n").replace(/\x7f/g, "\x08");
+    const translated = translateSerialInput(data);
+    if (!translated) {
+      return;
+    }
     // Forward the whole chunk as ONE request so a paste is a single IRQ edge,
     // matching the emulator's one-edge-per-`push_input` contract.
     this.session

--- a/editors/web/.gitignore
+++ b/editors/web/.gitignore
@@ -1,4 +1,5 @@
 /dist/
+# The wasm build writes to editors/shared/pkg; a working copy may still hold one here.
 /pkg/
 /node_modules/
 /test-results/

--- a/editors/web/README.md
+++ b/editors/web/README.md
@@ -12,7 +12,7 @@ Run from this directory, or from the repository root with
 | --- | --- |
 | `pnpm run start` | Build the wasm bindings (dev profile) and serve the app |
 | `pnpm run build` | Build the wasm bindings (release) and the production bundle |
-| `pnpm run build:wasm:dev` | Build the wasm bindings into `pkg/` on their own |
+| `pnpm --filter z33-editor-shared run build:wasm:dev` | Build the wasm bindings into `editors/shared/pkg/` on their own |
 | `pnpm run check` | `tsc -b`, then oxlint and oxfmt |
 | `pnpm run test` | Vitest: both projects |
 | `pnpm run test:unit` | The `unit` project alone, in node |
@@ -21,5 +21,6 @@ Run from this directory, or from the repository root with
 | `pnpm run knip` | Unused files, dependencies and exports |
 | `pnpm run storybook` | The Storybook dev server |
 
-`check` type-checks against the generated bindings, so `pkg/` has to exist:
-run `pnpm run build:wasm:dev` first in a fresh checkout.
+`check` type-checks against the generated bindings, so `editors/shared/pkg/`
+has to exist: run `pnpm --filter z33-editor-shared run build:wasm:dev` first in
+a fresh checkout.

--- a/editors/web/app/lib/wasm-module.ts
+++ b/editors/web/app/lib/wasm-module.ts
@@ -7,7 +7,7 @@
 // fetch and the editor chunk are in flight together: on a slow link the editor
 // arrives later than it would alone, and the program becomes runnable at about
 // the moment it becomes editable, instead of a wasm round trip after it.
-import wasmUrl from "../../pkg/z33_web_bg.wasm?url";
+import wasmUrl from "z33-editor-shared/wasm-binary?url";
 
 let compiled: Promise<WebAssembly.Module> | null = null;
 

--- a/editors/web/app/lib/wasm.ts
+++ b/editors/web/app/lib/wasm.ts
@@ -4,4 +4,4 @@
 // (`workers/emulator.worker.ts`, `workers/lsp.worker.ts`); the main thread only
 // needs the types, so importing this module must never pull the wasm glue or
 // the binary into the main bundle.
-export type * from "../../pkg/z33_web.js";
+export type * from "z33-editor-shared/wasm";

--- a/editors/web/app/serial-terminal.tsx
+++ b/editors/web/app/serial-terminal.tsx
@@ -2,6 +2,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { type ITheme, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { useEffect, useImperativeHandle, useRef } from "react";
+import { translateSerialInput } from "z33-editor-shared/serial-input";
 import type { SerialPort } from "./computer-types";
 import { useThemeStore } from "./stores/theme-store";
 
@@ -43,26 +44,6 @@ const FONT_FAMILY =
   'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace';
 
 /**
- * Translate an xterm `onData` string into serial receive bytes, following the
- * serial-port policy: Enter -> LF, Backspace -> BS, arrow/function-key CSI
- * escapes dropped (no cursor semantics on a serial line), other control chars
- * forwarded as-is, everything else UTF-8 encoded. Returns `null` when nothing
- * should be sent.
- *
- * Newlines are normalized to LF before encoding: a typed Enter arrives as a
- * lone `\r`, but xterm also normalizes any newlines *inside* a pasted string
- * to `\r` (never `\r\n`, but handle both defensively) — without this, a
- * multi-line paste would send raw CR bytes that the LF-oriented emulator
- * never recognizes as a line terminator.
- */
-function translateInput(data: string): Uint8Array | null {
-  if (data === "\u007F") return Uint8Array.of(0x08);
-  // Escape sequences (arrows, function keys, ...) carry no serial meaning.
-  if (data.startsWith("\u001B")) return null;
-  return encoder.encode(data.replaceAll(/\r\n?/gu, "\n"));
-}
-
-/**
  * The xterm.js-backed serial terminal. Lazy-loaded so xterm stays out of the
  * initial bundle. Program output is written straight through (`convertEol`
  * handles the emulator's LF-only newlines); keystrokes and pastes are
@@ -99,7 +80,8 @@ const SerialTerminal: React.FC<SerialTerminalProps> = ({ computer, ref }) => {
     terminal.open(container);
     terminalRef.current = terminal;
 
-    // Expose the instance for e2e tests, like the editor's `__z33e2e` hook.
+    // The e2e tests read the scrollback through this instance: xterm's DOM
+    // grid holds no text nodes they can assert on.
     if (import.meta.env.DEV) {
       (globalThis as { __z33Terminal?: Terminal }).__z33Terminal = terminal;
     }
@@ -151,8 +133,8 @@ const SerialTerminal: React.FC<SerialTerminalProps> = ({ computer, ref }) => {
     terminal.reset();
 
     const onData = terminal.onData((data) => {
-      const bytes = translateInput(data);
-      if (bytes && bytes.length > 0) computer.sendInput([...bytes]);
+      const translated = translateSerialInput(data);
+      if (translated) computer.sendInput([...encoder.encode(translated)]);
     });
 
     const unsubscribe = computer.onOutput((bytes) => {

--- a/editors/web/app/workers/emulator.worker.ts
+++ b/editors/web/app/workers/emulator.worker.ts
@@ -23,7 +23,7 @@ import init, {
   Computer,
   InMemoryPreprocessor,
   type SourceIndex,
-} from "../../pkg/z33_web.js";
+} from "z33-editor-shared/wasm";
 
 /** Instructions per batch; tuned so pause latency stays well under a frame. */
 const BATCH_SIZE = 50_000;

--- a/editors/web/app/workers/lsp.worker.ts
+++ b/editors/web/app/workers/lsp.worker.ts
@@ -14,7 +14,7 @@ import {
   BrowserMessageWriter,
   type Message,
 } from "vscode-jsonrpc/browser";
-import init, { WasmLspServer } from "../../pkg/z33_web.js";
+import init, { WasmLspServer } from "z33-editor-shared/wasm";
 import { WORKER_ERROR, isWorkerInitFrame } from "./worker-protocol";
 
 const reader = new BrowserMessageReader(self);

--- a/editors/web/e2e/serial-console.spec.ts
+++ b/editors/web/e2e/serial-console.spec.ts
@@ -102,8 +102,8 @@ test.describe("Serial console", () => {
 
     // Drive xterm's own `paste()` API instead of `keyboard.type`: real browser
     // paste events go through the same internal normalization (embedded
-    // newlines become a bare `\r`), so this exercises the exact input our
-    // `translateInput` regression fix targets, without needing a real
+    // newlines become a bare `\r`), so this exercises the exact input
+    // `translateSerialInput` normalizes, without needing a real
     // clipboard/paste simulation.
     await page.evaluate(() => {
       const terminal = (

--- a/editors/web/package.json
+++ b/editors/web/package.json
@@ -6,10 +6,8 @@
     "#*": ["./*", "./*.ts", "./*.tsx"]
   },
   "scripts": {
-    "build:wasm": "wasm-pack build ../../crates/wasm --target web --out-dir ../../editors/web/pkg --out-name z33_web",
-    "build:wasm:dev": "wasm-pack build ../../crates/wasm --dev --target web --out-dir ../../editors/web/pkg --out-name z33_web",
-    "build": "pnpm run build:wasm && vite build",
-    "start": "pnpm run build:wasm:dev && vite",
+    "build": "pnpm --filter z33-editor-shared run build:wasm && vite build",
+    "start": "pnpm --filter z33-editor-shared run build:wasm:dev && vite",
     "check": "tsc -b && oxlint app/ e2e/ scripts/ && oxfmt --check app/ e2e/ scripts/",
     "lint": "oxlint app/ e2e/ scripts/",
     "lint:fix": "oxlint --fix app/ e2e/ scripts/",
@@ -53,8 +51,7 @@
     "tailwindcss": "^4.3.3",
     "typescript": "catalog:",
     "vite": "^8.2.2",
-    "vitest": "^4.1.11",
-    "wasm-pack": "catalog:"
+    "vitest": "^4.1.11"
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",
@@ -76,6 +73,7 @@
     "tw-animate-css": "^1.4.0",
     "vscode-jsonrpc": "^9.0.2",
     "vscode-languageserver-protocol": "^3.18.3",
+    "z33-editor-shared": "workspace:*",
     "zustand": "^5.0.15"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,24 @@ importers:
 
   .: {}
 
+  editors/shared:
+    devDependencies:
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.66.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.81.0(oxlint-tsgolint@7.0.2001)
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@26.4.1)(@vitest/browser-playwright@4.1.11)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
+      wasm-pack:
+        specifier: 'catalog:'
+        version: 0.15.0
+
   editors/vscode:
     dependencies:
       vscode-languageclient:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
-      wasm-pack:
-        specifier: 'catalog:'
-        version: 0.15.0
+      z33-editor-shared:
+        specifier: workspace:*
+        version: link:../shared
 
   editors/web:
     dependencies:
@@ -140,6 +140,9 @@ importers:
       vscode-languageserver-protocol:
         specifier: ^3.18.3
         version: 3.18.3
+      z33-editor-shared:
+        specifier: workspace:*
+        version: link:../shared
       zustand:
         specifier: ^5.0.15
         version: 5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
@@ -222,9 +225,6 @@ importers:
       vitest:
         specifier: ^4.1.11
         version: 4.1.11(@types/node@26.4.1)(@vitest/browser-playwright@4.1.11)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
-      wasm-pack:
-        specifier: 'catalog:'
-        version: 0.15.0
 
   tree-sitter-z33:
     devDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 # $schema: https://www.schemastore.org/pnpm-workspace.json
 
 packages:
+  - editors/shared
   - editors/web
   - editors/vscode
   - tree-sitter-z33


### PR DESCRIPTION
Both editors built the same wasm crate into their own output directory, and each serial console carried its own copy of the terminal-input translation. This adds `editors/shared` (`z33-editor-shared`, a private workspace package) holding one wasm-pack build and one `translateSerialInput`.

The package exports `./wasm` (glue + `.d.ts`), `./wasm-binary` (the `.wasm`) and `./serial-input`. The web app imports `z33-editor-shared/wasm-binary?url`; the VS Code build copies the binary into `dist/` from an esbuild `onEnd` plugin so the VSIX still ships it. CI builds the wasm once per job through the shared package and no longer copies one job's output into the other tree. The `/pkg/` gitignore in `editors/web` and `dist/pkg/**` in `.vscodeignore` stay, since existing working copies still hold the old build output.

Serial translation is now identical on both sides: escape-prefixed chunks dropped, CR and CRLF to LF, DEL to BS, everything else through. Against the old code that means the web console now maps DEL anywhere in a chunk rather than only when the chunk is exactly DEL, and VS Code drops arrow and function keys instead of forwarding raw CSI bytes and stops sending a request for an empty chunk. Ten unit tests pin the rules.

The two LSP worker bridges stay separate: they share two lines and differ in transport, wasm loading and error policy.

One thing to watch in CI: the Storybook job resolves the shared wasm URL through the Vite dev server rather than a build, and only a local run covers that path (`test-storybook`, 20 files / 67 tests). Everything else passes locally: `pnpm -r run check`, knip, `vite build`, the web Playwright suite including the WebKit startup spec, the VS Code `@vscode/test-web` suite, and `vsce ls` contents.

Stacked on #1044 (the web unit-test project); #1045 unifies the Vitest and Playwright configuration at the workspace root on top of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
