### PR TITLE
Web IDE: a node Vitest project for the pure logic, with the extractions and the persistence bugs it found

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -83,6 +83,8 @@ jobs:
       - name: Run cargo deny
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
 
+  # `pnpm -r run check` also type-checks: the web and vscode packages both run
+  # tsc from it. The job name is a required status check, so it stays as is.
   lint:
     name: "oxlint + oxfmt check"
     runs-on: ubuntu-24.04
@@ -265,8 +267,8 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-  storybook:
-    name: "Storybook tests"
+  vitest:
+    name: "Vitest tests"
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -286,17 +288,19 @@ jobs:
       - name: Setup Rust build cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
-      # The story graph reaches lib/wasm-module.ts, which imports the binary for
-      # its URL only, so vite has to resolve the file; no story instantiates it
-      # and the dev build is enough.
+      # Only the storybook project needs this: its story graph reaches
+      # lib/wasm-module.ts, whose `?url` import vite has to resolve to a real
+      # file. No story instantiates the binary, so the dev build is enough. The
+      # unit project mocks that module and runs without it.
       - name: Build the wasm bindings
         run: pnpm run build:wasm:dev
 
+      # Only the storybook project needs a browser; the unit project runs in node.
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps
 
-      - name: Run Storybook tests
-        run: pnpm run test-storybook
+      - name: Run the unit and Storybook tests
+        run: pnpm run test
 
   tree-sitter:
     name: Tree-sitter grammar

--- a/editors/web/README.md
+++ b/editors/web/README.md
@@ -1,0 +1,25 @@
+# z33-web
+
+The Z33 web IDE: a React + Vite app around Monaco, talking to the emulator and
+the language server through the wasm bindings in `crates/wasm`.
+
+## Commands
+
+Run from this directory, or from the repository root with
+`pnpm --filter z33-web run <script>`.
+
+| Command | What it does |
+| --- | --- |
+| `pnpm run start` | Build the wasm bindings (dev profile) and serve the app |
+| `pnpm run build` | Build the wasm bindings (release) and the production bundle |
+| `pnpm run build:wasm:dev` | Build the wasm bindings into `pkg/` on their own |
+| `pnpm run check` | `tsc -b`, then oxlint and oxfmt |
+| `pnpm run test` | Vitest: both projects |
+| `pnpm run test:unit` | The `unit` project alone, in node |
+| `pnpm run test-storybook` | The `storybook` project alone, in chromium |
+| `pnpm run e2e` | The Playwright suite, against a dev server it starts |
+| `pnpm run knip` | Unused files, dependencies and exports |
+| `pnpm run storybook` | The Storybook dev server |
+
+`check` type-checks against the generated bindings, so `pkg/` has to exist:
+run `pnpm run build:wasm:dev` first in a fresh checkout.

--- a/editors/web/app/computer-types.test.ts
+++ b/editors/web/app/computer-types.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { formatAddress, formatWord } from "./computer-types";
+
+describe("formatWord", () => {
+  it("formats zero", () => {
+    expect(formatWord(0, "decimal")).toBe("0");
+    expect(formatWord(0, "hex")).toBe("0x0");
+    expect(formatWord(0, "binary")).toBe("0b0");
+  });
+
+  it("formats a positive word", () => {
+    expect(formatWord(255, "decimal")).toBe("255");
+    expect(formatWord(255, "hex")).toBe("0xFF");
+    expect(formatWord(5, "binary")).toBe("0b101");
+  });
+
+  // Words are signed, and the panels render the sign in front of the base
+  // prefix rather than a two's-complement bit pattern.
+  it("formats a negative word with the sign before the prefix", () => {
+    expect(formatWord(-1, "decimal")).toBe("-1");
+    expect(formatWord(-255, "hex")).toBe("-0xFF");
+    expect(formatWord(-5, "binary")).toBe("-0b101");
+  });
+
+  it("formats a multi-digit word in every base", () => {
+    expect(formatWord(48_879, "decimal")).toBe("48879");
+    expect(formatWord(48_879, "hex")).toBe("0xBEEF");
+    expect(formatWord(48_879, "binary")).toBe("0b1011111011101111");
+  });
+
+  // A Word is an i64 in the emulator and crosses to the UI as a JS number, so
+  // the largest one that survives the trip intact is 2**53 - 1.
+  it("formats the largest word that reaches the UI intact", () => {
+    expect(formatWord(Number.MAX_SAFE_INTEGER, "decimal")).toBe(
+      "9007199254740991",
+    );
+    expect(formatWord(Number.MAX_SAFE_INTEGER, "hex")).toBe("0x1FFFFFFFFFFFFF");
+    expect(formatWord(-Number.MAX_SAFE_INTEGER, "hex")).toBe(
+      "-0x1FFFFFFFFFFFFF",
+    );
+  });
+});
+
+describe("formatAddress", () => {
+  it("formats an address in every base", () => {
+    expect(formatAddress(0, "decimal")).toBe("0");
+    expect(formatAddress(0, "hex")).toBe("0x0");
+    expect(formatAddress(1000, "decimal")).toBe("1000");
+    expect(formatAddress(1000, "hex")).toBe("0x3E8");
+    expect(formatAddress(2, "binary")).toBe("0b10");
+  });
+});

--- a/editors/web/app/lib/breakpoint-gutter.test.ts
+++ b/editors/web/app/lib/breakpoint-gutter.test.ts
@@ -1,0 +1,87 @@
+// oxlint-disable unicorn/no-useless-undefined -- `undefined` is the "no debug session" case under test
+import { describe, expect, it } from "vitest";
+import {
+  breakpointDecorations,
+  requestedLineForClick,
+} from "./breakpoint-gutter";
+import type { ResolvedForFile } from "../stores/breakpoint-store";
+
+const resolvedAt = (line: number) => ({ line, address: 1000 + line });
+
+describe("breakpointDecorations", () => {
+  it("returns nothing for a file without breakpoints", () => {
+    expect(breakpointDecorations(undefined, undefined)).toEqual([]);
+    expect(breakpointDecorations([], {})).toEqual([]);
+  });
+
+  it("marks every breakpoint verified outside a debug session", () => {
+    const decorations = breakpointDecorations([3, 7], undefined);
+    expect(decorations).toHaveLength(2);
+    expect(decorations.map((d) => d.range.startLineNumber)).toEqual([3, 7]);
+    expect(decorations.map((d) => d.options.glyphMarginClassName)).toEqual([
+      "bp-glyph",
+      "bp-glyph",
+    ]);
+  });
+
+  it("draws a resolved breakpoint on the line it snapped to", () => {
+    const resolved: ResolvedForFile = { 3: resolvedAt(5) };
+    const [decoration] = breakpointDecorations([3], resolved);
+    expect(decoration?.range).toEqual({
+      startLineNumber: 5,
+      startColumn: 1,
+      endLineNumber: 5,
+      endColumn: 1,
+    });
+    expect(decoration?.options.glyphMarginClassName).toBe("bp-glyph");
+  });
+
+  it("greys out a breakpoint the program could not resolve", () => {
+    const resolved: ResolvedForFile = { 3: null };
+    const [decoration] = breakpointDecorations([3], resolved);
+    expect(decoration?.range.startLineNumber).toBe(3);
+    expect(decoration?.options.glyphMarginClassName).toBe(
+      "bp-glyph-unverified",
+    );
+  });
+
+  // A breakpoint added mid-session has no entry until the worker answers.
+  it("greys out a breakpoint missing from the resolution map", () => {
+    const [decoration] = breakpointDecorations([9], { 3: resolvedAt(5) });
+    expect(decoration?.range.startLineNumber).toBe(9);
+    expect(decoration?.options.glyphMarginClassName).toBe(
+      "bp-glyph-unverified",
+    );
+  });
+});
+
+describe("requestedLineForClick", () => {
+  it("returns the clicked line when there is no session", () => {
+    expect(requestedLineForClick(4, undefined)).toBe(4);
+  });
+
+  it("maps a click on a snapped glyph back to the requested line", () => {
+    expect(requestedLineForClick(5, { 3: resolvedAt(5) })).toBe(3);
+  });
+
+  it("returns the clicked line when it is not a resolved target", () => {
+    expect(requestedLineForClick(9, { 3: resolvedAt(5) })).toBe(9);
+  });
+
+  it("ignores unresolved entries", () => {
+    expect(requestedLineForClick(3, { 3: null })).toBe(3);
+  });
+
+  it("keeps a self-resolving breakpoint on its own line", () => {
+    expect(requestedLineForClick(3, { 3: resolvedAt(3) })).toBe(3);
+  });
+
+  // Two requested lines can snap to the same instruction, stacking their
+  // glyphs; the click clears the lowest of them, so repeated clicks peel them
+  // off one at a time. Integer keys iterate in ascending order.
+  it("clears the lowest requested line when several snapped together", () => {
+    expect(
+      requestedLineForClick(5, { 3: resolvedAt(5), 4: resolvedAt(5) }),
+    ).toBe(3);
+  });
+});

--- a/editors/web/app/lib/breakpoint-gutter.ts
+++ b/editors/web/app/lib/breakpoint-gutter.ts
@@ -1,0 +1,51 @@
+// How the breakpoint store's per-file state becomes gutter glyphs, and how a
+// click on one maps back to the store entry that owns it.
+import type * as monaco from "monaco-editor";
+import type { ResolvedForFile } from "../stores/breakpoint-store";
+
+/**
+ * Build the gutter glyph decorations for a file's breakpoints. During a debug
+ * session breakpoints snap to their resolved line; unresolvable ones render
+ * greyed out. Outside a session (no resolution info) all render as-is.
+ */
+export function breakpointDecorations(
+  lines: number[] | undefined,
+  resolvedForFile: ResolvedForFile | undefined,
+): monaco.editor.IModelDeltaDecoration[] {
+  return (lines ?? []).map((line) => {
+    const entry = resolvedForFile?.[line];
+    const targetLine = entry ? entry.line : line;
+    const verified = resolvedForFile === undefined || Boolean(entry);
+    return {
+      range: {
+        startLineNumber: targetLine,
+        startColumn: 1,
+        endLineNumber: targetLine,
+        endColumn: 1,
+      },
+      options: {
+        glyphMarginClassName: verified ? "bp-glyph" : "bp-glyph-unverified",
+        stickiness: 1, // NeverGrowsWhenTypingAtEdges
+      },
+    };
+  });
+}
+
+/**
+ * Map a clicked gutter line back to the *requested* breakpoint line that owns
+ * it. During a session a breakpoint requested on line N renders its glyph at the
+ * resolved line M, so a click on M must toggle the N entry (removing it) rather
+ * than adding a fresh, never-resolving breakpoint at M. Falls back to the
+ * clicked line when it isn't a resolved target (i.e. a brand-new breakpoint).
+ */
+export function requestedLineForClick(
+  clickedLine: number,
+  resolvedForFile: ResolvedForFile | undefined,
+): number {
+  if (resolvedForFile) {
+    for (const [requested, entry] of Object.entries(resolvedForFile)) {
+      if (entry && entry.line === clickedLine) return Number(requested);
+    }
+  }
+  return clickedLine;
+}

--- a/editors/web/app/lib/computer-proxy.test.ts
+++ b/editors/web/app/lib/computer-proxy.test.ts
@@ -1,0 +1,467 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FakeWorker, installFakeWorker } from "../testing/fake-worker";
+import type { Cell, Registers } from "./wasm";
+import type { Snapshot, WorkerRequest } from "./emulator-protocol";
+
+// The proxy asks for the compiled binary in its constructor and forwards it to
+// the worker; nothing here instantiates it.
+const WASM_MODULE = { fake: "module" };
+vi.mock("./wasm-module", () => ({
+  compiledWasmModule: () => Promise.resolve(WASM_MODULE),
+}));
+
+type ProxyModule = typeof import("./computer-proxy");
+
+const REGISTERS: Registers = {
+  a: { type: "empty" },
+  b: { type: "empty" },
+  pc: 1000,
+  sp: 10_000,
+  sr: 0,
+};
+
+const word = (value: number): Cell => ({ type: "word", word: value });
+
+/** A callback the proxy invokes, typed as the void return it expects. */
+const listener = () => vi.fn((..._args: unknown[]): void => {});
+
+function snapshot(overrides: Partial<Snapshot> = {}): Snapshot {
+  return {
+    registers: REGISTERS,
+    cycles: 0,
+    changedCells: [],
+    status: "paused",
+    pc: 1000,
+    location: null,
+    output: [],
+    ...overrides,
+  };
+}
+
+/**
+ * A fresh copy of the module: it keeps one worker client in a module-level
+ * singleton, and a client that has failed stays failed.
+ */
+function freshModule(): Promise<ProxyModule> {
+  vi.resetModules();
+  installFakeWorker();
+  return import("./computer-proxy");
+}
+
+/**
+ * The worker's outbox as the protocol it carries. `FakeWorker` is
+ * protocol-agnostic, so the shape is asserted once, here.
+ */
+function sent(worker: FakeWorker): WorkerRequest[] {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return worker.sent as WorkerRequest[];
+}
+
+/** The request ids the client assigns are private; read them off the wire. */
+function idOf(request: WorkerRequest): number {
+  if (!("id" in request)) throw new Error("message carries no request id");
+  return request.id;
+}
+
+/**
+ * Wait for the client to post a request of this type and hand it back. The
+ * binary arrives asynchronously, so the `init` message can land either side of
+ * a request that was issued synchronously.
+ */
+function sentRequest(
+  worker: FakeWorker,
+  type: WorkerRequest["type"],
+): Promise<WorkerRequest> {
+  return vi.waitFor(() => {
+    const found = sent(worker).find((message) => message.type === type);
+    if (!found) throw new Error(`no ${type} request was posted`);
+    return found;
+  });
+}
+
+/** Start a session and return the worker plus the proxy it produced. */
+async function startAndAwaitSession(startSession: ProxyModule["startSession"]) {
+  const pending = startSession({ "a.s": "nop" }, "a.s", "main");
+  const worker = FakeWorker.last();
+  const request = await sentRequest(worker, "start");
+  worker.respond({
+    id: idOf(request),
+    type: "started",
+    labels: [["main", 1000]],
+    touchedFiles: ["a.s"],
+    snapshot: snapshot(),
+  });
+  const { proxy, labels, touchedFiles } = await pending;
+  return { worker, proxy, labels, touchedFiles };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("worker startup", () => {
+  it("spawns one module worker and hands it the compiled binary", async () => {
+    const { checkProgram } = await freshModule();
+    void checkProgram({ "a.s": "nop" }, "a.s");
+
+    const worker = FakeWorker.last();
+    expect(worker.scriptUrl).toContain("emulator.worker");
+    await vi.waitFor(() => {
+      expect(worker.sent).toContainEqual({
+        type: "init",
+        module: WASM_MODULE,
+      });
+    });
+  });
+
+  it("reuses the same worker across sessions", async () => {
+    const { checkProgram } = await freshModule();
+    void checkProgram({ "a.s": "nop" }, "a.s");
+    void checkProgram({ "a.s": "nop" }, "a.s");
+    expect(FakeWorker.instances).toHaveLength(1);
+  });
+});
+
+describe("request / response", () => {
+  it("resolves a check with the worker's result", async () => {
+    const { checkProgram } = await freshModule();
+    const pending = checkProgram({ "a.s": "nop" }, "a.s");
+    const worker = FakeWorker.last();
+
+    const request = await sentRequest(worker, "check");
+    expect(request).toMatchObject({
+      type: "check",
+      files: { "a.s": "nop" },
+      rootFile: "a.s",
+    });
+
+    worker.respond({
+      id: idOf(request),
+      type: "checked",
+      result: { type: "success", labels: ["main"] },
+    });
+    await expect(pending).resolves.toEqual({
+      type: "success",
+      labels: ["main"],
+    });
+  });
+
+  it("gives each request its own id and settles them independently", async () => {
+    const { checkProgram } = await freshModule();
+    const first = checkProgram({ "a.s": "" }, "a.s");
+    const second = checkProgram({ "b.s": "" }, "b.s");
+    const worker = FakeWorker.last();
+
+    const requests = await vi.waitFor(() => {
+      const found = sent(worker).filter((message) => "id" in message);
+      if (found.length !== 2) throw new Error("expected two requests");
+      return found;
+    });
+    const [one, two] = requests;
+    if (!one || !two) throw new Error("expected two requests");
+    expect(idOf(one)).not.toBe(idOf(two));
+
+    // Answering out of order still settles the right promise.
+    worker.respond({
+      id: idOf(two),
+      type: "checked",
+      result: { type: "error", message: "boom", labels: [] },
+    });
+    worker.respond({
+      id: idOf(one),
+      type: "checked",
+      result: { type: "success", labels: [] },
+    });
+    await expect(first).resolves.toMatchObject({ type: "success" });
+    await expect(second).resolves.toMatchObject({ message: "boom" });
+  });
+
+  it("rejects a session the worker could not compile", async () => {
+    const { startSession } = await freshModule();
+    const pending = startSession({ "a.s": "?" }, "a.s", "main");
+    const worker = FakeWorker.last();
+    const request = await sentRequest(worker, "start");
+
+    worker.respond({
+      id: idOf(request),
+      type: "startError",
+      error: "unknown instruction",
+    });
+    await expect(pending).rejects.toThrow("unknown instruction");
+  });
+
+  it("resolves a breakpoint through the running session", async () => {
+    const { startSession } = await freshModule();
+    const { worker, proxy } = await startAndAwaitSession(startSession);
+
+    const pending = proxy.resolveBreakpoint("a.s", 3);
+    const request = await sentRequest(worker, "resolveBreakpoint");
+    worker.respond({
+      id: idOf(request),
+      type: "resolved",
+      resolved: { line: 4, address: 1004 },
+    });
+    await expect(pending).resolves.toEqual({ line: 4, address: 1004 });
+  });
+});
+
+describe("session state", () => {
+  it("carries the labels and touched files out of the started frame", async () => {
+    const { startSession } = await freshModule();
+    const { labels, touchedFiles, proxy } =
+      await startAndAwaitSession(startSession);
+    expect(labels).toEqual([["main", 1000]]);
+    expect(touchedFiles).toEqual(["a.s"]);
+    expect(proxy.getStatus()).toBe("paused");
+    expect(proxy.registers()).toEqual(REGISTERS);
+  });
+
+  it("notifies subscribers of a pushed snapshot", async () => {
+    const { startSession } = await freshModule();
+    const { worker, proxy } = await startAndAwaitSession(startSession);
+
+    const registers = listener();
+    const cycles = listener();
+    const status = listener();
+    const output = listener();
+    proxy.subscribe_registers(registers);
+    proxy.subscribe_cycles(cycles);
+    proxy.subscribeStatus(status);
+    proxy.onOutput(output);
+
+    worker.respond({
+      type: "snapshot",
+      snapshot: snapshot({
+        cycles: 12,
+        status: "running",
+        output: [72, 105],
+        registers: { ...REGISTERS, pc: 1004 },
+      }),
+    });
+
+    expect(registers).toHaveBeenCalledWith({ ...REGISTERS, pc: 1004 });
+    expect(cycles).toHaveBeenCalledWith(12);
+    expect(status).toHaveBeenCalledWith("running");
+    expect(output).toHaveBeenCalledWith([72, 105]);
+    expect(proxy.cycles()).toBe(12);
+    expect(proxy.getStatus()).toBe("running");
+  });
+
+  it("holds the cycle count and status steady when they do not move", async () => {
+    const { startSession } = await freshModule();
+    const { worker, proxy } = await startAndAwaitSession(startSession);
+    const cycles = listener();
+    const status = listener();
+    proxy.subscribe_cycles(cycles);
+    proxy.subscribeStatus(status);
+
+    worker.respond({ type: "snapshot", snapshot: snapshot() });
+    expect(cycles).not.toHaveBeenCalled();
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it("keeps the panic message off a snapshot that is not a panic", async () => {
+    const { startSession } = await freshModule();
+    const { worker, proxy } = await startAndAwaitSession(startSession);
+
+    worker.respond({
+      type: "snapshot",
+      snapshot: snapshot({ status: "panicked", error: "divide by zero" }),
+    });
+    expect(proxy.getError()).toBe("divide by zero");
+
+    worker.respond({
+      type: "snapshot",
+      snapshot: snapshot({ status: "paused" }),
+    });
+    expect(proxy.getError()).toBeNull();
+  });
+
+  it("defaults a panic with no message", async () => {
+    const { startSession } = await freshModule();
+    const { worker, proxy } = await startAndAwaitSession(startSession);
+    worker.respond({
+      type: "snapshot",
+      snapshot: snapshot({ status: "panicked" }),
+    });
+    expect(proxy.getError()).toBe("panicked");
+  });
+});
+
+describe("watched memory", () => {
+  it("watches an address on the first subscriber and drops it on the last", async () => {
+    const { startSession } = await freshModule();
+    const { worker, proxy } = await startAndAwaitSession(startSession);
+    const watchTraffic = () =>
+      sent(worker).filter(
+        (m) => m.type === "watchCells" || m.type === "unwatchCells",
+      );
+
+    const unsubscribeFirst = proxy.subscribe_memory(1000, listener());
+    const unsubscribeSecond = proxy.subscribe_memory(1000, listener());
+    expect(watchTraffic()).toEqual([{ type: "watchCells", addresses: [1000] }]);
+
+    unsubscribeFirst();
+    expect(watchTraffic()).toHaveLength(1);
+
+    unsubscribeSecond();
+    expect(watchTraffic().at(-1)).toEqual({
+      type: "unwatchCells",
+      addresses: [1000],
+    });
+  });
+
+  it("reads an unwatched address as an empty cell", async () => {
+    const { startSession } = await freshModule();
+    const { proxy } = await startAndAwaitSession(startSession);
+    expect(proxy.memory(4242)).toEqual({ type: "empty" });
+  });
+
+  it("caches pushed cells and notifies that address only", async () => {
+    const { startSession } = await freshModule();
+    const { worker, proxy } = await startAndAwaitSession(startSession);
+    const watcher = listener();
+    proxy.subscribe_memory(1000, watcher);
+
+    worker.respond({
+      type: "cells",
+      cells: [
+        [1000, word(7)],
+        [1001, word(8)],
+      ],
+    });
+
+    expect(watcher).toHaveBeenCalledExactlyOnceWith(word(7));
+    expect(proxy.memory(1000)).toEqual(word(7));
+    expect(proxy.memory(1001)).toEqual(word(8));
+  });
+
+  it("delivers the cells a snapshot changed", async () => {
+    const { startSession } = await freshModule();
+    const { worker, proxy } = await startAndAwaitSession(startSession);
+    const watcher = listener();
+    proxy.subscribe_memory(1000, watcher);
+
+    worker.respond({
+      type: "snapshot",
+      snapshot: snapshot({ changedCells: [[1000, word(9)]] }),
+    });
+    expect(watcher).toHaveBeenCalledWith(word(9));
+  });
+
+  it("stops notifying an unsubscribed watcher", async () => {
+    const { startSession } = await freshModule();
+    const { worker, proxy } = await startAndAwaitSession(startSession);
+    const watcher = listener();
+    proxy.subscribe_memory(1000, watcher)();
+
+    worker.respond({ type: "cells", cells: [[1000, word(7)]] });
+    expect(watcher).not.toHaveBeenCalled();
+  });
+});
+
+describe("execution controls", () => {
+  it("forwards each control to the worker", async () => {
+    const { startSession } = await freshModule();
+    const { worker, proxy } = await startAndAwaitSession(startSession);
+    const before = worker.sent.length;
+
+    proxy.step();
+    proxy.step(5);
+    proxy.run();
+    proxy.pause();
+    proxy.setSpeed(100);
+    proxy.setBreakpoints([1000, 1004]);
+    proxy.sendInput([65]);
+    proxy.dispose();
+
+    expect(sent(worker).slice(before)).toEqual([
+      { type: "step", n: 1 },
+      { type: "step", n: 5 },
+      { type: "run" },
+      { type: "pause" },
+      { type: "setSpeed", speed: 100 },
+      { type: "setBreakpoints", addresses: [1000, 1004] },
+      { type: "input", bytes: [65] },
+      { type: "stop" },
+    ]);
+  });
+
+  it("stops pushing state into a disposed proxy", async () => {
+    const { startSession } = await freshModule();
+    const { worker, proxy } = await startAndAwaitSession(startSession);
+    const cycles = listener();
+    proxy.subscribe_cycles(cycles);
+    proxy.dispose();
+
+    worker.respond({ type: "snapshot", snapshot: snapshot({ cycles: 99 }) });
+    expect(cycles).not.toHaveBeenCalled();
+    expect(proxy.cycles()).toBe(0);
+  });
+});
+
+describe("worker failure", () => {
+  it("rejects every in-flight request on a worker error frame", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { checkProgram } = await freshModule();
+    const pending = checkProgram({ "a.s": "" }, "a.s");
+    const worker = FakeWorker.last();
+    await sentRequest(worker, "check");
+
+    worker.respond({ type: "workerError", message: "wasm init failed" });
+    await expect(pending).rejects.toThrow("wasm init failed");
+  });
+
+  it("rejects a later request immediately, without posting it", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { checkProgram } = await freshModule();
+    void checkProgram({ "a.s": "" }, "a.s").catch(() => {});
+    const worker = FakeWorker.last();
+    await sentRequest(worker, "check");
+
+    worker.respond({ type: "workerError", message: "wasm init failed" });
+    const after = worker.sent.length;
+    await expect(checkProgram({ "a.s": "" }, "a.s")).rejects.toThrow(
+      "wasm init failed",
+    );
+    expect(worker.sent).toHaveLength(after);
+  });
+
+  it("turns a hard script failure into the same rejection", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { checkProgram } = await freshModule();
+    const pending = checkProgram({ "a.s": "" }, "a.s");
+    const worker = FakeWorker.last();
+    await sentRequest(worker, "check");
+
+    worker.crash("Unexpected token");
+    await expect(pending).rejects.toThrow(
+      "Emulator worker error: Unexpected token",
+    );
+  });
+
+  it("drops a live session into a panicked state", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { startSession } = await freshModule();
+    const { worker, proxy } = await startAndAwaitSession(startSession);
+    const status = listener();
+    proxy.subscribeStatus(status);
+
+    worker.respond({ type: "workerError", message: "worker died" });
+    expect(status).toHaveBeenCalledWith("panicked");
+    expect(proxy.getStatus()).toBe("panicked");
+    expect(proxy.getError()).toBe("worker died");
+  });
+
+  it("reports the failure once, however many frames arrive", async () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { checkProgram } = await freshModule();
+    void checkProgram({ "a.s": "" }, "a.s").catch(() => {});
+    const worker = FakeWorker.last();
+    await sentRequest(worker, "check");
+
+    worker.respond({ type: "workerError", message: "first" });
+    worker.crash("second");
+    expect(logged).toHaveBeenCalledOnce();
+  });
+});

--- a/editors/web/app/lib/file-paths.test.ts
+++ b/editors/web/app/lib/file-paths.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { stripLeadingSlash, toMonacoPath } from "./file-paths";
+
+describe("toMonacoPath", () => {
+  it("prefixes a store key with a slash", () => {
+    expect(toMonacoPath("fact.s")).toBe("/fact.s");
+    expect(toMonacoPath("lib/util.s")).toBe("/lib/util.s");
+    expect(toMonacoPath("")).toBe("/");
+  });
+});
+
+describe("stripLeadingSlash", () => {
+  it("strips exactly one leading slash", () => {
+    expect(stripLeadingSlash("/fact.s")).toBe("fact.s");
+    expect(stripLeadingSlash("//fact.s")).toBe("/fact.s");
+  });
+
+  it("leaves a path without a leading slash alone", () => {
+    expect(stripLeadingSlash("fact.s")).toBe("fact.s");
+    expect(stripLeadingSlash("a/b.s")).toBe("a/b.s");
+    expect(stripLeadingSlash("")).toBe("");
+  });
+});
+
+describe("round trip", () => {
+  it("recovers the store key from the Monaco path", () => {
+    for (const key of ["fact.s", "lib/util.s", "a b.s", "é.s"]) {
+      expect(stripLeadingSlash(toMonacoPath(key))).toBe(key);
+    }
+  });
+});

--- a/editors/web/app/lib/lsp-client.test.ts
+++ b/editors/web/app/lib/lsp-client.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FakeWorker, installFakeWorker } from "../testing/fake-worker";
+import { WORKER_ERROR, WORKER_INIT } from "../workers/worker-protocol";
+
+const WASM_MODULE = { fake: "module" };
+vi.mock("./wasm-module", () => ({
+  compiledWasmModule: () => Promise.resolve(WASM_MODULE),
+}));
+
+const LEGEND = { tokenTypes: ["keyword"], tokenModifiers: ["declaration"] };
+
+interface JsonRpcFrame {
+  jsonrpc: string;
+  id?: number | string;
+  method?: string;
+  params?: unknown;
+}
+
+/** A fresh copy of the module: it keeps the client in a module-level singleton. */
+function freshModule(): Promise<typeof import("./lsp-client")> {
+  vi.resetModules();
+  installFakeWorker();
+  return import("./lsp-client");
+}
+
+/** Everything the client has written to the JSON-RPC channel. */
+function frames(worker: FakeWorker): JsonRpcFrame[] {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return worker.sent.filter(
+    (message) =>
+      typeof message === "object" && message !== null && "jsonrpc" in message,
+  ) as JsonRpcFrame[];
+}
+
+/** Wait for the client to send this JSON-RPC method and hand back the frame. */
+function sentFrame(worker: FakeWorker, method: string): Promise<JsonRpcFrame> {
+  return vi.waitFor(() => {
+    const found = frames(worker).find((frame) => frame.method === method);
+    if (!found) throw new Error(`no ${method} frame was sent`);
+    return found;
+  });
+}
+
+/** Answer the client's `initialize` so its readiness promise resolves. */
+async function completeHandshake(worker: FakeWorker): Promise<void> {
+  const initialize = await sentFrame(worker, "initialize");
+  worker.respond({
+    jsonrpc: "2.0",
+    id: initialize.id,
+    result: { capabilities: { semanticTokensProvider: { legend: LEGEND } } },
+  });
+  await sentFrame(worker, "initialized");
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("startup", () => {
+  it("hands the worker the compiled binary and opens the handshake", async () => {
+    const { getLspClient } = await freshModule();
+    getLspClient();
+    const worker = FakeWorker.last();
+
+    expect(worker.scriptUrl).toContain("lsp.worker");
+    await vi.waitFor(() => {
+      expect(worker.sent).toContainEqual({
+        type: WORKER_INIT,
+        module: WASM_MODULE,
+      });
+    });
+
+    const initialize = await sentFrame(worker, "initialize");
+    expect(initialize.params).toMatchObject({
+      rootUri: null,
+      capabilities: { experimental: { commands: ["zorglub33.run"] } },
+    });
+  });
+
+  it("returns the same client on every call", async () => {
+    const { getLspClient } = await freshModule();
+    expect(getLspClient()).toBe(getLspClient());
+    expect(FakeWorker.instances).toHaveLength(1);
+  });
+
+  it("takes the semantic-tokens legend from the initialize result", async () => {
+    const { getLspClient } = await freshModule();
+    const client = getLspClient();
+    expect(client.legend).toBeNull();
+
+    await completeHandshake(FakeWorker.last());
+    await client.ready();
+    expect(client.legend).toEqual(LEGEND);
+  });
+
+  it("leaves the legend unset when the server offers no semantic tokens", async () => {
+    const { getLspClient } = await freshModule();
+    const client = getLspClient();
+    const worker = FakeWorker.last();
+    const initialize = await sentFrame(worker, "initialize");
+    worker.respond({
+      jsonrpc: "2.0",
+      id: initialize.id,
+      result: { capabilities: {} },
+    });
+
+    await client.ready();
+    expect(client.legend).toBeNull();
+  });
+});
+
+describe("notifications", () => {
+  it("holds a notification sent before the handshake finishes", async () => {
+    const { getLspClient } = await freshModule();
+    const client = getLspClient();
+    const worker = FakeWorker.last();
+
+    client.notify("zorglub33/workspaceFiles", { files: { "a.s": "nop" } });
+    expect(
+      frames(worker).some((f) => f.method === "zorglub33/workspaceFiles"),
+    ).toBe(false);
+
+    await completeHandshake(worker);
+    const held = await sentFrame(worker, "zorglub33/workspaceFiles");
+    expect(held.params).toEqual({ files: { "a.s": "nop" } });
+  });
+
+  it("fans a diagnostics notification out to its listeners", async () => {
+    const { getLspClient } = await freshModule();
+    const client = getLspClient();
+    const worker = FakeWorker.last();
+    await completeHandshake(worker);
+
+    const first = vi.fn((..._args: unknown[]): void => {});
+    const second = vi.fn((..._args: unknown[]): void => {});
+    client.onDiagnostics(first);
+    const unsubscribe = client.onDiagnostics(second);
+    unsubscribe();
+
+    worker.respond({
+      jsonrpc: "2.0",
+      method: "textDocument/publishDiagnostics",
+      params: { uri: "file:///a.s", diagnostics: [{ message: "boom" }] },
+    });
+
+    await vi.waitFor(() => {
+      expect(first).toHaveBeenCalledWith("file:///a.s", [{ message: "boom" }]);
+    });
+    expect(second).not.toHaveBeenCalled();
+  });
+});
+
+describe("worker failure", () => {
+  it("rejects readiness on the worker's error frame", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { getLspClient } = await freshModule();
+    const client = getLspClient();
+
+    FakeWorker.last().respond({
+      type: WORKER_ERROR,
+      message: "wasm init failed",
+    });
+    await expect(client.ready()).rejects.toThrow(
+      "LSP worker failed to start: wasm init failed",
+    );
+    await expect(client.request("textDocument/hover", {})).rejects.toThrow(
+      "wasm init failed",
+    );
+  });
+
+  it("rejects readiness on a hard script failure", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { getLspClient } = await freshModule();
+    const client = getLspClient();
+
+    FakeWorker.last().crash("Unexpected token");
+    await expect(client.ready()).rejects.toThrow("Unexpected token");
+  });
+
+  it("drops a notification that can no longer be delivered", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { getLspClient } = await freshModule();
+    const client = getLspClient();
+    const worker = FakeWorker.last();
+
+    worker.respond({ type: WORKER_ERROR, message: "wasm init failed" });
+    await expect(client.ready()).rejects.toThrow("wasm init failed");
+
+    client.notify("zorglub33/workspaceFiles", { files: {} });
+    // `notify` defers to the readiness promise, so give both of its handlers a
+    // turn before concluding that nothing was written.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(
+      frames(worker).some((f) => f.method === "zorglub33/workspaceFiles"),
+    ).toBe(false);
+  });
+
+  it("reports the failure once, however many times the worker dies", async () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { getLspClient } = await freshModule();
+    const client = getLspClient();
+    const worker = FakeWorker.last();
+
+    worker.respond({ type: WORKER_ERROR, message: "first" });
+    worker.crash("second");
+    await expect(client.ready()).rejects.toThrow("first");
+    expect(logged).toHaveBeenCalledOnce();
+  });
+
+  it("gives up on a handshake that never completes", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.useFakeTimers();
+    const { getLspClient } = await freshModule();
+    const client = getLspClient();
+    const readiness = expect(client.ready()).rejects.toThrow(
+      "LSP handshake timed out after 30000ms",
+    );
+
+    // The budget starts once the binary has been handed to the worker, which
+    // the mocked `compiledWasmModule` settles a microtask later.
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await readiness;
+  });
+});

--- a/editors/web/app/lib/lsp-monaco.ts
+++ b/editors/web/app/lib/lsp-monaco.ts
@@ -38,6 +38,7 @@ import type {
 } from "vscode-languageserver-protocol";
 import { useFileStore } from "../stores/file-store";
 import { getLspClient } from "./lsp-client";
+import { fixSemanticTokenLengths } from "./semantic-tokens";
 
 type Monaco = typeof monaco;
 type Disposable = monaco.IDisposable;
@@ -358,43 +359,6 @@ function registerProviders(
   );
 }
 
-const encoder = new TextEncoder();
-const decoder = new TextDecoder();
-
-/**
- * The server emits semantic-token *lengths* in UTF-8 bytes but token *offsets*
- * in UTF-16 code units. On lines with multi-byte characters (e.g. comments with
- * accents) that makes a token overrun the line, and Monaco rejects the whole
- * set. Rewrite each length from bytes to UTF-16 code units using the model text.
- */
-function fixSemanticTokenLengths(
-  model: monaco.editor.ITextModel,
-  tokens: SemanticTokens,
-): SemanticTokens {
-  const data = Array.from(tokens.data);
-  let line = 0;
-  let char = 0;
-  for (let i = 0; i < data.length; i += 5) {
-    const deltaLine = data[i] ?? 0;
-    const deltaStart = data[i + 1] ?? 0;
-    line += deltaLine;
-    char = deltaLine === 0 ? char + deltaStart : deltaStart;
-
-    const byteLength = data[i + 2] ?? 0;
-    const lineText = model.getLineContent(line + 1);
-    const rest = lineText.slice(char);
-    const restBytes = encoder.encode(rest);
-    const utf16Length =
-      byteLength >= restBytes.length
-        ? rest.length
-        : decoder.decode(restBytes.slice(0, byteLength)).length;
-    data[i + 2] = utf16Length;
-  }
-  return tokens.resultId === undefined
-    ? { data }
-    : { resultId: tokens.resultId, data };
-}
-
 async function registerSemanticTokens(
   m: Monaco,
   flush: FlushFn,
@@ -420,7 +384,11 @@ async function registerSemanticTokens(
           { textDocument: { uri: uriOf(model) } },
         );
         if (cancelled(token) || !result) return null;
-        return toSemanticTokens(fixSemanticTokenLengths(model, result));
+        // The server answers against the text it last received, so a token can
+        // name a line an edit has since removed; Monaco throws on those.
+        const lineText = (line: number) =>
+          line <= model.getLineCount() ? model.getLineContent(line) : "";
+        return toSemanticTokens(fixSemanticTokenLengths(result, lineText));
       },
       releaseDocumentSemanticTokens() {},
     }),

--- a/editors/web/app/lib/semantic-tokens.test.ts
+++ b/editors/web/app/lib/semantic-tokens.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { fixSemanticTokenLengths } from "./semantic-tokens";
+
+/**
+ * A `getLineContent` over a document given as an array of lines (1-based),
+ * empty past the end as the contract requires.
+ */
+const lines =
+  (...content: string[]) =>
+  (line: number): string =>
+    content[line - 1] ?? "";
+
+/** One token entry: [deltaLine, deltaStart, length, type, modifiers]. */
+const token = (
+  deltaLine: number,
+  deltaStart: number,
+  length: number,
+): number[] => [deltaLine, deltaStart, length, 0, 0];
+
+describe("fixSemanticTokenLengths", () => {
+  it("leaves ASCII lengths untouched", () => {
+    const fixed = fixSemanticTokenLengths(
+      { data: [...token(0, 0, 4), ...token(0, 5, 2)] },
+      lines("main: ld"),
+    );
+    expect(fixed.data).toEqual([...token(0, 0, 4), ...token(0, 5, 2)]);
+  });
+
+  // "é" is two UTF-8 bytes, so the server's byte length overshoots the line.
+  it("shortens a length that counted multi-byte characters", () => {
+    const fixed = fixSemanticTokenLengths(
+      { data: token(0, 0, 4) },
+      lines("héllo"),
+    );
+    expect(fixed.data).toEqual(token(0, 0, 3));
+  });
+
+  it("clamps a length that overruns the rest of the line", () => {
+    const fixed = fixSemanticTokenLengths(
+      { data: token(0, 2, 99) },
+      lines("héllo"),
+    );
+    expect(fixed.data).toEqual(token(0, 2, 3));
+  });
+
+  it("counts an astral character as its two UTF-16 code units", () => {
+    // "🙂" is four UTF-8 bytes and two UTF-16 code units.
+    const fixed = fixSemanticTokenLengths(
+      { data: token(0, 0, 4) },
+      lines("🙂ab"),
+    );
+    expect(fixed.data).toEqual(token(0, 0, 2));
+  });
+
+  it("tracks the running line and column across deltas", () => {
+    const fixed = fixSemanticTokenLengths(
+      {
+        data: [
+          ...token(0, 0, 3), // line 1, col 0: "ré", 3 bytes
+          ...token(0, 3, 4), // line 1, col 3: "sét", 4 bytes
+          ...token(2, 1, 2), // line 3, col 1: "ç", 2 bytes
+        ],
+      },
+      lines("ré sét", "", " ç"),
+    );
+    expect(fixed.data).toEqual([
+      ...token(0, 0, 2),
+      ...token(0, 3, 3),
+      ...token(2, 1, 1),
+    ]);
+  });
+
+  it("clamps a token on a line the document no longer has", () => {
+    const fixed = fixSemanticTokenLengths(
+      { data: [...token(0, 0, 2), ...token(5, 0, 3)] },
+      lines("ab"),
+    );
+    expect(fixed.data).toEqual([...token(0, 0, 2), ...token(5, 0, 0)]);
+  });
+
+  it("does not mutate the input token data", () => {
+    const data = token(0, 0, 4);
+    fixSemanticTokenLengths({ data }, lines("héllo"));
+    expect(data).toEqual(token(0, 0, 4));
+  });
+
+  it("keeps a result id when the server sent one", () => {
+    expect(fixSemanticTokenLengths({ data: [] }, lines(""))).toEqual({
+      data: [],
+    });
+    expect(
+      fixSemanticTokenLengths({ resultId: "7", data: [] }, lines("")),
+    ).toEqual({ resultId: "7", data: [] });
+  });
+});

--- a/editors/web/app/lib/semantic-tokens.ts
+++ b/editors/web/app/lib/semantic-tokens.ts
@@ -1,0 +1,41 @@
+import type { SemanticTokens } from "vscode-languageserver-protocol";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/**
+ * The server emits semantic-token *lengths* in UTF-8 bytes but token *offsets*
+ * in UTF-16 code units. On lines with multi-byte characters (e.g. comments with
+ * accents) that makes a token overrun the line, and Monaco rejects the whole
+ * set. Rewrite each length from bytes to UTF-16 code units.
+ *
+ * `getLineContent` takes a 1-based line number, like Monaco's model, and
+ * returns "" for a line past the end of the document.
+ */
+export function fixSemanticTokenLengths(
+  tokens: SemanticTokens,
+  getLineContent: (line: number) => string,
+): SemanticTokens {
+  const data = Array.from(tokens.data);
+  let line = 0;
+  let char = 0;
+  for (let i = 0; i < data.length; i += 5) {
+    const deltaLine = data[i] ?? 0;
+    const deltaStart = data[i + 1] ?? 0;
+    line += deltaLine;
+    char = deltaLine === 0 ? char + deltaStart : deltaStart;
+
+    const byteLength = data[i + 2] ?? 0;
+    const lineText = getLineContent(line + 1);
+    const rest = lineText.slice(char);
+    const restBytes = encoder.encode(rest);
+    const utf16Length =
+      byteLength >= restBytes.length
+        ? rest.length
+        : decoder.decode(restBytes.slice(0, byteLength)).length;
+    data[i + 2] = utf16Length;
+  }
+  return tokens.resultId === undefined
+    ? { data }
+    : { resultId: tokens.resultId, data };
+}

--- a/editors/web/app/monaco-file-editor.tsx
+++ b/editors/web/app/monaco-file-editor.tsx
@@ -4,13 +4,14 @@
 import { Editor } from "@monaco-editor/react";
 import type * as monaco from "monaco-editor";
 import { useEffect, useRef } from "react";
+import {
+  breakpointDecorations,
+  requestedLineForClick,
+} from "./lib/breakpoint-gutter";
 import { toMonacoPath } from "./lib/file-paths";
 import { initMonacoSync } from "./lib/monaco-sync";
 import { monacoApi } from "./monaco";
-import {
-  type ResolvedBreakpoint,
-  useBreakpointStore,
-} from "./stores/breakpoint-store";
+import { useBreakpointStore } from "./stores/breakpoint-store";
 import { useFileStore } from "./stores/file-store";
 import { useThemeStore } from "./stores/theme-store";
 
@@ -19,53 +20,6 @@ export type EditorProps = {
   readOnly?: boolean;
   onEditorMount?: (editor: monaco.editor.IStandaloneCodeEditor) => void;
 };
-
-/**
- * Build the gutter glyph decorations for a file's breakpoints. During a debug
- * session breakpoints snap to their resolved line; unresolvable ones render
- * greyed out. Outside a session (no resolution info) all render as-is.
- */
-function breakpointDecorations(
-  lines: number[] | undefined,
-  resolvedForFile: Record<number, ResolvedBreakpoint | null> | undefined,
-): monaco.editor.IModelDeltaDecoration[] {
-  return (lines ?? []).map((line) => {
-    const entry = resolvedForFile?.[line];
-    const targetLine = entry ? entry.line : line;
-    const verified = resolvedForFile === undefined || Boolean(entry);
-    return {
-      range: {
-        startLineNumber: targetLine,
-        startColumn: 1,
-        endLineNumber: targetLine,
-        endColumn: 1,
-      },
-      options: {
-        glyphMarginClassName: verified ? "bp-glyph" : "bp-glyph-unverified",
-        stickiness: 1, // NeverGrowsWhenTypingAtEdges
-      },
-    };
-  });
-}
-
-/**
- * Map a clicked gutter line back to the *requested* breakpoint line that owns
- * it. During a session a breakpoint requested on line N renders its glyph at the
- * resolved line M, so a click on M must toggle the N entry (removing it) rather
- * than adding a fresh, never-resolving breakpoint at M. Falls back to the
- * clicked line when it isn't a resolved target (i.e. a brand-new breakpoint).
- */
-function requestedLineForClick(
-  clickedLine: number,
-  resolvedForFile: Record<number, ResolvedBreakpoint | null> | undefined,
-): number {
-  if (resolvedForFile) {
-    for (const [requested, entry] of Object.entries(resolvedForFile)) {
-      if (entry && entry.line === clickedLine) return Number(requested);
-    }
-  }
-  return clickedLine;
-}
 
 const MonacoFileEditor: React.FC<EditorProps> = ({
   filePath,

--- a/editors/web/app/monaco-file-editor.tsx
+++ b/editors/web/app/monaco-file-editor.tsx
@@ -82,19 +82,6 @@ const MonacoFileEditor: React.FC<EditorProps> = ({
         editorRef.current = editor;
         decorationsRef.current = editor.createDecorationsCollection();
 
-        if (import.meta.env.DEV) {
-          // e2e hook: lets tests drive Monaco through its API instead of
-          // querying the rendered token-span DOM, whose slicing differs
-          // across platforms/builds.
-          (window as unknown as { __z33e2e?: unknown }).__z33e2e = {
-            showHoverAt(lineNumber: number, column: number) {
-              editor.setPosition({ lineNumber, column });
-              editor.focus();
-              editor.trigger("e2e", "editor.action.showHover", {});
-            },
-          };
-        }
-
         const glyphMargin =
           monacoInstance.editor.MouseTargetType.GUTTER_GLYPH_MARGIN;
         editor.onMouseDown((e) => {

--- a/editors/web/app/stores/breakpoint-store.test.ts
+++ b/editors/web/app/stores/breakpoint-store.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { rehydrateStore } from "../testing/rehydrate-store";
+import { useBreakpointStore } from "./breakpoint-store";
+import { BREAKPOINTS_STORAGE_KEY } from "./persist-keys";
+
+const rehydrateFrom = (state: unknown) =>
+  rehydrateStore(useBreakpointStore, BREAKPOINTS_STORAGE_KEY, state);
+
+beforeEach(() => {
+  useBreakpointStore.setState({ breakpoints: {}, resolved: {} });
+});
+
+describe("rehydration", () => {
+  it("loads well-formed breakpoints", async () => {
+    await rehydrateFrom({ breakpoints: { "a.s": [2, 5] } });
+    expect(useBreakpointStore.getState().breakpoints).toEqual({
+      "a.s": [2, 5],
+    });
+  });
+
+  it.each([null, "2", 2, [2], { "a.s": 2 }, { "a.s": ["2"] }, { "a.s": [0] }])(
+    "starts with no breakpoints when the payload holds %o",
+    async (breakpoints) => {
+      await rehydrateFrom({ breakpoints });
+      expect(useBreakpointStore.getState().breakpoints).toEqual({});
+    },
+  );
+
+  it("never restores resolution results, which belong to a session", async () => {
+    await rehydrateFrom({
+      breakpoints: { "a.s": [2] },
+      resolved: { "a.s": { 2: { line: 2, address: 1002 } } },
+    });
+    expect(useBreakpointStore.getState().resolved).toEqual({});
+  });
+});
+
+describe("toggle", () => {
+  it("adds a breakpoint to a file that had none", () => {
+    useBreakpointStore.getState().toggle("a.s", 4);
+    expect(useBreakpointStore.getState().breakpoints).toEqual({ "a.s": [4] });
+  });
+
+  it("keeps the lines of a file sorted", () => {
+    for (const line of [7, 2, 5])
+      useBreakpointStore.getState().toggle("a.s", line);
+    expect(useBreakpointStore.getState().breakpoints["a.s"]).toEqual([2, 5, 7]);
+  });
+
+  it("removes a line that was already set", () => {
+    useBreakpointStore.getState().toggle("a.s", 2);
+    useBreakpointStore.getState().toggle("a.s", 5);
+    useBreakpointStore.getState().toggle("a.s", 2);
+    expect(useBreakpointStore.getState().breakpoints).toEqual({ "a.s": [5] });
+  });
+
+  it("drops the file once its last breakpoint goes", () => {
+    useBreakpointStore.getState().toggle("a.s", 2);
+    useBreakpointStore.getState().toggle("a.s", 2);
+    expect(useBreakpointStore.getState().breakpoints).toEqual({});
+  });
+
+  it("keeps files independent", () => {
+    useBreakpointStore.getState().toggle("a.s", 2);
+    useBreakpointStore.getState().toggle("b.s", 2);
+    useBreakpointStore.getState().toggle("a.s", 2);
+    expect(useBreakpointStore.getState().breakpoints).toEqual({ "b.s": [2] });
+  });
+});
+
+describe("resolution results", () => {
+  it("replaces the whole map, then clears it", () => {
+    const resolved = { "a.s": { 2: { line: 3, address: 1003 } } };
+    useBreakpointStore.getState().setResolved(resolved);
+    expect(useBreakpointStore.getState().resolved).toEqual(resolved);
+    useBreakpointStore.getState().clearResolved();
+    expect(useBreakpointStore.getState().resolved).toEqual({});
+  });
+});

--- a/editors/web/app/stores/breakpoint-store.ts
+++ b/editors/web/app/stores/breakpoint-store.ts
@@ -1,8 +1,8 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import type { ResolvedBreakpoint } from "../lib/wasm";
-
-const BREAKPOINTS_KEY = "z33:breakpoints";
+import { BREAKPOINTS_STORAGE_KEY } from "./persist-keys";
+import { lineNumberRecord, persistedField } from "./persisted";
 
 /** Resolution results for one file: requested line -> resolved info, or null. */
 export type ResolvedForFile = Record<number, ResolvedBreakpoint | null>;
@@ -51,9 +51,15 @@ export const useBreakpointStore = create<BreakpointState & BreakpointActions>()(
       },
     }),
     {
-      name: BREAKPOINTS_KEY,
+      name: BREAKPOINTS_STORAGE_KEY,
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({ breakpoints: state.breakpoints }),
+      merge: (persisted, current) => ({
+        ...current,
+        breakpoints:
+          lineNumberRecord(persistedField(persisted, "breakpoints")) ??
+          current.breakpoints,
+      }),
     },
   ),
 );

--- a/editors/web/app/stores/breakpoint-store.ts
+++ b/editors/web/app/stores/breakpoint-store.ts
@@ -4,14 +4,11 @@ import type { ResolvedBreakpoint } from "../lib/wasm";
 
 const BREAKPOINTS_KEY = "z33:breakpoints";
 
-/** A breakpoint resolved against a compiled program (tsify-generated type). */
-export type { ResolvedBreakpoint };
+/** Resolution results for one file: requested line -> resolved info, or null. */
+export type ResolvedForFile = Record<number, ResolvedBreakpoint | null>;
 
-/** Resolution result per file: requested line -> resolved info (or null). */
-export type ResolvedMap = Record<
-  string,
-  Record<number, ResolvedBreakpoint | null>
->;
+/** Resolution results for every file, keyed by file store key. */
+export type ResolvedMap = Record<string, ResolvedForFile>;
 
 interface BreakpointState {
   /** Requested breakpoint lines (1-based) per file store key. Persisted. */

--- a/editors/web/app/stores/display-store.test.ts
+++ b/editors/web/app/stores/display-store.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { rehydrateStore } from "../testing/rehydrate-store";
+import { useDisplayStore } from "./display-store";
+import { DISPLAY_STORAGE_KEY } from "./persist-keys";
+
+const rehydrateFrom = (state: unknown) =>
+  rehydrateStore(useDisplayStore, DISPLAY_STORAGE_KEY, state);
+
+beforeEach(() => {
+  useDisplayStore.setState({ format: "decimal" });
+});
+
+describe("setFormat", () => {
+  it("switches between the three bases", () => {
+    for (const format of ["hex", "binary", "decimal"] as const) {
+      useDisplayStore.getState().setFormat(format);
+      expect(useDisplayStore.getState().format).toBe(format);
+    }
+  });
+});
+
+describe("rehydration", () => {
+  it("loads a known format", async () => {
+    await rehydrateFrom({ format: "hex" });
+    expect(useDisplayStore.getState().format).toBe("hex");
+  });
+
+  // `formatWord` and `formatAddress` switch exhaustively and throw on anything
+  // else, which takes the whole debug view down with them.
+  it.each(["octal", "", 3, null, ["hex"]])(
+    "falls back to decimal on the unknown format %o",
+    async (format) => {
+      await rehydrateFrom({ format });
+      expect(useDisplayStore.getState().format).toBe("decimal");
+    },
+  );
+
+  it("falls back to decimal on a payload that is not an object", async () => {
+    await rehydrateFrom("hex");
+    expect(useDisplayStore.getState().format).toBe("decimal");
+  });
+});

--- a/editors/web/app/stores/display-store.ts
+++ b/editors/web/app/stores/display-store.ts
@@ -1,7 +1,11 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { DISPLAY_STORAGE_KEY } from "./persist-keys";
+import { oneOf, persistedField } from "./persisted";
 
 export type DisplayFormat = "decimal" | "hex" | "binary";
+
+const DISPLAY_FORMATS: readonly DisplayFormat[] = ["decimal", "hex", "binary"];
 
 interface DisplayState {
   format: DisplayFormat;
@@ -16,6 +20,17 @@ export const useDisplayStore = create<DisplayState>()(
         set({ format });
       },
     }),
-    { name: "z33:display" },
+    {
+      name: DISPLAY_STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+      // Every formatter switches exhaustively on this, so a format that is no
+      // longer one of the three throws on the next render of a memory cell.
+      merge: (persisted, current) => ({
+        ...current,
+        format:
+          oneOf(DISPLAY_FORMATS, persistedField(persisted, "format")) ??
+          current.format,
+      }),
+    },
   ),
 );

--- a/editors/web/app/stores/file-store.test.ts
+++ b/editors/web/app/stores/file-store.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { rehydrateStore } from "../testing/rehydrate-store";
+import { useFileStore } from "./file-store";
+import {
+  WORKSPACE_PERSIST_VERSION,
+  WORKSPACE_STORAGE_KEY,
+} from "./persist-keys";
+
+const defaults = {
+  files: useFileStore.getState().files,
+  activeFile: useFileStore.getState().activeFile,
+  entrypoints: useFileStore.getState().entrypoints,
+};
+
+const rehydrateFrom = (state: unknown) =>
+  rehydrateStore(
+    useFileStore,
+    WORKSPACE_STORAGE_KEY,
+    state,
+    WORKSPACE_PERSIST_VERSION,
+  );
+
+beforeEach(() => {
+  useFileStore.setState(defaults);
+});
+
+describe("defaults", () => {
+  it("starts on the bundled samples", () => {
+    expect(Object.keys(defaults.files)).toContain("fact.s");
+    expect(defaults.activeFile).toBe("fact.s");
+    expect(defaults.entrypoints).toEqual({});
+  });
+});
+
+describe("rehydration", () => {
+  it("loads a well-formed workspace", async () => {
+    await rehydrateFrom({
+      files: { "a.s": "nop", "b.s": "" },
+      activeFile: "b.s",
+      entrypoints: { "a.s": "main" },
+    });
+    const state = useFileStore.getState();
+    expect(state.files).toEqual({ "a.s": "nop", "b.s": "" });
+    expect(state.activeFile).toBe("b.s");
+    expect(state.entrypoints).toEqual({ "a.s": "main" });
+  });
+
+  it.each([null, "a.s", 42, ["a.s"], { "a.s": 3 }])(
+    "keeps the sample files when the persisted map is %o",
+    async (files) => {
+      await rehydrateFrom({ files, activeFile: "a.s", entrypoints: {} });
+      expect(useFileStore.getState().files).toEqual(defaults.files);
+    },
+  );
+
+  it("falls back to a file that exists when the persisted name is not a string", async () => {
+    await rehydrateFrom({ files: { "a.s": "nop", "b.s": "" }, activeFile: 3 });
+    expect(useFileStore.getState().activeFile).toBe("a.s");
+  });
+
+  it("falls back to a file that exists when the persisted name is not among them", async () => {
+    await rehydrateFrom({ files: { "a.s": "nop" }, activeFile: "gone.s" });
+    expect(useFileStore.getState().activeFile).toBe("a.s");
+  });
+
+  // The mirror: an active file that only made sense beside the files it was
+  // saved with cannot stand once those fall back to the samples.
+  it("reconciles the active file when only the file map fell back", async () => {
+    await rehydrateFrom({ files: 42, activeFile: "gone.s" });
+    const state = useFileStore.getState();
+    expect(state.files).toEqual(defaults.files);
+    expect(state.activeFile).toBe(defaults.activeFile);
+  });
+
+  it("keeps empty entrypoints when the persisted ones are malformed", async () => {
+    await rehydrateFrom({
+      files: { "a.s": "nop" },
+      activeFile: "a.s",
+      entrypoints: ["main"],
+    });
+    expect(useFileStore.getState().entrypoints).toEqual({});
+  });
+
+  it("falls back entirely on a payload that is not an object", async () => {
+    await rehydrateFrom("nonsense");
+    const state = useFileStore.getState();
+    expect(state.files).toEqual(defaults.files);
+    expect(state.activeFile).toBe(defaults.activeFile);
+  });
+
+  it("keeps an empty workspace, which is reachable by deleting every file", async () => {
+    await rehydrateFrom({ files: {}, activeFile: "", entrypoints: {} });
+    const state = useFileStore.getState();
+    expect(state.files).toEqual({});
+    expect(state.activeFile).toBe("");
+  });
+});
+
+describe("createFile", () => {
+  it("adds a file and makes it active", () => {
+    useFileStore.getState().createFile("new.s", "nop");
+    const state = useFileStore.getState();
+    expect(state.files["new.s"]).toBe("nop");
+    expect(state.activeFile).toBe("new.s");
+  });
+
+  it("defaults the content to empty", () => {
+    useFileStore.getState().createFile("new.s");
+    expect(useFileStore.getState().files["new.s"]).toBe("");
+  });
+
+  it("does not overwrite an existing file, but does switch to it", () => {
+    useFileStore.getState().createFile("keep.s", "original");
+    useFileStore.getState().setActiveFile("fact.s");
+    useFileStore.getState().createFile("keep.s", "replacement");
+    const state = useFileStore.getState();
+    expect(state.files["keep.s"]).toBe("original");
+    expect(state.activeFile).toBe("keep.s");
+  });
+});
+
+describe("deleteFile", () => {
+  it("removes the file and leaves the active one alone", () => {
+    useFileStore.getState().createFile("gone.s", "nop");
+    useFileStore.getState().setActiveFile("fact.s");
+    useFileStore.getState().deleteFile("gone.s");
+    const state = useFileStore.getState();
+    expect("gone.s" in state.files).toBe(false);
+    expect(state.activeFile).toBe("fact.s");
+  });
+
+  it("moves to another file when the active one goes", () => {
+    useFileStore.getState().createFile("gone.s", "nop");
+    useFileStore.getState().deleteFile("gone.s");
+    const state = useFileStore.getState();
+    expect(state.activeFile).not.toBe("gone.s");
+    expect(Object.keys(state.files)).toContain(state.activeFile);
+  });
+
+  it("leaves no active file once the last one goes", () => {
+    useFileStore.setState({ files: { "only.s": "nop" }, activeFile: "only.s" });
+    useFileStore.getState().deleteFile("only.s");
+    const state = useFileStore.getState();
+    expect(state.files).toEqual({});
+    expect(state.activeFile).toBe("");
+  });
+
+  it("ignores a file that is not there", () => {
+    useFileStore.getState().deleteFile("absent.s");
+    expect(useFileStore.getState().files).toEqual(defaults.files);
+  });
+});
+
+describe("content updates", () => {
+  it("writes content from Monaco and from the outside alike", () => {
+    useFileStore.getState().onMonacoEdit("fact.s", "typed");
+    expect(useFileStore.getState().files["fact.s"]).toBe("typed");
+    useFileStore.getState().setContent("fact.s", "uploaded");
+    expect(useFileStore.getState().files["fact.s"]).toBe("uploaded");
+  });
+
+  it("resets to the samples, dropping files created since", () => {
+    useFileStore.getState().createFile("scratch.s", "nop");
+    useFileStore.getState().onMonacoEdit("fact.s", "clobbered");
+    useFileStore.getState().resetFiles();
+    const state = useFileStore.getState();
+    expect(state.files).toEqual(defaults.files);
+    expect(state.activeFile).toBe(defaults.activeFile);
+  });
+});
+
+describe("setEntrypoint", () => {
+  it("records one entrypoint per file", () => {
+    useFileStore.getState().setEntrypoint("fact.s", "main");
+    useFileStore.getState().setEntrypoint("echo.s", "start");
+    useFileStore.getState().setEntrypoint("fact.s", "other");
+    expect(useFileStore.getState().entrypoints).toEqual({
+      "fact.s": "other",
+      "echo.s": "start",
+    });
+  });
+});

--- a/editors/web/app/stores/file-store.ts
+++ b/editors/web/app/stores/file-store.ts
@@ -4,6 +4,7 @@ import {
   WORKSPACE_PERSIST_VERSION,
   WORKSPACE_STORAGE_KEY,
 } from "./persist-keys";
+import { persistedField, stringRecord } from "./persisted";
 
 const sampleFiles = Object.fromEntries(
   Object.entries(
@@ -16,6 +17,21 @@ const sampleFiles = Object.fromEntries(
 );
 
 const initial = { files: sampleFiles, activeFile: "fact.s" };
+
+/**
+ * The file the editor opens on. It has to be one of the files beside it, or
+ * the editor opens on a name nothing answers to; only an empty workspace has
+ * no active file. Candidates are tried in order of preference.
+ */
+function reconcileActiveFile(
+  files: Record<string, string>,
+  ...candidates: unknown[]
+): string {
+  for (const name of candidates) {
+    if (typeof name === "string" && Object.hasOwn(files, name)) return name;
+  }
+  return Object.keys(files)[0] ?? "";
+}
 
 interface FileState {
   files: Record<string, string>; // filename (no leading slash) → content
@@ -98,6 +114,22 @@ export const useFileStore = create<FileState & FileActions>()(
         activeFile: state.activeFile,
         entrypoints: state.entrypoints,
       }),
+      merge: (persisted, current) => {
+        const files =
+          stringRecord(persistedField(persisted, "files")) ?? current.files;
+        return {
+          ...current,
+          files,
+          activeFile: reconcileActiveFile(
+            files,
+            persistedField(persisted, "activeFile"),
+            current.activeFile,
+          ),
+          entrypoints:
+            stringRecord(persistedField(persisted, "entrypoints")) ??
+            current.entrypoints,
+        };
+      },
     },
   ),
 );

--- a/editors/web/app/stores/persist-keys.ts
+++ b/editors/web/app/stores/persist-keys.ts
@@ -1,10 +1,27 @@
-// Persistence identifiers for the workspace store, kept in a dependency-free
-// leaf module so they can be shared with e2e fixtures. Importing `file-store`
-// itself from the Playwright process would eval Vite-only macros
-// (`import.meta.glob`) and fail, so the single source of truth lives here.
+// The localStorage keys every persisted store writes under, kept in a
+// dependency-free leaf module so they can be shared with e2e fixtures and
+// tests. Importing a store itself from the Playwright process would eval
+// Vite-only macros (`import.meta.glob`) and fail, so the single source of
+// truth lives here.
 
 /** localStorage key holding the persisted workspace (files + entrypoints). */
 export const WORKSPACE_STORAGE_KEY = "z33:workspace-v2";
 
 /** Schema version of the persisted workspace payload (zustand `persist`). */
 export const WORKSPACE_PERSIST_VERSION = 0;
+
+/** localStorage key holding the requested breakpoint lines per file. */
+export const BREAKPOINTS_STORAGE_KEY = "z33:breakpoints";
+
+/**
+ * localStorage key holding the chosen theme. The bootstrap script in
+ * index.html reads it too, spelled out, so renaming it here means renaming it
+ * there (see theme-store.ts).
+ */
+export const THEME_STORAGE_KEY = "z33:theme";
+
+/** localStorage key holding the number display format. */
+export const DISPLAY_STORAGE_KEY = "z33:display";
+
+/** localStorage key holding the target clock speed. */
+export const SPEED_STORAGE_KEY = "z33:speed";

--- a/editors/web/app/stores/persisted.test.ts
+++ b/editors/web/app/stores/persisted.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  lineNumberRecord,
+  oneOf,
+  persistedField,
+  stringRecord,
+} from "./persisted";
+
+describe("persistedField", () => {
+  it("reads a present field", () => {
+    expect(persistedField({ theme: "dark" }, "theme")).toBe("dark");
+    expect(persistedField({ speed: 0 }, "speed")).toBe(0);
+    expect(persistedField({ speed: null }, "speed")).toBeNull();
+  });
+
+  it("returns undefined for a missing field", () => {
+    expect(persistedField({}, "theme")).toBeUndefined();
+  });
+
+  it("returns undefined for a payload that is not an object", () => {
+    for (const payload of [null, undefined, "dark", 3, true]) {
+      expect(persistedField(payload, "theme")).toBeUndefined();
+    }
+  });
+
+  it("reads through an array payload by index", () => {
+    expect(persistedField(["a", "b"], "1")).toBe("b");
+  });
+
+  // A payload straight out of JSON.parse inherits Object.prototype, so every
+  // method on it is a name the payload appears to carry.
+  it("reads own properties only", () => {
+    expect(persistedField({}, "toString")).toBeUndefined();
+    expect(persistedField({}, "constructor")).toBeUndefined();
+    expect(persistedField({}, "hasOwnProperty")).toBeUndefined();
+  });
+});
+
+describe("oneOf", () => {
+  const themes = ["dark", "light", "system"] as const;
+
+  it("accepts a member of the union", () => {
+    expect(oneOf(themes, "dark")).toBe("dark");
+    expect(oneOf(themes, "system")).toBe("system");
+  });
+
+  it("rejects anything else", () => {
+    for (const value of [
+      "DARK",
+      "",
+      "toString",
+      0,
+      null,
+      undefined,
+      {},
+      ["dark"],
+    ]) {
+      expect(oneOf(themes, value)).toBeUndefined();
+    }
+  });
+});
+
+describe("stringRecord", () => {
+  it("accepts a map of strings", () => {
+    expect(stringRecord({})).toEqual({});
+    expect(stringRecord({ "a.s": "nop", "b.s": "" })).toEqual({
+      "a.s": "nop",
+      "b.s": "",
+    });
+  });
+
+  it("rejects a non-object", () => {
+    for (const value of [null, undefined, "a.s", 3, true]) {
+      expect(stringRecord(value)).toBeUndefined();
+    }
+  });
+
+  it("rejects an array", () => {
+    expect(stringRecord(["a.s"])).toBeUndefined();
+    expect(stringRecord([])).toBeUndefined();
+  });
+
+  it("rejects a map with a non-string value", () => {
+    expect(stringRecord({ "a.s": "nop", "b.s": 3 })).toBeUndefined();
+    expect(stringRecord({ "a.s": null })).toBeUndefined();
+    expect(stringRecord({ "a.s": ["nop"] })).toBeUndefined();
+  });
+});
+
+describe("lineNumberRecord", () => {
+  it("accepts a map of line-number arrays", () => {
+    expect(lineNumberRecord({})).toEqual({});
+    expect(lineNumberRecord({ "a.s": [], "b.s": [1, 2] })).toEqual({
+      "a.s": [],
+      "b.s": [1, 2],
+    });
+  });
+
+  it("rejects a non-object", () => {
+    for (const value of [null, undefined, "a.s", 3]) {
+      expect(lineNumberRecord(value)).toBeUndefined();
+    }
+  });
+
+  it("rejects an array", () => {
+    expect(lineNumberRecord([[1, 2]])).toBeUndefined();
+  });
+
+  it("rejects a map whose values are not arrays of numbers", () => {
+    expect(lineNumberRecord({ "a.s": 3 })).toBeUndefined();
+    expect(lineNumberRecord({ "a.s": "12" })).toBeUndefined();
+    expect(lineNumberRecord({ "a.s": [1, "2"] })).toBeUndefined();
+    expect(lineNumberRecord({ "a.s": [1, null] })).toBeUndefined();
+  });
+
+  it("rejects numbers that could not be a 1-based line", () => {
+    for (const line of [-5, 0, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(lineNumberRecord({ "a.s": [line] })).toBeUndefined();
+      expect(lineNumberRecord({ "a.s": [1, line, 3] })).toBeUndefined();
+    }
+  });
+});

--- a/editors/web/app/stores/persisted.ts
+++ b/editors/web/app/stores/persisted.ts
@@ -1,0 +1,62 @@
+// Shape checks for the payloads the zustand `persist` middleware reads back out
+// of localStorage. That storage is user-editable and outlives every schema
+// change the app has ever made, so a store's `merge` re-checks each field it
+// takes from it and keeps its default when the check fails.
+
+/** One field of an unvalidated `persist` payload, or undefined if absent. */
+export function persistedField(persisted: unknown, key: string): unknown {
+  if (typeof persisted !== "object" || persisted === null) return undefined;
+  // Own properties only: `in` would answer for every name on Object.prototype.
+  if (!Object.hasOwn(persisted, key)) return undefined;
+  // The payload is JSON of unknown shape; the caller narrows the value.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return (persisted as Record<string, unknown>)[key];
+}
+
+/** `value` if it is one of `values`, otherwise undefined. */
+export function oneOf<T extends string>(
+  values: readonly T[],
+  value: unknown,
+): T | undefined {
+  return typeof value === "string" &&
+    (values as readonly string[]).includes(value)
+    ? // The includes() above is the narrowing TypeScript cannot express here.
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+      (value as T)
+    : undefined;
+}
+
+/** `value` if it maps every key to a string, otherwise undefined. */
+export function stringRecord(
+  value: unknown,
+): Record<string, string> | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const entries = Object.entries(value);
+  if (entries.some(([, item]) => typeof item !== "string")) return undefined;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return value as Record<string, string>;
+}
+
+/**
+ * `value` if it maps every key to an array of line numbers, otherwise
+ * undefined. Lines are 1-based integers, so anything below 1 or fractional
+ * could never name a line in the editor.
+ */
+export function lineNumberRecord(
+  value: unknown,
+): Record<string, number[]> | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const entries = Object.entries(value);
+  const valid = entries.every(
+    ([, item]) =>
+      Array.isArray(item) &&
+      item.every((line) => Number.isInteger(line) && line >= 1),
+  );
+  if (!valid) return undefined;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return value as Record<string, number[]>;
+}

--- a/editors/web/app/stores/speed-store.test.ts
+++ b/editors/web/app/stores/speed-store.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { rehydrateStore } from "../testing/rehydrate-store";
+import { SPEED_STORAGE_KEY } from "./persist-keys";
+import { SPEED_OPTIONS, useSpeedStore } from "./speed-store";
+
+const rehydrateFrom = (state: unknown) =>
+  rehydrateStore(useSpeedStore, SPEED_STORAGE_KEY, state);
+
+beforeEach(() => {
+  useSpeedStore.setState({ speed: null });
+});
+
+describe("SPEED_OPTIONS", () => {
+  it("offers full speed plus descending presets", () => {
+    expect(SPEED_OPTIONS[0]?.speed).toBeNull();
+    const paced = SPEED_OPTIONS.slice(1).map((o) => o.speed);
+    expect(paced).toEqual(paced.toSorted((a, b) => Number(b) - Number(a)));
+  });
+});
+
+describe("setSpeed", () => {
+  it("stores a preset and full speed alike", () => {
+    useSpeedStore.getState().setSpeed(100);
+    expect(useSpeedStore.getState().speed).toBe(100);
+    useSpeedStore.getState().setSpeed(null);
+    expect(useSpeedStore.getState().speed).toBeNull();
+  });
+});
+
+describe("rehydration", () => {
+  // Max is `null`, which is also the default, so rehydrating onto the initial
+  // state would let that row pass without the validator ever accepting it.
+  // Park the store on another preset first and rehydrate over it.
+  it.each(SPEED_OPTIONS)("loads the $label preset", async ({ speed }) => {
+    useSpeedStore.setState({ speed: 1000 });
+    localStorage.setItem(
+      SPEED_STORAGE_KEY,
+      JSON.stringify({ state: { speed } }),
+    );
+    await useSpeedStore.persist.rehydrate();
+    expect(useSpeedStore.getState().speed).toBe(speed);
+  });
+
+  it.each([7, 0, -1, "1000", null, undefined, {}])(
+    "falls back to full speed on %o, which is not a preset",
+    async (speed) => {
+      await rehydrateFrom({ speed });
+      expect(useSpeedStore.getState().speed).toBeNull();
+    },
+  );
+
+  it("falls back to full speed on a payload that is not an object", async () => {
+    await rehydrateFrom(1000);
+    expect(useSpeedStore.getState().speed).toBeNull();
+  });
+});

--- a/editors/web/app/stores/speed-store.ts
+++ b/editors/web/app/stores/speed-store.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { SPEED_STORAGE_KEY } from "./persist-keys";
+import { persistedField } from "./persisted";
 
 /** Clock-speed presets offered by the debug toolbar. */
 export const SPEED_OPTIONS: { label: string; speed: number | null }[] = [
@@ -25,25 +27,16 @@ export const useSpeedStore = create<SpeedState>()(
       },
     }),
     {
-      name: "z33:speed",
-      // Normalize a persisted speed that is no longer a preset back to full
-      // speed, so the toolbar select always reflects the worker's pacing.
+      name: SPEED_STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+      // The toolbar select can only show one of the presets, so a persisted
+      // speed that is no longer among them goes back to the default. `null`
+      // is itself a preset (Max), so the match is against the option list
+      // rather than a typeof check.
       merge: (persisted, current) => {
-        let speed: number | null = null;
-        if (
-          persisted &&
-          typeof persisted === "object" &&
-          "speed" in persisted
-        ) {
-          const value = persisted.speed;
-          if (
-            typeof value === "number" &&
-            SPEED_OPTIONS.some((o) => o.speed === value)
-          ) {
-            speed = value;
-          }
-        }
-        return { ...current, speed };
+        const value = persistedField(persisted, "speed");
+        const match = SPEED_OPTIONS.find((option) => option.speed === value);
+        return { ...current, speed: match ? match.speed : current.speed };
       },
     },
   ),

--- a/editors/web/app/stores/theme-store.ts
+++ b/editors/web/app/stores/theme-store.ts
@@ -1,13 +1,12 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { THEME_STORAGE_KEY } from "./persist-keys";
+import { oneOf, persistedField } from "./persisted";
 
 type EffectiveTheme = "dark" | "light";
 type Theme = EffectiveTheme | "system";
 
 const THEMES: readonly Theme[] = ["dark", "light", "system"];
-
-const isTheme = (value: unknown): value is Theme =>
-  typeof value === "string" && (THEMES as readonly string[]).includes(value);
 
 const darkMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
 
@@ -32,14 +31,12 @@ export const useThemeStore = create<ThemeState>()(
       },
     }),
     {
-      name: "z33:theme",
+      name: THEME_STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({ theme: state.theme }),
       merge: (persisted, current) => {
-        const stored =
-          persisted && typeof persisted === "object" && "theme" in persisted
-            ? persisted.theme
-            : undefined;
-        const theme = isTheme(stored) ? stored : "system";
+        const theme =
+          oneOf(THEMES, persistedField(persisted, "theme")) ?? "system";
         return { ...current, theme, effective: resolveEffective(theme) };
       },
     },

--- a/editors/web/app/testing/fake-worker.ts
+++ b/editors/web/app/testing/fake-worker.ts
@@ -17,6 +17,11 @@ export class FakeWorker {
   readonly sent: unknown[] = [];
   readonly scriptUrl: string;
 
+  // `vscode-jsonrpc`'s browser transport takes the `onmessage` property rather
+  // than a listener, so both routes have to deliver.
+  onmessage: Listener | null = null;
+  onerror: Listener | null = null;
+
   #listeners = new Map<string, Set<Listener>>();
 
   constructor(scriptUrl: string | URL) {
@@ -62,13 +67,12 @@ export class FakeWorker {
 
   #emit(type: string, event: unknown): void {
     for (const listener of this.#listeners.get(type) ?? []) listener(event);
+    if (type === "message") this.onmessage?.(event);
+    if (type === "error") this.onerror?.(event);
   }
 }
 
-/**
- * Point `globalThis.Worker` at `FakeWorker` and clear the instance list.
- * Vitest restores the global when the test file's stubs are reset.
- */
+/** Point `globalThis.Worker` at `FakeWorker` and clear the instance list. */
 export function installFakeWorker(): void {
   FakeWorker.reset();
   // FakeWorker covers the surface a worker client uses, not all of `Worker`.

--- a/editors/web/app/testing/fake-worker.ts
+++ b/editors/web/app/testing/fake-worker.ts
@@ -1,0 +1,77 @@
+// Stand-in for a `Worker`, for tests that drive a worker client from the main
+// thread's side of `postMessage`. Install it as `globalThis.Worker` before the
+// client under test constructs one; `FakeWorker.last()` then hands back the
+// instance it got, to read what it was sent and to answer.
+//
+// Two ways this is not a worker: messages are delivered synchronously, so a
+// `respond` has landed by the time it returns, and they cross by reference
+// rather than being structured-cloned, so a payload a real worker would refuse
+// to send goes through here and both sides share the same object.
+
+type Listener = (event: unknown) => void;
+
+export class FakeWorker {
+  static readonly instances: FakeWorker[] = [];
+
+  /** Every message the client has posted, in order. */
+  readonly sent: unknown[] = [];
+  readonly scriptUrl: string;
+
+  #listeners = new Map<string, Set<Listener>>();
+
+  constructor(scriptUrl: string | URL) {
+    this.scriptUrl = String(scriptUrl);
+    FakeWorker.instances.push(this);
+  }
+
+  /** The worker most recently constructed. */
+  static last(): FakeWorker {
+    const worker = FakeWorker.instances.at(-1);
+    if (!worker) throw new Error("no FakeWorker was constructed");
+    return worker;
+  }
+
+  /** Forget every instance, so `last()` cannot reach across tests. */
+  static reset(): void {
+    FakeWorker.instances.length = 0;
+  }
+
+  postMessage(message: unknown): void {
+    this.sent.push(message);
+  }
+
+  addEventListener(type: string, listener: Listener): void {
+    const set = this.#listeners.get(type) ?? new Set();
+    set.add(listener);
+    this.#listeners.set(type, set);
+  }
+
+  removeEventListener(type: string, listener: Listener): void {
+    this.#listeners.get(type)?.delete(listener);
+  }
+
+  /** Deliver a worker -> main thread message. */
+  respond(data: unknown): void {
+    this.#emit("message", { data });
+  }
+
+  /** Fire the `error` event a hard script failure would produce. */
+  crash(message: string): void {
+    this.#emit("error", { message });
+  }
+
+  #emit(type: string, event: unknown): void {
+    for (const listener of this.#listeners.get(type) ?? []) listener(event);
+  }
+}
+
+/**
+ * Point `globalThis.Worker` at `FakeWorker` and clear the instance list.
+ * Vitest restores the global when the test file's stubs are reset.
+ */
+export function installFakeWorker(): void {
+  FakeWorker.reset();
+  // FakeWorker covers the surface a worker client uses, not all of `Worker`.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  globalThis.Worker = FakeWorker as unknown as typeof Worker;
+}

--- a/editors/web/app/testing/local-storage.ts
+++ b/editors/web/app/testing/local-storage.ts
@@ -1,5 +1,5 @@
 // In-memory `localStorage` for the node test environment, installed as the
-// unit project's setup file (vitest.config.ts) and reset between tests so a
+// unit project's setup file (vitest.config.ts) and emptied between tests so a
 // persisted store never leaks state from one case into the next.
 import { beforeEach } from "vitest";
 
@@ -31,16 +31,15 @@ class MemoryStorage implements Storage {
   }
 }
 
-function installMemoryLocalStorage(): void {
-  Object.defineProperty(globalThis, "localStorage", {
-    value: new MemoryStorage(),
-    configurable: true,
-    writable: true,
-  });
-}
-
-installMemoryLocalStorage();
+// Installed once, and emptied rather than replaced between tests: zustand's
+// `createJSONStorage` resolves the backing object when the store is created and
+// holds on to it, so a fresh instance here would not be the one it writes to.
+Object.defineProperty(globalThis, "localStorage", {
+  value: new MemoryStorage(),
+  configurable: true,
+  writable: true,
+});
 
 beforeEach(() => {
-  installMemoryLocalStorage();
+  localStorage.clear();
 });

--- a/editors/web/app/testing/local-storage.ts
+++ b/editors/web/app/testing/local-storage.ts
@@ -1,0 +1,46 @@
+// In-memory `localStorage` for the node test environment, installed as the
+// unit project's setup file (vitest.config.ts) and reset between tests so a
+// persisted store never leaks state from one case into the next.
+import { beforeEach } from "vitest";
+
+class MemoryStorage implements Storage {
+  #entries = new Map<string, string>();
+
+  get length(): number {
+    return this.#entries.size;
+  }
+
+  key(index: number): string | null {
+    return [...this.#entries.keys()][index] ?? null;
+  }
+
+  getItem(key: string): string | null {
+    return this.#entries.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.#entries.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.#entries.delete(key);
+  }
+
+  clear(): void {
+    this.#entries.clear();
+  }
+}
+
+function installMemoryLocalStorage(): void {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: new MemoryStorage(),
+    configurable: true,
+    writable: true,
+  });
+}
+
+installMemoryLocalStorage();
+
+beforeEach(() => {
+  installMemoryLocalStorage();
+});

--- a/editors/web/app/testing/rehydrate-store.ts
+++ b/editors/web/app/testing/rehydrate-store.ts
@@ -1,0 +1,27 @@
+import type { StoreApi } from "zustand";
+
+type PersistedStore<T> = Pick<StoreApi<T>, "setState" | "getInitialState"> & {
+  persist: { rehydrate: () => Promise<void> | void };
+};
+
+/**
+ * Seed `key` with a raw persisted payload and rehydrate `store` from it, the
+ * way a page load would.
+ *
+ * The store is reset first because a page load rehydrates onto the initial
+ * state, which is what a `merge` falls back to; the reset writes through to
+ * storage, so it has to happen before the payload is seeded.
+ */
+export async function rehydrateStore<T>(
+  store: PersistedStore<T>,
+  key: string,
+  state: unknown,
+  version?: number,
+): Promise<void> {
+  store.setState(store.getInitialState());
+  localStorage.setItem(
+    key,
+    JSON.stringify(version === undefined ? { state } : { state, version }),
+  );
+  await store.persist.rehydrate();
+}

--- a/editors/web/app/workers/worker-protocol.test.ts
+++ b/editors/web/app/workers/worker-protocol.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  WORKER_ERROR,
+  WORKER_INIT,
+  isWorkerErrorFrame,
+  isWorkerInitFrame,
+} from "./worker-protocol";
+
+// The LSP worker's channel also carries JSON-RPC traffic, so both guards run
+// over frames they are meant to say no to.
+const JSON_RPC_FRAMES = [
+  { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+  { jsonrpc: "2.0", id: 1, result: {} },
+  { jsonrpc: "2.0", method: "textDocument/publishDiagnostics", params: {} },
+];
+
+describe("isWorkerInitFrame", () => {
+  it("accepts the init frame", () => {
+    expect(isWorkerInitFrame({ type: WORKER_INIT, module: {} })).toBe(true);
+  });
+
+  it("rejects JSON-RPC traffic and other frames", () => {
+    for (const frame of [
+      ...JSON_RPC_FRAMES,
+      { type: WORKER_ERROR, message: "boom" },
+      { type: "init" },
+      null,
+      undefined,
+      WORKER_INIT,
+      42,
+    ]) {
+      expect(isWorkerInitFrame(frame)).toBe(false);
+    }
+  });
+});
+
+describe("isWorkerErrorFrame", () => {
+  it("accepts the error sentinel", () => {
+    expect(isWorkerErrorFrame({ type: WORKER_ERROR, message: "boom" })).toBe(
+      true,
+    );
+  });
+
+  it("rejects JSON-RPC traffic and other frames", () => {
+    for (const frame of [
+      ...JSON_RPC_FRAMES,
+      { type: WORKER_INIT, module: {} },
+      { type: "workerError", message: "boom" },
+      null,
+      undefined,
+      WORKER_ERROR,
+    ]) {
+      expect(isWorkerErrorFrame(frame)).toBe(false);
+    }
+  });
+});

--- a/editors/web/e2e/fixtures.ts
+++ b/editors/web/e2e/fixtures.ts
@@ -1,6 +1,7 @@
 import { test as base, expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import {
+  BREAKPOINTS_STORAGE_KEY,
   WORKSPACE_PERSIST_VERSION,
   WORKSPACE_STORAGE_KEY,
 } from "../app/stores/persist-keys";
@@ -39,10 +40,16 @@ export async function getCycleCount(page: Page): Promise<number> {
 export const test = base.extend<{ cleanPage: Page }>({
   cleanPage: async ({ page }, use) => {
     await page.goto("/");
-    await page.evaluate((storageKey) => {
-      localStorage.removeItem(storageKey);
-      localStorage.removeItem("z33:breakpoints");
-    }, WORKSPACE_STORAGE_KEY);
+    await page.evaluate(
+      ({ workspaceKey, breakpointsKey }) => {
+        localStorage.removeItem(workspaceKey);
+        localStorage.removeItem(breakpointsKey);
+      },
+      {
+        workspaceKey: WORKSPACE_STORAGE_KEY,
+        breakpointsKey: BREAKPOINTS_STORAGE_KEY,
+      },
+    );
     await page.reload();
     await page.waitForSelector(".monaco-editor", { timeout: 30_000 });
     await use(page);
@@ -57,7 +64,7 @@ export async function loadWorkspace(
 ): Promise<void> {
   await page.goto("/");
   await page.evaluate(
-    ({ files, activeFile, storageKey, version }) => {
+    ({ files, activeFile, storageKey, breakpointsKey, version }) => {
       localStorage.setItem(
         storageKey,
         JSON.stringify({
@@ -65,12 +72,13 @@ export async function loadWorkspace(
           version,
         }),
       );
-      localStorage.removeItem("z33:breakpoints");
+      localStorage.removeItem(breakpointsKey);
     },
     {
       files,
       activeFile,
       storageKey: WORKSPACE_STORAGE_KEY,
+      breakpointsKey: BREAKPOINTS_STORAGE_KEY,
       version: WORKSPACE_PERSIST_VERSION,
     },
   );

--- a/editors/web/e2e/lsp.spec.ts
+++ b/editors/web/e2e/lsp.spec.ts
@@ -33,31 +33,31 @@ test.describe("LSP", () => {
       "main.s",
     );
 
-    // Drive Monaco through its API (dev-only `__z33e2e` hook) instead of
-    // hovering the rendered token spans: their DOM slicing differs across
-    // platforms/builds (an exact-text span locator matched locally but never
-    // matched in CI, even with the editor fully rendered).
-    await expect
-      .poll(() => page.evaluate(() => "__z33e2e" in window), {
-        timeout: 90_000,
-      })
-      .toBe(true);
+    // Monaco gives the mnemonic a span of its own, with the line's indentation
+    // folded into it as non-breaking spaces.
+    const mnemonic = page
+      .locator(".view-lines span")
+      .filter({ hasText: /^\s*ld$/u })
+      .first();
+    await expect(mnemonic).toBeVisible({ timeout: 90_000 });
 
     // The LSP runs in a web worker that compiles the wasm on first load, so the
     // hover round-trip can be slow to become ready on CI. Retry the hover until
     // the LSP responds with the instruction docs instead of assuming a delay.
+    // Each attempt leaves the token first, so re-entering it fires a fresh
+    // mousemove for Monaco to act on, and aims just inside the span's right
+    // edge: how much of the indentation the span carries varies with the
+    // build, but the mnemonic is always at its end. `x + width` is the
+    // exclusive edge and the box is fractional, so the pointer steps two
+    // pixels back to land on the last character rather than past it.
     const hover = page
       .locator(".monaco-hover")
-      .filter({ hasText: /Load a value/i });
+      .filter({ hasText: /Load a value/iu });
     await expect(async () => {
-      // Column 6 sits inside the `ld` mnemonic on line 2.
-      await page.evaluate(() => {
-        (
-          window as unknown as {
-            __z33e2e: { showHoverAt(line: number, column: number): void };
-          }
-        ).__z33e2e.showHoverAt(2, 6);
-      });
+      const box = await mnemonic.boundingBox();
+      if (!box) throw new Error("the mnemonic token has no box");
+      await page.mouse.move(0, 0);
+      await page.mouse.move(box.x + box.width - 2, box.y + box.height / 2);
       await expect(hover).toBeVisible({ timeout: 5_000 });
     }).toPass({ timeout: 60_000 });
   });
@@ -76,7 +76,7 @@ test.describe("LSP", () => {
     // `.first()` is the reference in `jmp target`, not the `target:` label.
     const target = page
       .locator(".view-lines span")
-      .filter({ hasText: /^target$/ })
+      .filter({ hasText: /^target$/u })
       .first();
     await expect(target).toBeVisible({ timeout: 90_000 });
     await target.scrollIntoViewIfNeeded();

--- a/editors/web/package.json
+++ b/editors/web/package.json
@@ -10,7 +10,7 @@
     "build:wasm:dev": "wasm-pack build ../../crates/wasm --dev --target web --out-dir ../../editors/web/pkg --out-name z33_web",
     "build": "pnpm run build:wasm && vite build",
     "start": "pnpm run build:wasm:dev && vite",
-    "check": "oxlint app/ e2e/ scripts/ && oxfmt --check app/ e2e/ scripts/",
+    "check": "tsc -b && oxlint app/ e2e/ scripts/ && oxfmt --check app/ e2e/ scripts/",
     "lint": "oxlint app/ e2e/ scripts/",
     "lint:fix": "oxlint --fix app/ e2e/ scripts/",
     "fmt": "oxfmt app/ e2e/ scripts/",
@@ -22,6 +22,8 @@
     "e2e:headed": "playwright test --headed",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
+    "test": "vitest run",
+    "test:unit": "vitest run --project=unit",
     "test-storybook": "vitest run --project=storybook",
     "test-storybook:watch": "vitest --project=storybook"
   },

--- a/editors/web/tsconfig.json
+++ b/editors/web/tsconfig.json
@@ -9,7 +9,7 @@
       "@/*": ["./app/*"]
     }
   },
-  "include": ["app", "e2e"],
+  "include": ["app", "e2e", ".storybook/preview.tsx"],
   "references": [
     {
       "path": "./tsconfig.node.json"

--- a/editors/web/tsconfig.node.json
+++ b/editors/web/tsconfig.node.json
@@ -1,7 +1,19 @@
 {
   "extends": "@tsconfig/node24/tsconfig.json",
   "compilerOptions": {
-    "composite": true
+    "composite": true,
+    // A referenced project has to emit; nothing consumes the declarations, so
+    // they go next to the build info instead of into the checkout.
+    "outDir": "./node_modules/.tmp/node",
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "allowJs": true,
+    "checkJs": true
   },
-  "include": ["vite.config.ts"]
+  "include": [
+    "vite.config.ts",
+    "vitest.config.ts",
+    "playwright.config.ts",
+    "scripts",
+    ".storybook/main.ts"
+  ]
 }

--- a/editors/web/vitest.config.ts
+++ b/editors/web/vitest.config.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 import { playwright } from "@vitest/browser-playwright";
+import { defaultServerConditions } from "vite";
 import { defineConfig } from "vitest/config";
 
 // Two projects: `unit` covers the app's pure logic in node, `storybook` runs
@@ -19,6 +20,12 @@ export default defineConfig({
           alias: {
             "@": fileURLToPath(new URL("./app", import.meta.url)),
           },
+        },
+        // The modules under test are browser code, so their dependencies
+        // resolve the way a browser would as well as the way node does:
+        // `vscode-jsonrpc/browser` has no export for node to pick.
+        ssr: {
+          resolve: { conditions: [...defaultServerConditions, "browser"] },
         },
         test: {
           name: "unit",

--- a/editors/web/vitest.config.ts
+++ b/editors/web/vitest.config.ts
@@ -3,14 +3,31 @@ import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 import { playwright } from "@vitest/browser-playwright";
 import { defineConfig } from "vitest/config";
 
-// Storybook stories are run as a dedicated Vitest project in a real browser
-// (Playwright/chromium). The project extends the app's ./vite.config.ts so the
-// Tailwind plugin and the `@` alias apply, just like the running app. The
-// storybookTest plugin auto-injects the preview's project annotations
-// (decorators/parameters), so no explicit setup file is needed.
+// Two projects: `unit` covers the app's pure logic in node, `storybook` runs
+// the stories in a real browser (Playwright/chromium).
+//
+// Only the storybook project extends the app's ./vite.config.ts: merging that
+// config into the node project duplicates its `oxc.target` entries, which the
+// transform rejects, so the node project carries its own copy of the `@`
+// alias. The storybookTest plugin auto-injects the preview's project
+// annotations (decorators/parameters), so no explicit setup file is needed.
 export default defineConfig({
   test: {
     projects: [
+      {
+        resolve: {
+          alias: {
+            "@": fileURLToPath(new URL("./app", import.meta.url)),
+          },
+        },
+        test: {
+          name: "unit",
+          environment: "node",
+          include: ["app/**/*.test.{ts,tsx}"],
+          // The persisted stores reach for `localStorage` on every write.
+          setupFiles: ["./app/testing/local-storage.ts"],
+        },
+      },
       {
         extends: "./vite.config.ts",
         plugins: [


### PR DESCRIPTION
Adds a `unit` Vitest project (node) beside the existing storybook one and covers the web app's pure logic: 144 tests across 12 files. `pnpm test` runs both projects, and so does the CI job that ran the stories alone.

Testing that logic meant moving it somewhere a node test can reach: `requestedLineForClick` and `breakpointDecorations` out of `monaco-file-editor.tsx` into `app/lib/breakpoint-gutter.ts`, and `fixSemanticTokenLengths` off its Monaco model onto a `getLineContent(line)` callback. Persisted-state validation now goes through one leaf module, `app/stores/persisted.ts`, and all five localStorage keys live in `persist-keys.ts`.

The tests found three bugs, each covered by a test that fails without its fix. A `z33:display` value outside the three bases reached `formatWord`'s exhaustive switch and threw, taking the debug view down with it. The workspace and breakpoint payloads came back from storage untyped, and the workspace could rehydrate incoherent, its active file naming a file that was not there.

`tsc` never ran for editors/web in CI. It does now, from the package's `check`, and its two tsconfigs cover the vitest/playwright/storybook configs and `scripts/`, which nothing checked before. The dev-only `__z33e2e` window hook is gone: the hover spec drives a real `mouse.move` onto the `ld` token span.

Two things CI has to confirm. The hover locator has no local proof, since the previous attempt matched here and never matched on CI; this one matches the token span the way the passing go-to-definition test already does, and aims inside its right edge rather than at its centre. "Vitest tests" is also a new job outside the required-checks ruleset, so the unit tests do not gate merges until someone adds it.

First of a stack: #1043 (shared editor package) sits on top of this one, and #1045 unifies the Vitest and Playwright configuration at the workspace root on top of both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
